### PR TITLE
Csv user friendly

### DIFF
--- a/signbank/dictionary/templates/dictionary/import_csv_create.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_create.html
@@ -34,7 +34,7 @@
 
 {% if stage == 0 %}
 
-    <div>{% blocktrans %}Upload your changed CSV here:{% endblocktrans %}</div>
+    <div>{% blocktrans %}Upload your CSV here:{% endblocktrans %}</div>
 
     <form action="" method="post" enctype="multipart/form-data" role="form">
         {% csrf_token %}

--- a/signbank/dictionary/templates/dictionary/import_csv_create.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_create.html
@@ -47,7 +47,9 @@
                           Dataset (acronym), Lemma ID Gloss, and Annotation ID Gloss for the translation languages of the dataset. Only one dataset can be modified."></span>
                 </div>
                 <div class="col-sm-10">
-                    <input type="file" required="" name="file" class="filestyle" data-icon="false" data-buttonText='{% trans "Browse&hellip;"%}' data-buttonBefore="true">
+                    <input type="file" required="" name="file" class="filestyle" data-icon="false"
+                           accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, text/csv, application/vnd.ms-excel"
+                           data-buttonText='{% trans "Browse&hellip;"%}' data-buttonBefore="true">
                 </div>
                 <div class="col-sm-1">
                     <input class="btn btn-primary" type="submit" value="{% blocktrans %}Submit{% endblocktrans %}" />

--- a/signbank/dictionary/templates/dictionary/import_csv_update.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_update.html
@@ -51,7 +51,9 @@
                           make sure that the old values that should stay are also in the second column."></span>
                 </div>
                 <div class="col-sm-10">
-                    <input type="file" required="" name="file" class="filestyle" data-icon="false" data-buttonText='{% trans "Browse&hellip;"%}' data-buttonBefore="true">
+                    <input type="file" required="" name="file" class="filestyle" data-icon="false"
+                           accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, text/csv, application/vnd.ms-excel"
+                           data-buttonText='{% trans "Browse&hellip;"%}' data-buttonBefore="true">
                 </div>
                 <div class="col-sm-1">
                     <input class="btn btn-primary" type="submit" value="{% blocktrans %}Submit{% endblocktrans %}" />

--- a/signbank/dictionary/templates/dictionary/import_csv_update.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_update.html
@@ -59,10 +59,16 @@
                     <input class="btn btn-primary" type="submit" value="{% blocktrans %}Submit{% endblocktrans %}" />
                 </div>
             </div>
+            <div class="col-xs-offset-1 col-xs-10">
+                <input type="radio" name="delimiter" id="delimiter_comma" value="comma" checked>
+                <label for="delimiter_comma">{% trans "Comma" %}</label>
+                <input type="radio" name="delimiter" id="delimiter_tab" value="tab">
+                <label for="delimiter_tab">{% trans "Tab" %}</label>
+                <input type="radio" name="delimiter" id="delimiter_semicolon" value="semicolon">
+                <label for="delimiter_semicolon">{% trans "Semicolon" %}</label>
+            </div>
         </div>
     </form>
-
-<div>{% blocktrans %}To speed up processing of updates, remove columns that will not be updated.{% endblocktrans %}</div>
 
 {% elif stage == 1 %}
 

--- a/signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html
@@ -50,7 +50,9 @@
                           indicating the fields you want to make changes to."></span>
                 </div>
                 <div class="col-sm-10">
-                    <input type="file" required="" name="file" class="filestyle" data-icon="false" data-buttonText='{% trans "Browse&hellip;"%}' data-buttonBefore="true">
+                    <input type="file" required="" name="file" class="filestyle" data-icon="false"
+                           accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, text/csv, application/vnd.ms-excel"
+                           data-buttonText='{% trans "Browse&hellip;"%}' data-buttonBefore="true">
                 </div>
                 <div class="col-sm-1">
                     <input class="btn btn-primary" type="submit" value="{% blocktrans %}Submit{% endblocktrans %}" />

--- a/signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html
@@ -58,6 +58,14 @@
                     <input class="btn btn-primary" type="submit" value="{% blocktrans %}Submit{% endblocktrans %}" />
                 </div>
             </div>
+            <div class="col-xs-offset-1 col-xs-10">
+                <input type="radio" name="delimiter" id="delimiter_comma" value="comma" checked>
+                <label for="delimiter_comma">{% trans "Comma" %}</label>
+                <input type="radio" name="delimiter" id="delimiter_tab" value="tab">
+                <label for="delimiter_tab">{% trans "Tab" %}</label>
+                <input type="radio" name="delimiter" id="delimiter_semicolon" value="semicolon">
+                <label for="delimiter_semicolon">{% trans "Semicolon" %}</label>
+            </div>
         </div>
     </form>
 


### PR DESCRIPTION
This branch adds user friendly import of csv files as discussed in #761.

Empty rows are ignored rather than complained about.

Non-UTF-8 encoded files are given an informative error message rather than crashing. (See screenshot in the issue.)

Files that do not end in csv are not allowed to be chosen by the browser input dialog.
If a user has changed the extension of a non-csv file to csv, it is caught in the python code and an error message displayed rather than crashing.

Delimiters can be chosen on the` Import CSV Update` and `Import CSV Lemma` templates.
This was previously only on the `Import CSV Create` template as it was assumed users would obtain an initial csv from exporting.