### PR TITLE
Issue #793: Added submap functionality for corpus files.

### DIFF
--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2189,12 +2189,12 @@ class Dataset(models.Model):
 
     def uploaded_eafs(self):
 
-        dataset_eaf_folder = WRITABLE_FOLDER + DATASET_EAF_DIRECTORY + '/' + self.acronym
+        # this is to move the file system commands out of models.py
+        from signbank.frequency import uploaded_eaf_paths, eaf_file_from_paths
 
-        uploaded_eafs = []
-        if os.path.isdir(dataset_eaf_folder):
-            for filename in os.listdir(dataset_eaf_folder):
-                uploaded_eafs.append(filename)
+        eaf_paths = uploaded_eaf_paths(self.acronym)
+        uploaded_eafs = eaf_file_from_paths(eaf_paths)
+
         uploaded_eafs.sort()
 
         return uploaded_eafs

--- a/signbank/dictionary/templates/dictionary/admin_dataset_manager.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_manager.html
@@ -26,6 +26,35 @@
               placeholder: 'Select an option'
             });
         });
+
+        function selectFolder(e) {
+<!--            console.log(JSON.stringify(e));-->
+            var theFiles = e.target.files;
+            var relativePath = theFiles[0].webkitRelativePath;
+            var folder = relativePath.split("/");
+            $("#dir_name").val(folder[0]);
+
+<!--            console.log(JSON.stringify(theFiles[0]));-->
+<!--            var countFiles = theFiles.length;-->
+<!--            console.log(countFiles);-->
+<!--            for (var i = 0; i < countFiles; i++) {-->
+<!--                var relativePath = theFiles[i].webkitRelativePath;-->
+<!--                console.log(relativePath);-->
+<!--                var folder = relativePath.split("/");-->
+<!--                console.log(folder[1]);-->
+<!--            }-->
+        }
+
+        function do_toggle_import(el) {
+              var words = el.id.split("_");
+              var input_file_or_folder = document.getElementById(words[2]+'_file_or_folder');
+              if (words[1] == 'files') {
+                    $(input_file_or_folder).removeProp("webkitdirectory");
+              } else {
+                    $(input_file_or_folder).prop({"webkitdirectory":true});
+              }
+       }
+
     </script>
 
 {% endblock %}
@@ -47,10 +76,10 @@
           <th style="width:200px;">{% trans "Users who can View Dataset (Group permissions excluded)" %}</th>
           <th style="width:200px;">{% trans "Users who can Change Dataset (Group permissions excluded)" %}</th>
           <th style="width:200px;">{% trans "Default language" %}</th>
-          <th style="width:200px;">
+          <th style="width:80px;">
               <div class="text-container"><p>{% trans "Hyperlinks" %}</p></div>
           </th>
-          <th style="width:200px;">
+          <th style="width:250px;">
                 <div class="text-container hasTooltip"><p>{% trans "Metadata CSV" %}</p>
               <span class="isTooltip" style="width: 400px;">The Metadata CSV currently supports:<br>
                   <table>
@@ -71,7 +100,7 @@
                     </tr>
                   </table>
               </span></div></th>
-          <th style="width:200px;">{% trans "EAF Files" %}</th>
+          <th style="width:270px;">{% trans "EAF Files" %}</th>
       </tr>
     </thead>
     <tbody>
@@ -290,10 +319,18 @@
           <form id='upload_eaf_files' action="{{PREFIX_URL}}/update/dataset_eafs/" method="post" enctype="multipart/form-data">
             {% csrf_token %}
             <input class='btn btn-primary' id='upload_eafs' name='upload_eafs' type='submit'
-                   value='{% trans "Upload EAF Files" %}' >
-
+                   value='{% trans "Upload EAF" %}' >
+             <input type="radio" name="radio_folder_or_files" id="radio_folder_{{dataset.acronym}}" value="folder" checked
+                onclick="do_toggle_import(this);">
+              <label for="radio_folder">{% trans "Folder" %}</label>
+                <input type="radio" name="radio_folder_or_files" id="radio_files_{{dataset.acronym}}" value="files"
+                onclick="do_toggle_import(this);">
+                <label for="radio_files">{% trans "Files" %}</label>
+            <input type="hidden" name="dir_name" id="dir_name" value="">
             <input type='hidden' name='dataset_acronym' value='{{dataset.acronym}}'>
-            <input class='form-control' placeholder='{% trans "Upload EAF Files" %}' name='file' type='file' multiple required="">
+            <input class='form-control' placeholder='{% trans "Upload EAF Files" %}'
+                   name='file' type='file' multiple="" required="" webkitdirectory=true
+                    onchange="selectFolder(event)" id="{{dataset.acronym}}_file_or_folder">
           </form>
           </div>
           </td>

--- a/signbank/dictionary/templates/dictionary/dataset_frequency.html
+++ b/signbank/dictionary/templates/dictionary/dataset_frequency.html
@@ -37,14 +37,19 @@
         function update_document(el) {
             var this_document = $(el).attr('value');
             var lookup = "#toelichting_"+this_document;
+            var datum = "#datum_"+this_document;
+            var numglosses = "#numglosses_"+this_document;
             $.ajax({
                 url : url + "dictionary/update_corpus_document_counts/"+{{dataset.id}}+ "/" + this_document + "/",
                 datatype: "json",
                 type: "POST",
                 async: true,
                 success : function(result) {
+                    split_values = result[0].split('\t');
                     $(lookup).html('');
-                    $(lookup).append(result);
+                    $(lookup).append(split_values[0]);
+                    $(datum).html(split_values[1]);
+                    $(numglosses).html(split_values[2]);
                 }
             });
         };
@@ -89,6 +94,7 @@ dd {
 </style>
 {% endblock %}
 
+{% block bootstrap3_title %}Signbank: Corpus Overview{% endblock %}
 
 {% block content %}
 
@@ -286,17 +292,17 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
                  <dl class="row list-group-item active"  style="width:1008px; padding: 0;">
                       <dt class="col-sm-2">{% trans "Document" %}</dt>
                       <dt class="col-sm-2">{% trans "Creation Date" %}</dt>
-                      <dt class="col-sm-2">{% trans "Number of Glosses" %}</dt>
+                      <dt class="col-sm-3">{% trans "Number of Annotations" %}</dt>
                       <dt class="col-sm-2">{% trans "Refresh" %}</dt>
                       <dt class="col-sm-2">{% trans "Comment" %}</dt>
                   </dl>
               <list name="document_tuples"
                     style="height:146px; display:block;">
-              {% for identifier, creation_time, number_of_glosses, other_dataset in documents %}
+              {% for identifier, creation_time, number_of_glosses, toelichting in documents %}
                   <dl id="document_{{identifier}}" class="row list-group-item" style="padding: 0;">
                       <dd class="col-sm-2">{{identifier}}</dd>
-                      <dd class="col-sm-2">{{creation_time}}</dd>
-                      <dd class="col-sm-2">{{number_of_glosses}}</dd>
+                      <dd class="col-sm-2" id='datum_{{identifier}}'>{{creation_time}}</dd>
+                      <dd class="col-sm-3" id='numglosses_{{identifier}}'>{{number_of_glosses}}</dd>
                       <dd class="col-sm-2">
                    {% csrf_token %}
                    <input type='hidden' name='sourceid' value='{{gloss.pk}}'>
@@ -308,7 +314,7 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
                                         value='{{identifier}}'>{{identifier}}</button>
                             </div>
                       </dd>
-                      <dd class="col-sm-2" id='toelichting_{{identifier}}'>
+                      <dd class="col-sm-2" id='toelichting_{{identifier}}'>{{toelichting}}
                       </dd>
                   </dl>
               {% endfor %}
@@ -320,11 +326,113 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
           </td>
         </tr>
     </table>
+    </div>
+        {% if duplicates %}
+        <div>
+            {% blocktrans %}
+            <p style="color:red;">Some eaf files have been uploaded to more than one location.
+                Please identify the unwanted copies in the list below.</p>
+            {% endblocktrans %}
+        </div>
+        {% endif %}
+
+      <form name='remove_eafs_form' id='remove_eafs_form'
+            method="post" action="{{PREFIX_URL}}/update/remove_eaf_files/">
+
+        {% csrf_token %}
+        <div class="hidden">
+            <input name='dataset_acronym' class='form-control' value='{{dataset.acronym}}' >
+        </div>
+        <div class='hidden'>
+            <input name='remove_eafs' value='{{dataset.acronym}}'>
+        </div>
+        <table class='table'>
+        <tr>
+            <th style="width:200px;">{% trans "Overview EAF Files" %}</th>
+            <td >
+               <div name="overview_eaf_files"
+                    style="height:180px; display:block;">
+                  <ul class="list-group-hover" style="padding: 0;">
+                      <li class="list-group-item active row" style="padding: 0;">
+                          <dt class="col-sm-2">{% trans "Document" %}</dt>
+                          <dt class="col-sm-6">{% trans "Path" %}</dt>
+                          <dt class="col-sm-2">{% trans "Delete" %}</dt>
+                      </li>
+
+                  <list name="document_path_tuples"
+                    style="height:146px; display:block;">
+                      {% for document_identifier in sorted_document_identifiers %}
+                      {% with overview_eaf_files|keyvalue:document_identifier as eaf_paths %}
+                      {% for path in eaf_paths %}
+                      <li id="document_paths_{{document_identifier}}" class="row"
+                            {% if document_identifier in duplicates %}
+                                style="padding: 0; color:red;"
+                            {% elif document_identifier in document_identifiers %}
+                                style="padding: 0; color:blue;"
+                            {% else %}
+                                style="padding: 0;"
+                            {% endif %} >
+                        <dd class="col-sm-2">{{document_identifier}}</dd>
+                        <dd class="col-sm-6" >{{path}}</dd>
+
+                        <dd class="col-sm-2" id='{{dataset.acronym}}_{{document_identifier}}_{{path}}' value=''
+                            name="{{dataset.acronym}}_{{document_identifier}}_{{path}}">
+                                <input type="checkbox" name="select_document:{{path}}"
+                                       id="select_document_{{path}}" value="{{path}}" >
+                        </dd>
+                      </li>
+                      {% endfor %}
+                      {% endwith %}
+                      {% endfor %}
+                  </list>
+                  </ul>
+              </div>
+            </td>
+        </tr>
+        </table>
+
+
+    {% if dataset.get_metadata_path and dataset.uploaded_eafs %}
+    {% if request.user|has_group:"Dataset_Manager" %}
+    {% get_obj_perms request.user for dataset as "dataset_perms" %}
+    {% if "change_dataset" in dataset_perms %}
+    <button id='remove_eafs_btn'
+            {% if duplicates %}
+            class='btn btn-danger'
+            {% else %}
+            class="btn btn-primary"
+            {% endif %}
+            data-toggle='modal' type="button"
+            data-target='#remove_eafs_modal'>{% trans "Remove EAF Files" %}</button>
+
+    <div class="modal fade" id="remove_eafs_modal" tabindex="-1" role="dialog" aria-labelledby="#modalRemoveEafs" aria-hidden="true">
+         <div class="modal-dialog modal-sm">
+            <div class="modal-content">
+                <div class='modal-header'>
+                    <h3 id='modalRemoveEafs'>{% trans "Remove EAF Files" %}</h3>
+                </div>
+                <div class='modal-body'>
+                    <p>{% trans "Please make sure to leave one copy of the documents you want." %}</p>
+                    <p>{% trans "If all copies of a file are removed, the associated document and its frequency data will be removed." %}</p>
+                 </div>
+
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Cancel" %}</button>
+                        <input type="submit" class="btn btn-warning" value='{% trans "Remove EAF Files" %}'>
+                      </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+    {% endif %}
+    {% endif %}
+    </form>
+    <br/><br/>
     {% if new_eaf_files %}
     <div style="width:1200px">
     <table class='table'>
         <tr>
-          <th style="width:200px;">{% trans "New EAF Files" %}</th>
+          <th style="width:200px;">{% trans "Unprocessed EAF Files" %}</th>
           <td >
 
               {% url 'dictionary:protected_media' '' as protected_media_url %}
@@ -342,19 +450,40 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
     </table>
     </div>
     {% endif %}
+    </div>
+    {% if not duplicates %}
     {% if dataset.get_metadata_path and dataset.uploaded_eafs %}
     {% if request.user|has_group:"Dataset_Manager" %}
     {% get_obj_perms request.user for dataset as "dataset_perms" %}
     {% if "change_dataset" in dataset_perms %}
-    <form name='update_documents_form' id='update_documents_form' method='get'>
-        <div class="hidden">
-            <input name='dataset_name' class='form-control' value='{{dataset.acronym}}' >
+    <button id='refresh_all_btn' class='btn btn-primary' data-toggle='modal' data-target='#refresh_all_modal'>{% trans "Refresh All Documents" %}</button>
+
+    <div class="modal fade" id="refresh_all_modal" tabindex="-1" role="dialog" aria-labelledby="#modalRefreshAll" aria-hidden="true">
+         <div class="modal-dialog modal-sm">
+            <div class="modal-content">
+                <div class='modal-header'>
+                    <h3 id='modalRefreshAll'>{% trans "Refresh All Documents" %}</h3>
+                </div>
+                <div class='modal-body'>
+                    <p>{% trans "Depending on how many files and annotations you have, this could take some time." %}</p>
+                    <p>{% trans "Once your corpus has been created, its files are refreshed in a cron job during the night." %}</p>
+                 </div>
+                  <form name='update_documents_form' id='update_documents_form' method='get'>
+                    <div class="hidden">
+                        <input name='dataset_name' class='form-control' value='{{dataset.acronym}}' >
+                    </div>
+                    <div class='hidden'>
+                        <input name='update_corpus' value='{{dataset.acronym}}'>
+                    </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Cron Job" %}</button>
+                        <input type="submit" class="btn btn-warning" value='{% trans "Refresh Now" %}'>
+                      </div>
+                  </form>
+            </div>
         </div>
-        <div class='btn-group'>
-            <button id="update_documents" class="btn btn-primary" type="submit"
-                    name='update_corpus' value='{{dataset.acronym}}'>{% trans "Refresh All Documents" %}</button>
-        </div>
-    </form>
+    </div>
+    {% endif %}
     {% endif %}
     {% endif %}
     {% endif %}

--- a/signbank/dictionary/tests.py
+++ b/signbank/dictionary/tests.py
@@ -2753,7 +2753,7 @@ class Corpus_Tests(TestCase):
         sp_per_document = dictionary_documents_to_speakers(self.test_dataset.acronym)
 
         for did in sp_per_document.keys():
-            speakers = document_to_speakers(did)
+            speakers = document_to_speakers(self.test_dataset.acronym, did)
             self.assertEqual(sp_per_document[did], speakers)
 
         gl_appear_in_documents = dictionary_glosses_to_documents(self.test_dataset.acronym)

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -2296,144 +2296,183 @@ def upload_metadata(request):
 
 
 def remove_eaf_files(request):
-    if request.method == "POST":
+    if request.method != "POST":
+        return
 
-        selected_paths = []
-        dataset_acronym = ''
-        for key in request.POST.keys():
-            if key == 'dataset_acronym':
-                dataset_acronym = request.POST['dataset_acronym']
-            if key.startswith('select_document:'):
-                value = request.POST[key]
-                selected_paths.append(value)
-        if dataset_acronym == '':
-            messages.add_message(request, messages.ERROR, _('No acronym for dataset.'))
-            return HttpResponseRedirect(reverse('admin_dataset_view'))
-        try:
-            dataset = Dataset.objects.get(acronym=dataset_acronym)
-        except ObjectDoesNotExist:
-            messages.add_message(request, messages.ERROR, _('Dataset does not exist.'))
-            return HttpResponseRedirect(reverse('admin_dataset_view'))
-        # Check for 'change_dataset' permission
-        user_change_datasets = get_objects_for_user(request.user, 'change_dataset', Dataset, accept_global_perms=False)
-        if not user_change_datasets.exists() or dataset not in user_change_datasets:
-            messages.add_message(request, messages.ERROR, _("You are not authorized to remove eaf files."))
-            return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
-        dataset_eaf_folder = os.path.join(WRITABLE_FOLDER,DATASET_EAF_DIRECTORY,dataset_acronym)
-        for selected_path in selected_paths:
-            destination_location = dataset_eaf_folder + '/' + selected_path
-            os.remove(destination_location)
+    # Process the request data
+    selected_paths = []
+    dataset_acronym = ''
+
+    for key in request.POST.keys():
+        if key == 'dataset_acronym':
+            dataset_acronym = request.POST['dataset_acronym']
+        if key.startswith('select_document:'):
+            value = request.POST[key]
+            selected_paths.append(value)
+
+    if dataset_acronym == '':
+        messages.add_message(request, messages.ERROR, _('No acronym for dataset.'))
+        return HttpResponseRedirect(reverse('admin_dataset_view'))
+
+    # Get the dataset
+    try:
+        dataset = Dataset.objects.get(acronym=dataset_acronym)
+
+    except ObjectDoesNotExist:
+        messages.add_message(request, messages.ERROR, _('Dataset does not exist.'))
+        return HttpResponseRedirect(reverse('admin_dataset_view'))
+
+    # Check for 'change_dataset' permission
+    user_change_datasets = get_objects_for_user(request.user, 'change_dataset', Dataset, accept_global_perms=False)
+    if not user_change_datasets.exists() or dataset not in user_change_datasets:
+        messages.add_message(request, messages.ERROR, _("You are not authorized to remove eaf files."))
         return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+    # The actual removal
+    dataset_eaf_folder = os.path.join(WRITABLE_FOLDER,DATASET_EAF_DIRECTORY,dataset_acronym)
+    for selected_path in selected_paths:
+        os.remove(dataset_eaf_folder + '/' + selected_path)
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
 
 def upload_eaf_files(request):
-    if request.method == "POST":
+    if request.method != "POST":
+        raise Http404('Incorrect request')
 
-        form = EAFFilesForm(request.POST,request.FILES)
-        if form.is_valid():
+    form = EAFFilesForm(request.POST,request.FILES)
+    if form.is_valid():
 
-            folder = ''
-            dataset_acronym = ''
+        # Process the request data
+        if not request.FILES:
+            messages.add_message(request, messages.ERROR, _('No eaf files found.'))
+            return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
-            eaf_filenames_list = []
+        folder = ''
+        dataset_acronym = ''
+        eaf_filenames_list = []
 
-            if request.FILES:
-                for f in request.FILES.getlist('file'):
-                    eaf_filenames_list.append(f.name)
-            else:
-                messages.add_message(request, messages.ERROR, _('No eaf files found.'))
-                return HttpResponseRedirect(reverse('admin_dataset_manager'))
+        for f in request.FILES.getlist('file'):
+            eaf_filenames_list.append(f.name)
 
-            for key in request.POST.keys():
-                if key == 'dataset_acronym':
-                    dataset_acronym = request.POST['dataset_acronym']
-                if key == 'dir_name':
-                    folder = request.POST.get('dir_name', '')
+        for key in request.POST.keys():
+            if key == 'dataset_acronym':
+                dataset_acronym = request.POST['dataset_acronym']
+            if key == 'dir_name':
+                folder = request.POST.get('dir_name', '')
 
-            if dataset_acronym == '':
-                messages.add_message(request, messages.ERROR, _('No acronym for dataset.'))
-                return HttpResponseRedirect(reverse('admin_dataset_manager'))
+        if dataset_acronym == '':
+            messages.add_message(request, messages.ERROR, _('No acronym for dataset.'))
+            return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
-            try:
-                dataset = Dataset.objects.get(acronym=dataset_acronym)
-            except ObjectDoesNotExist:
-                messages.add_message(request, messages.ERROR, _('Dataset does not exist.'))
-                return HttpResponseRedirect(reverse('admin_dataset_manager'))
+        # Get the dataset
+        try:
+            dataset = Dataset.objects.get(acronym=dataset_acronym)
 
-            already_uploaded_eafs = dataset.uploaded_eafs()
-            document_identifiers_of_uploaded_eafs = document_identifiers_from_paths(already_uploaded_eafs)
+        except ObjectDoesNotExist:
+            messages.add_message(request, messages.ERROR, _('Dataset does not exist.'))
+            return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
-            (eaf_paths_dict, duplicates) = documents_paths_dictionary(dataset_acronym)
+        # Check for 'change_dataset' permission
+        user_change_datasets = get_objects_for_user(request.user, 'change_dataset', Dataset, accept_global_perms=False)
+        if not user_change_datasets.exists() or dataset not in user_change_datasets:
+            messages.add_message(request, messages.ERROR, _("You are not authorized to upload eaf files."))
+            return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
-            if not os.path.isdir(WRITABLE_FOLDER + DATASET_EAF_DIRECTORY):
-                os.mkdir(WRITABLE_FOLDER + DATASET_EAF_DIRECTORY, mode=0o755)
+        # For the following, we want to keep track of which files are already uploaded
+        # Some files may be uploaded but may or may not be processed in the corpus
+        already_uploaded_eafs = dataset.uploaded_eafs()
+        document_identifiers_of_uploaded_eafs = document_identifiers_from_paths(already_uploaded_eafs)
 
-            dataset_eaf_folder = os.path.join(WRITABLE_FOLDER,DATASET_EAF_DIRECTORY,dataset_acronym)
+        # this structure is used by the corpus overview template
+        # We're using it here during upload in the database manager template because it's already implemented
+        (eaf_paths_dict, duplicates) = documents_paths_dictionary(dataset_acronym)
+
+        # if this is the first time eaf files are uploadd to the system, create the folder
+        if not os.path.isdir(WRITABLE_FOLDER + DATASET_EAF_DIRECTORY):
+            os.mkdir(WRITABLE_FOLDER + DATASET_EAF_DIRECTORY, mode=0o755)
+
+        # if this is the first time eaf files are uploadd for the dataset, create a dataset folder
+        dataset_eaf_folder = os.path.join(WRITABLE_FOLDER,DATASET_EAF_DIRECTORY,dataset_acronym)
+        if not os.path.isdir(dataset_eaf_folder):
+            os.mkdir(dataset_eaf_folder, mode=0o755)
+
+        # folder was retrieved by the template during selection to upload a folder
+        if folder:
+            # this could have a side effect of creating an empty folder
+            # at a later step the files are checked to be eaf files
+            # incorrectly typed files are removed after creation, but not the folder
+            dataset_eaf_folder = os.path.join(dataset_eaf_folder,folder)
             if not os.path.isdir(dataset_eaf_folder):
                 os.mkdir(dataset_eaf_folder, mode=0o755)
 
-            if folder:
-                # this could have a side effect of creating an empty folder
-                # at a later step the files are checked to be eaf files
-                # incorrectly typed files are removed after creation, but not the folder
-                dataset_eaf_folder = os.path.join(dataset_eaf_folder,folder)
-                if not os.path.isdir(dataset_eaf_folder):
-                    os.mkdir(dataset_eaf_folder, mode=0o755)
+        # move uploaded files to appropriate location
+        for f in request.FILES.getlist('file'):
+            next_eaf_file = os.path.join(dataset_eaf_folder,f.name)
+            f_handle = open(next_eaf_file, mode='wb+')
+            for chunk in f.chunks():
+                f_handle.write(chunk)
 
-            # move uploaded files to appropriate location
-            for f in request.FILES.getlist('file'):
-                next_eaf_file = os.path.join(dataset_eaf_folder,f.name)
-                f_handle = open(next_eaf_file, mode='wb+')
-                for chunk in f.chunks():
-                    f_handle.write(chunk)
+        # this import has limited usage, reduce its scope
+        import magic
+        # check whether anything should not have been uploaded
+        # check the type of the first chunk of the uploaded files
+        # check that the files do not already exist
 
-            # this import has limited usage, reduce its scope
-            import magic
-            # check whether anything should not have been uploaded
-            # check the type of the first chunk of the uploaded files
-            # check that the files do not already exist
-            ignored_files = []
-            duplicate_files = []
-            already_seen = []
-            import_twice = []
-            for new_file in eaf_filenames_list:
-                # duplicate_found = False
-                norm_filename = os.path.normpath(new_file)
-                split_norm_filename = norm_filename.split('.')
-                if len(split_norm_filename) == 1:
-                    # file has no extension
-                    wrong_format = True
-                else:
-                    extension = split_norm_filename[-1]
-                    wrong_format = (extension.lower() != 'eaf')
-                destination_location = os.path.join(dataset_eaf_folder,new_file)
-                file_basename = os.path.basename(new_file)
-                basename = os.path.splitext(file_basename)[0]
-                if basename in document_identifiers_of_uploaded_eafs or basename in eaf_paths_dict.keys():
-                    # check if the new file is in the same location
-                    new_file_location = os.path.join(folder,file_basename)
-                    if new_file_location not in eaf_paths_dict[basename]:
-                        duplicate_files.append(new_file)
-                if basename in already_seen:
-                    # potential conflict, the same file is being imported twice from different locations
-                    import_twice.append(new_file)
-                else:
-                    already_seen.append(basename)
+        # Create lists for all problems we might encounter
+        ignored_files = []
+        duplicate_files = []
+        already_seen = []
+        import_twice = []
 
-                magic_file_type = magic.from_buffer(open(destination_location, "rb").read(2040), mime=True)
-                if magic_file_type != 'text/xml' or wrong_format:
-                    # this file is not an eaf file or is missing an extension
-                    ignored_files.append(new_file)
-                    os.remove(destination_location)
-            if ignored_files:
-                message_string = ", ".join(ignored_files)
-                messages.add_message(request, messages.ERROR, _('Non-EAF file(s) ignored: ')+message_string)
-            if import_twice:
-                message_string = ", ".join(import_twice)
-                messages.add_message(request, messages.WARNING, _('File(s) encountered twice: ')+message_string)
-            if duplicate_files:
-                message_string = ", ".join(duplicate_files)
-                messages.add_message(request, messages.INFO, _('Already imported to different folder: ')+message_string)
+        for new_file in eaf_filenames_list:
 
-            return HttpResponseRedirect(reverse('admin_dataset_manager'))
-    raise Http404('Incorrect request')
+            # Get the normalized file name
+            norm_filename = os.path.normpath(new_file)
+            split_norm_filename = norm_filename.split('.')
+
+            # Validate format
+            if len(split_norm_filename) == 1:
+                # file has no extension
+                wrong_format = True
+            else:
+                extension = split_norm_filename[-1]
+                wrong_format = (extension.lower() != 'eaf')
+
+            # Get full paths
+            destination_location = os.path.join(dataset_eaf_folder,new_file)
+            file_basename = os.path.basename(new_file)
+            basename = os.path.splitext(file_basename)[0]
+
+            # Check if the new file is in the same location
+            if basename in document_identifiers_of_uploaded_eafs or basename in eaf_paths_dict.keys():
+                new_file_location = os.path.join(folder,file_basename)
+                if new_file_location not in eaf_paths_dict[basename]:
+                    duplicate_files.append(new_file)
+
+            # Potential conflict, the same file is being imported twice from different locations
+            if basename in already_seen:
+                import_twice.append(new_file)
+            else:
+                already_seen.append(basename)
+
+            # Maybe the file is not an eaf file or is missing an extension
+            magic_file_type = magic.from_buffer(open(destination_location, "rb").read(2040), mime=True)
+            if magic_file_type != 'text/xml' or wrong_format:
+                ignored_files.append(new_file)
+                os.remove(destination_location)
+
+        # Any problems encountered? Add error messages
+        if ignored_files:
+            message_string = ", ".join(ignored_files)
+            messages.add_message(request, messages.ERROR, _('Non-EAF file(s) ignored: ')+message_string)
+
+        if import_twice:
+            message_string = ", ".join(import_twice)
+            messages.add_message(request, messages.WARNING, _('File(s) encountered twice: ')+message_string)
+
+        if duplicate_files:
+            message_string = ", ".join(duplicate_files)
+            messages.add_message(request, messages.INFO, _('Already imported to different folder: ')+message_string)
+
+        return HttpResponseRedirect(reverse('admin_dataset_manager'))

--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -84,6 +84,8 @@ urlpatterns = [
     # url(r'^import_other_media/$', permission_required('dictionary.change_gloss')(signbank.dictionary.views.import_other_media)),
     url(r'update_corpus_document_counts/(?P<dataset_id>.*)/(?P<document_id>.*)/$',
         permission_required('dictionary.change_gloss')(signbank.frequency.update_document_counts)),
+    url(r'update_corpora/$',
+        permission_required('dictionary.change_gloss')(signbank.frequency.update_corpora)),
 
     url(r'find_and_save_variants/$',permission_required('dictionary.change_gloss')(signbank.dictionary.views.find_and_save_variants)),
 

--- a/signbank/urls.py
+++ b/signbank/urls.py
@@ -122,6 +122,7 @@ urlpatterns = [
     url(r'^datasets/(?P<acronym>.*)$', dataset_detail_view_by_acronym, name='dataset_detail_view_by_acronym'),
     url(r'^update/metadata/', signbank.dictionary.update.upload_metadata, name='upload_metadata'),
     url(r'^update/dataset_eafs/', signbank.dictionary.update.upload_eaf_files, name='upload_eaf_files'),
+    url(r'^update/remove_eaf_files/', signbank.dictionary.update.remove_eaf_files, name='remove_eaf_files'),
                   url(r'^__debug__/', include(debug_toolbar.urls))
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This branch adds submap functionality for corpora eaf files. See Issue #793 for screenshots.

The Dataset Manager page allows importing eaf files or folders of eaf files. This is indicated with a toggle in the interface.

The Corpus Overview page has been extended with a panel list of uploaded eaf files for the documents.
Duplicates are highlighted in red.
Already processed files are highlighted in blue.

Because duplicate eaf files are a problem, because frequencies would be processed twice, this is considered an error.
Functionality is provided to remove the unwanted eaf files.
Once duplicates have been removed, the user can refresh the documents as before.

Modals have been added as an extra layer. A confirm dialogue is shown for removing files.
A helpful message is shown before the user wants to refresh all the documents. The user is informed that a cron job will do the work during the night.

A new cron job url has been added to refresh all documents of all corpora.