### PR TITLE
Lemmas without glosses 733 and minimalpairs to CSV 743

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sqlparse==0.2.4
 unicodecsv==0.14.1
 python-dateutil==2.8.0
 django-colorfield==0.3.2
+python-magic==0.4.22

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -2773,16 +2773,30 @@ class MinimalPairsListView(ListView):
         if not self.request.user.has_perm('dictionary.export_csv'):
             raise PermissionDenied
 
+        # this ends up being English for Global Signbank
+        language_code = settings.DEFAULT_KEYWORDS_LANGUAGE['language_code_2char']
+
+        rows = write_csv_for_minimalpairs(self, language_code=language_code)
+
         # Create the HttpResponse object with the appropriate CSV header.
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="dictionary-export-minimalpairs.csv"'
 
-        # this ends up being English for Global Signbank
-        language_code = settings.DEFAULT_KEYWORDS_LANGUAGE['language_code_2char']
+        import csv
+        csvwriter = csv.writer(response)
 
-        writer = csv.writer(response)
+        # write the actual file
+        if hasattr(settings, 'SHOW_DATASET_INTERFACE_OPTIONS') and settings.SHOW_DATASET_INTERFACE_OPTIONS:
+            header = ['Dataset', 'Focus Gloss', 'ID', 'Minimal Pair Gloss', 'ID', 'Field Name', 'Source Sign Value',
+                      'Contrasting Sign Value']
+        else:
+            header = ['Focus Gloss', 'ID', 'Minimal Pair Gloss', 'ID', 'Field Name', 'Source Sign Value',
+                      'Contrasting Sign Value']
 
-        writer = write_csv_for_minimalpairs(self, writer, language_code=language_code)
+        csvwriter.writerow(header)
+
+        for row in rows:
+            csvwriter.writerow(row)
 
         return response
 

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -5966,16 +5966,16 @@ class LemmaListView(ListView):
     def post(self, request, *args, **kwargs):
         # this method deletes lemmas in the query that have no glosses
         # plus their dependent translations
-        get = self.request.POST
-        # nothing is done with the post parameters
         if not self.request.user.is_authenticated():
             # this code should not be reached
-            messages.add_message(self.request, messages.ERROR, ('You must be logged in to use this functionality.'))
-            return HttpResponseRedirect(reverse('dictionary:admin_lemma_list'))
+            raise PermissionDenied
         if not self.request.user.has_perm('dictionary.delete_lemmaidgloss'):
             # the button should not have been displayed in the template
-            messages.add_message(self.request, messages.ERROR, ('No permission to delete lemmas.'))
-            return HttpResponseRedirect(reverse('dictionary:admin_lemma_list'))
+            raise PermissionDenied
+        delete_lemmas_confirmed = self.request.POST.get('delete_lemmas', 'false')
+        if delete_lemmas_confirmed != 'delete_lemmas':
+            # the template sets POST value 'delete_lemmas' to value 'delete_lemmas'
+            raise PermissionDenied
         queryset = self.get_annotated_queryset()
         for lemma in queryset:
             if lemma.num_gloss == 0:

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -516,7 +516,7 @@ class GlossListView(ListView):
         if self.request.user.is_authenticated():
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('Please login to use this functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use this functionality.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/signs/search/')
 
         # if the dataset is specified in the url parameters, set the dataset_name variable
@@ -524,13 +524,13 @@ class GlossListView(ListView):
         if 'dataset_name' in get:
             self.dataset_name = get['dataset_name']
         if self.dataset_name == '':
-            messages.add_message(self.request, messages.ERROR, ('Dataset name must be non-empty.'))
+            messages.add_message(self.request, messages.ERROR, _('Dataset name must be non-empty.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/signs/search/')
 
         try:
             dataset_object = Dataset.objects.get(name=self.dataset_name)
         except:
-            messages.add_message(self.request, messages.ERROR, ('No dataset with name '+self.dataset_name+' found.'))
+            messages.add_message(self.request, messages.ERROR, _('No dataset with name '+self.dataset_name+' found.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/signs/search/')
 
         # make sure the user can write to this dataset
@@ -540,7 +540,7 @@ class GlossListView(ListView):
         if user_change_datasets and dataset_object in user_change_datasets:
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('No permission to export dataset.'))
+            messages.add_message(self.request, messages.ERROR, _('No permission to export dataset.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/signs/search/')
 
         # if we get to here, the user is authenticated and has permission to export the dataset
@@ -561,10 +561,6 @@ class GlossListView(ListView):
         # Create the HttpResponse object with the appropriate CSV header.
         response = HttpResponse(content_type='text/csv')
         response['Content-Disposition'] = 'attachment; filename="dictionary-export.csv"'
-
-
-#        fields = [f.name for f in Gloss._meta.fields]
-        #We want to manually set which fields to export here
 
         fieldnames = FIELDS['main']+FIELDS['phonology']+FIELDS['semantics']+FIELDS['frequency']+['inWeb', 'isNew']
 
@@ -862,8 +858,6 @@ class GlossListView(ListView):
         if 'keyword' in get and get['keyword'] != '':
             val = get['keyword']
             qs = qs.filter(translation__translation__text__iregex=val)
-
-        # NULLBOOLEANCHOICES = [(0, '---------'), (1, 'Unknown'), (2, 'True'), (3, 'False')]
 
         if 'inWeb' in get and get['inWeb'] != '0':
             # Don't apply 'inWeb' filter, if it is unspecified ('0' according to the NULLBOOLEANCHOICES)
@@ -3806,7 +3800,7 @@ class DatasetListView(ListView):
         if self.request.user.is_authenticated():
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('Please login to use this functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use this functionality.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         # if the dataset is specified in the url parameters, set the dataset_name variable
@@ -3814,7 +3808,7 @@ class DatasetListView(ListView):
         if 'dataset_name' in get:
             self.dataset_name = get['dataset_name']
         if self.dataset_name == '':
-            messages.add_message(self.request, messages.ERROR, ('Dataset name must be non-empty.'))
+            messages.add_message(self.request, messages.ERROR, _('Dataset name must be non-empty.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         try:
@@ -3831,7 +3825,7 @@ class DatasetListView(ListView):
             pass
         else:
             # this should not happen from the html page. the check is made to catch a user adding a parameter to the url
-            messages.add_message(self.request, messages.INFO, ('You can already view this dataset.'))
+            messages.add_message(self.request, messages.INFO, _('You can already view this dataset.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         motivation = ''
@@ -3887,7 +3881,7 @@ class DatasetListView(ListView):
         if self.request.user.is_authenticated():
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('Please login to use this functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use this functionality.'))
             return HttpResponseRedirect(reverse('admin_dataset_view'))
 
         # if the dataset is specified in the url parameters, set the dataset_name variable
@@ -3895,7 +3889,7 @@ class DatasetListView(ListView):
         if 'dataset_name' in get:
             self.dataset_name = get['dataset_name']
         if self.dataset_name == '':
-            messages.add_message(self.request, messages.ERROR, ('Dataset name must be non-empty.'))
+            messages.add_message(self.request, messages.ERROR, _('Dataset name must be non-empty.'))
             return HttpResponseRedirect(reverse('admin_dataset_view'))
 
         try:
@@ -3910,7 +3904,7 @@ class DatasetListView(ListView):
         if user_change_datasets and dataset_object in user_change_datasets:
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('No permission to export dataset.'))
+            messages.add_message(self.request, messages.ERROR, _('No permission to export dataset.'))
             return HttpResponseRedirect(reverse('admin_dataset_view'))
 
         # make sure the dataset is non-empty, don't create an empty ecv file
@@ -4019,7 +4013,7 @@ class DatasetManagerView(ListView):
         if self.request.user.is_authenticated():
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('Please login to use this functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use this functionality.'))
             return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
         # check if the user can manage this dataset
@@ -4028,13 +4022,13 @@ class DatasetManagerView(ListView):
         try:
             group_manager = Group.objects.get(name='Dataset_Manager')
         except:
-            messages.add_message(self.request, messages.ERROR, ('No group Dataset_Manager found.'))
+            messages.add_message(self.request, messages.ERROR, _('No group Dataset_Manager found.'))
             return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
         groups_of_user = self.request.user.groups.all()
         if not group_manager in groups_of_user:
             messages.add_message(self.request, messages.ERROR,
-                                 ('You must be in group Dataset Manager to modify dataset permissions.'))
+                                 _('You must be in group Dataset Manager to modify dataset permissions.'))
             return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
         # make sure the user can write to this dataset
@@ -4044,7 +4038,7 @@ class DatasetManagerView(ListView):
         if user_change_datasets and dataset_object in user_change_datasets:
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('No permission to modify dataset permissions.'))
+            messages.add_message(self.request, messages.ERROR, _('No permission to modify dataset permissions.'))
             return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
         # Everything is alright
@@ -4060,7 +4054,7 @@ class DatasetManagerView(ListView):
         if 'dataset_name' in get:
             self.dataset_name = get['dataset_name']
         if self.dataset_name == '':
-            messages.add_message(self.request, messages.ERROR, ('Dataset name must be non-empty.'))
+            messages.add_message(self.request, messages.ERROR, _('Dataset name must be non-empty.'))
             return None, HttpResponseRedirect(reverse('admin_dataset_manager'))
 
         try:
@@ -4285,7 +4279,7 @@ class DatasetManagerView(ListView):
                 return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
 
         # the code doesn't seem to get here. if somebody puts something else in the url (else case), there is no (hidden) csrf token.
-        messages.add_message(self.request, messages.ERROR, ('Unrecognised argument to dataset manager url.'))
+        messages.add_message(self.request, messages.ERROR, _('Unrecognised argument to dataset manager url.'))
         return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
     def render_to_csv_response(self):
@@ -4382,12 +4376,12 @@ class DatasetManagerView(ListView):
             try:
                 group_manager = Group.objects.get(name='Dataset_Manager')
             except:
-                messages.add_message(self.request, messages.ERROR, ('No group Dataset_Manager found.'))
+                messages.add_message(self.request, messages.ERROR, _('No group Dataset_Manager found.'))
                 return None
 
             groups_of_user = self.request.user.groups.all()
             if not group_manager in groups_of_user:
-                messages.add_message(self.request, messages.ERROR, ('You must be in group Dataset_Manager to use the requested functionality.'))
+                messages.add_message(self.request, messages.ERROR, _('You must be in group Dataset_Manager to use the requested functionality.'))
                 return None
 
             from django.db.models import Prefetch
@@ -4498,7 +4492,7 @@ class DatasetDetailView(DetailView):
         if self.request.user.is_authenticated():
             pass
         else:
-            messages.add_message(self.request, messages.ERROR, ('Please login to use this functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use this functionality.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         # check if the user can manage this dataset
@@ -4507,12 +4501,12 @@ class DatasetDetailView(DetailView):
         try:
             group_manager = Group.objects.get(name='Dataset_Manager')
         except:
-            messages.add_message(self.request, messages.ERROR, ('No group Dataset_Manager found.'))
+            messages.add_message(self.request, messages.ERROR, _('No group Dataset_Manager found.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         groups_of_user = self.request.user.groups.all()
         if not group_manager in groups_of_user:
-            messages.add_message(self.request, messages.ERROR, ('You must be in group Dataset Manager to modify dataset permissions.'))
+            messages.add_message(self.request, messages.ERROR, _('You must be in group Dataset Manager to modify dataset permissions.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         # if the dataset is specified in the url parameters, set the dataset_name variable
@@ -4520,7 +4514,7 @@ class DatasetDetailView(DetailView):
         if 'dataset_name' in get:
             self.dataset_name = get['dataset_name']
         if self.dataset_name == '':
-            messages.add_message(self.request, messages.ERROR, ('Dataset name must be non-empty.'))
+            messages.add_message(self.request, messages.ERROR, _('Dataset name must be non-empty.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         try:
@@ -4533,7 +4527,7 @@ class DatasetDetailView(DetailView):
         if 'username' in get:
             username = get['username']
         if username == '':
-            messages.add_message(self.request, messages.ERROR, ('Username must be non-empty.'))
+            messages.add_message(self.request, messages.ERROR, _('Username must be non-empty.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
         try:
@@ -4678,12 +4672,12 @@ class DatasetFieldChoiceView(ListView):
             try:
                 group_manager = Group.objects.get(name='Dataset_Manager')
             except:
-                messages.add_message(self.request, messages.ERROR, ('No group Dataset_Manager found.'))
+                messages.add_message(self.request, messages.ERROR, _('No group Dataset_Manager found.'))
                 return None
 
             groups_of_user = self.request.user.groups.all()
             if not group_manager in groups_of_user:
-                messages.add_message(self.request, messages.ERROR, ('You must be in group Dataset_Manager to use the requested functionality.'))
+                messages.add_message(self.request, messages.ERROR, _('You must be in group Dataset_Manager to use the requested functionality.'))
                 return None
 
             from django.db.models import Prefetch
@@ -4705,7 +4699,7 @@ class DatasetFieldChoiceView(ListView):
             return qs
         else:
             # User is not authenticated
-            messages.add_message(self.request, messages.ERROR, ('Please login to use the requested functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use the requested functionality.'))
             return None
 
 class FieldChoiceView(ListView):
@@ -4849,11 +4843,11 @@ class FieldChoiceView(ListView):
             else:
                 # User is not authenticated
                 messages.add_message(self.request, messages.ERROR,
-                                     ('You must be superuser to use the requested functionality.'))
+                                     _('You must be superuser to use the requested functionality.'))
                 return None
         else:
             # User is not authenticated
-            messages.add_message(self.request, messages.ERROR, ('Please login to use the requested functionality.'))
+            messages.add_message(self.request, messages.ERROR, _('Please login to use the requested functionality.'))
             return None
 
 def order_handshape_queryset_by_sort_order(get, qs):
@@ -5410,7 +5404,7 @@ def lemma_ajax_complete(request, dataset_id, language_code, q):
     if request.user.is_authenticated():
         pass
     else:
-        messages.add_message(request, messages.ERROR, ('Please login to use this functionality.'))
+        messages.add_message(request, messages.ERROR, _('Please login to use this functionality.'))
         return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
     # the following code allows for specifying a language for the dataset in the add_gloss.html template
@@ -5965,17 +5959,27 @@ class LemmaListView(ListView):
     def post(self, request, *args, **kwargs):
         # this method deletes lemmas in the query that have no glosses
         # plus their dependent translations
-        if not self.request.user.is_authenticated():
-            # this code should not be reached
-            raise PermissionDenied
         if not self.request.user.has_perm('dictionary.delete_lemmaidgloss'):
-            # the button should not have been displayed in the template
-            raise PermissionDenied
+            messages.add_message(request, messages.WARNING, _("You have no permission to delete lemmas."))
+            return HttpResponseRedirect(reverse('dictionary:admin_lemma_list'))
         delete_lemmas_confirmed = self.request.POST.get('delete_lemmas', 'false')
         if delete_lemmas_confirmed != 'delete_lemmas':
             # the template sets POST value 'delete_lemmas' to value 'delete_lemmas'
-            raise PermissionDenied
+            messages.add_message(request, messages.WARNING, _("Incorrect deletion code."))
+            return HttpResponseRedirect(reverse('dictionary:admin_lemma_list'))
+        datasets_user_can_change = get_objects_for_user(request.user, 'change_dataset', Dataset, accept_global_perms=False)
+        selected_datasets = get_selected_datasets_for_user(self.request.user)
+
         queryset = self.get_annotated_queryset()
+        # check permissions, if fails, do nothing and show error message
+        for lemma in queryset:
+            if lemma.num_gloss == 0:
+                # the get_annotated_queryset which in turn calls get_queryset has already filtered on lemma's in the selected dataset
+                dataset_of_requested_lemma = lemma.dataset
+                if dataset_of_requested_lemma not in datasets_user_can_change:
+                    messages.add_message(request, messages.WARNING,
+                                         _("You do not have change permission on the dataset of the lemma you are atteempting to delete."))
+                    return HttpResponseRedirect(reverse('dictionary:admin_lemma_list'))
         for lemma in queryset:
             if lemma.num_gloss == 0:
                 lemma_translation_objects = lemma.lemmaidglosstranslation_set.all()

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -5823,9 +5823,8 @@ class LemmaListView(ListView):
             if get_key.startswith(LemmaSearchForm.lemma_search_field_prefix) and get_value != '':
                 language_code_2char = get_key[len(LemmaSearchForm.lemma_search_field_prefix):]
                 language = Language.objects.filter(language_code_2char=language_code_2char)
-                qs = qs.filter(lemmaidglosstranslation__text__icontains=get_value,
+                qs = qs.filter(lemmaidglosstranslation__text__iregex=get_value,
                                lemmaidglosstranslation__language=language)
-
         return qs
 
     def get_annotated_queryset(self, **kwargs):

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -675,12 +675,17 @@ class ImageUploadForHandshapeForm(forms.Form):
     handshape_id = forms.CharField(widget=forms.HiddenInput)
     redirect = forms.CharField(widget=forms.HiddenInput, required=False)
 
+
+NO_GLOSS_SELECTION = [(0,'False'),(1,'True')]
+
 class LemmaSearchForm(forms.ModelForm):
     use_required_attribute = False  # otherwise the html required attribute will show up on every form
 
     search = forms.CharField(label=_("Lemma"))
     sortOrder = forms.CharField(label=_("Sort Order"))
     lemma_search_field_prefix = "lemma_"
+    no_glosses = forms.ChoiceField(label=_(u'Only show results without glosses'),choices=NO_GLOSS_SELECTION)
+    has_glosses = forms.ChoiceField(label=_(u'Only show results with glosses'),choices=NO_GLOSS_SELECTION)
 
     class Meta:
 

--- a/signbank/dictionary/templates/dictionary/admin_lemma_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_lemma_list.html
@@ -8,6 +8,8 @@
 
 {% load annotation_idgloss_translation %}
 
+<script type="text/javascript" src="{{ STATIC_URL }}js/jquery.jeditable.mini.js"></script>
+
 <script type='text/javascript'>
 var show_dataset_interface_options = {{ SHOW_DATASET_INTERFACE_OPTIONS|yesno:"true,false" }};
 var csrf_token = '{{csrf_token}}';
@@ -15,45 +17,6 @@ var page_number = {{ page_number }};
 var objects_on_this_page = {{objects_on_page|safe}};
 var paginate_by = '{{paginate_by}}';
 
-
- /**
- * @param {string} field_name - name of the field to sort on
- * @param {string} action     - one of: desc, asc, del
- * @param {string} frmName    - name of the <form ...> that contains the 'sortOrder' <input> field
- * @returns {void}
- */
-function do_sort_column(field_name, action, frmName) {
-  // Combine @field_name and @action into [sOrder]
-  var sOrder = field_name;
-  if (action == 'desc') {
-    // Descending sort order is signified by a '-' prefix
-    sOrder = '-' + sOrder;
-  } else if (action == 'del') {
-    // "Deleting" (pressing 'x') the sort order of a column means: return to the default 'idgloss' sort order
-    sOrder = '';
-  }
-  // Set the value of the [sortOrder] field defined in dictionary/forms.py::GlossSearchForm
-  $("#" + frmName + " input[name='sortOrder']").val(sOrder);
-
-  // Submit the form with the indicated name
-
-  $("#" + frmName).submit();
-
-}
-
-/**
- * @returns {void}
- */
-function do_adminsearch(el) {
- var sSearchType = $(el).attr('value');
-  $("#adminsearch input[name='search_type']").val(sSearchType);
-  switch(sSearchType) {
-    case "lemma":
-        $("#adminsearch").attr('action', ' {{PREFIX_URL}}/dictionary/lemma/');
-        break;
-  }
-  document.getElementById('adminsearch').submit();
-}
 </script>
 
 
@@ -93,11 +56,8 @@ function do_adminsearch(el) {
             </span>
     </div>
 
-    <div id='query-area' class='collapse {% if request.GET|length == 0 and not show_all %} in {% endif %}'>
+    <div id='query-area' class='collapse {% if request.GET|length == 0 %} in {% endif %}'>
         <div id='searchformwell' class='well search-results-collapsable'>
-
-                <!-- EK: A sort-order specification is in a hidden form field, which is filled by JS:do_sort_column() -->
-                        <!-- this is empty as an initial value because the view python code sets it -->
                 <div class="hidden">
                     <input name='sortOrder' class='form-control' value='' >
                     <input name='search_type' class='form-control' value='{{search_type}}'>
@@ -118,6 +78,25 @@ function do_adminsearch(el) {
                             {% endwith %}
                         </tr>
                         {% endfor %}
+
+                        <tr id="lemma_with_no_glosses">
+                            <td>
+                                <div class='input-group'>
+                                <label class='input-group-addon' for='id_no_glosses'>{{searchform.no_glosses.label}}</label>
+                                {{searchform.no_glosses}}
+                                </div>
+                            </td>
+                         </tr>
+
+                         <tr id="lemma_with_glosses">
+                            <td>
+                                <div class='input-group'>
+                                <label class='input-group-addon' for='id_has_glosses'>{{searchform.has_glosses.label}}</label>
+                                {{searchform.has_glosses}}
+                                </div>
+                            </td>
+                         </tr>
+
                     </table>
                 </div>
         </div>
@@ -136,7 +115,7 @@ function do_adminsearch(el) {
     <h3>{% trans "Lemmas" %}</h3>
 
     <div>
-    {% trans "Number of matches:" %} {{page_obj.paginator.count}} {% if user.is_anonymous %}(publically available){% endif %} {% trans "out of" %} {{lemma_count}}.
+    {% trans "Number of matches:" %} {{search_matches}} {% if user.is_anonymous %}(publically available){% endif %} {% trans "out of" %} {{lemma_count}}.
 
         {% if SHOW_DATASET_INTERFACE_OPTIONS and selected_datasets %}
         {% trans "Datasets:" %}
@@ -146,19 +125,27 @@ function do_adminsearch(el) {
     </div>
 
     <br/>
-<div class='btn-group' style="margin-bottom: 20px">
+<div class='clearfix' style="margin-bottom: 20px">
+    <div class='btn-group'>
     {% if perms.dictionary.add_lemmaidgloss %}
     <a class="btn btn-primary" href="{% url 'dictionary:create_lemma' %}">{% trans "Create New Lemma" %}</a>
     {% endif %}
     {% if perms.dictionary.export_csv %}
     <input class='btn btn-default' type='submit' name='format' value='CSV'>
     {% endif %}
+    </div>
+    {% if perms.dictionary.delete_lemmaidgloss %}
+        <button id='delete_lemmas' type="button"
+                data-toggle="modal" data-target="#deleteNoGlossesModal"
+                data-keyboard="false" data-backdrop="static"
+                class='btn btn-primary pull-right'>{% trans "Delete Lemma's with No Glosses" %}</button>
 
+    {% endif %}
 </div>
 </form>
 
 
-{% if object_list %}
+{% if search_results %}
 
 <table class='table table-condensed'>
     <thead>
@@ -172,7 +159,7 @@ function do_adminsearch(el) {
       </tr>
     </thead>
     <tbody>
-      {% for lemma in object_list %}
+      {% for lemma in search_results %}
         <tr>
             {% if SHOW_DATASET_INTERFACE_OPTIONS %}
             <td>
@@ -276,6 +263,31 @@ function do_adminsearch(el) {
     </div>
 
   </div>
+</div>
+
+<div class="modal" id="deleteNoGlossesModal" role="dialog" >
+     <div class="modal-dialog">
+        <div class="modal-content">
+            <div class='modal-header'>
+                <h2 id='modalTitleDelete'>{% trans "Delete Lemmas with No Glosses" %}</h2>
+            </div>
+            <div class='modal-body'>
+                <p>{% trans "This action will delete all lemmas without glosses and all associated translations belonging to those lemma's. It cannot be undone." %}</p>
+             </div>
+          <div class="modal-footer">
+          <form id="delete-no-glosses-form" action='' method="POST">
+              {% csrf_token %}
+              <input type='hidden' value='delete_lemmas' name='delete_lemmas'>
+                  <div class='btn-group'>
+                    <button type="button" class="btn btn-success" data-dismiss="modal">{% trans "Cancel" %}</button>
+                    <button class="btn btn-danger"
+                           onclick="document.getElementById('delete-no-glosses').submit(); return false">{% trans "Confirm Delete" %}</button>
+                  </div>
+          </form>
+          </div>
+
+        </div>
+    </div>
 </div>
 
 

--- a/signbank/dictionary/templates/dictionary/admin_lemma_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_lemma_list.html
@@ -134,11 +134,11 @@ var paginate_by = '{{paginate_by}}';
     <input class='btn btn-default' type='submit' name='format' value='CSV'>
     {% endif %}
     </div>
-    {% if perms.dictionary.delete_lemmaidgloss %}
+    {% if perms.dictionary.delete_lemmaidgloss and num_gloss_zero_matches %}
         <button id='delete_lemmas' type="button"
                 data-toggle="modal" data-target="#deleteNoGlossesModal"
                 data-keyboard="false" data-backdrop="static"
-                class='btn btn-primary pull-right'>{% trans "Delete Lemma's with No Glosses" %}</button>
+                class='btn btn-danger pull-right'>{% trans "Delete Lemma's with No Glosses" %}</button>
 
     {% endif %}
 </div>
@@ -273,6 +273,7 @@ var paginate_by = '{{paginate_by}}';
             </div>
             <div class='modal-body'>
                 <p>{% trans "This action will delete all lemmas without glosses and all associated translations belonging to those lemma's. It cannot be undone." %}</p>
+                <p>{% trans "You have chosen to delete" %} {{num_gloss_zero_matches}} {% trans "lemma's." %}</p>
              </div>
           <div class="modal-footer">
           <form id="delete-no-glosses-form" action='' method="POST">

--- a/signbank/dictionary/templates/dictionary/search_result_bar.html
+++ b/signbank/dictionary/templates/dictionary/search_result_bar.html
@@ -11,7 +11,7 @@
                 a.setAttribute("class", "search_result");
                 a.style["float"] = "none";
                 var type_of_data = json_data[key].href_type;
-                a.href = "{{PREFIX_URL}}dictionary/" + type_of_data + "/" + json_data[key].id;
+                a.href = "{{URL}}{{PREFIX_URL}}dictionary/" + type_of_data + "/" + json_data[key].id;
                 a.id = json_data[key].id;
                 var data_label = json_data[key].data_label;
                 if (data_label) {

--- a/signbank/tools.py
+++ b/signbank/tools.py
@@ -2302,15 +2302,10 @@ def construct_scrollbar(qs, search_type, language_code):
 
     return items
 
-def write_csv_for_minimalpairs(minimalpairslistview, csvwriter, language_code):
+def write_csv_for_minimalpairs(minimalpairslistview, language_code):
 #  called from the MinimalPairsListView
 
-    if hasattr(settings, 'SHOW_DATASET_INTERFACE_OPTIONS') and settings.SHOW_DATASET_INTERFACE_OPTIONS:
-        header = ['Dataset', 'Focus Gloss', 'ID', 'Minimal Pair Gloss', 'ID', 'Field Name', 'Source Sign Value', 'Contrasting Sign Value']
-    else:
-        header = ['Focus Gloss', 'ID', 'Minimal Pair Gloss', 'ID', 'Field Name', 'Source Sign Value', 'Contrasting Sign Value']
-
-    csvwriter.writerow(header)
+    rows = []
 
     minimalpairs_list = minimalpairslistview.get_queryset()
     # for debug purposes use a count, otherwise this is extremely slow if all glosses are shown
@@ -2352,7 +2347,7 @@ def write_csv_for_minimalpairs(minimalpairslistview, csvwriter, language_code):
                     except AttributeError:
                         safe_row.append(None)
 
-                csvwriter.writerow(safe_row)
+                rows.append(safe_row)
         else:
             # Make it safe for weird chars
             safe_row = []
@@ -2362,8 +2357,9 @@ def write_csv_for_minimalpairs(minimalpairslistview, csvwriter, language_code):
                 except AttributeError:
                     safe_row.append(None)
 
-            csvwriter.writerow(safe_row)
-    return csvwriter
+            rows.append(safe_row)
+
+    return rows
 
 def minimalpairs_focusgloss(gloss_id, language_code):
 


### PR DESCRIPTION
This branch has the following:

- allows deletion of lemma's that have no glosses, along with their related translation objects. This functionality is offered on the Lemma List page. There is a confirm dialog. The deletion only applies to lemma's without glosses that are in the queried results.

- adjusts the order during export of minimal pairs to CSV to account for large files. The minimal pairs are computed before generation of the file is started. Previously, the file was created and then written row by row as the minimal pairs were computed. While the computation time is still slow, 15 minutes for NGT, it does not timeout/crash any more, at least on my local server.

-  includes a bugfix with the links in the results scroll bar

- adds magic to the python virtual environment requirements