### PR TITLE
Issue #800: Setting weakdrop back to Neutral; #760: Tags in GlossRevision; Refine Display

### DIFF
--- a/signbank/dictionary/templates/dictionary/gloss_revision_history.html
+++ b/signbank/dictionary/templates/dictionary/gloss_revision_history.html
@@ -84,9 +84,19 @@
             <tr>
                 <td>{{revision.user}}</td>
                 <td>{{revision.time}}</td>
-                <td>{{revision.field_name}}</td>
-                <td>{{revision.old_value}}</td>
-                <td>{{revision.new_value}}</td>
+                <td>{{revision.field_name}}{{revision.field_name_qualification}}</td>
+                <td>{% if revision.is_tag and revision.old_value %}
+                    {% load underscore_to_space %}
+                    <div class='tag' style="margin:0;">
+                        <span class='tagname'>{{revision.old_value|underscore_to_space}}</span>
+                    </div>
+                    {% else %}{{revision.old_value}}{% endif %}</td>
+                <td>{% if revision.is_tag and revision.new_value %}
+                    {% load underscore_to_space %}
+                    <div class='tag' style="margin:0;">
+                        <span class='tagname'>{{revision.new_value|underscore_to_space}}</span>
+                    </div>
+                    {% else %}{{revision.new_value}}{% endif %}</td>
             </tr>
         {% endfor %}
 

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -451,7 +451,14 @@ def update_gloss(request, glossid):
         except:
             original_human_value = original_value
 
-        revision = GlossRevision(old_value=original_human_value, new_value=newvalue,field_name=field,gloss=gloss,user=request.user,time=datetime.now(tz=get_current_timezone()))
+        # this takes care of a problem with None not being allowed as a value in GlossRevision
+        # the weakdrop and weakprop fields make use of three-valued logic and None is a legitimate value aka Neutral
+        if field in ['weakdrop', 'weakprop'] and newvalue is None:
+            # user is setting the field back to Neutral, show this in the Revision History
+            glossrevision_newvalue = _('Neutral')
+        else:
+            glossrevision_newvalue = newvalue
+        revision = GlossRevision(old_value=original_human_value, new_value=glossrevision_newvalue,field_name=field,gloss=gloss,user=request.user,time=datetime.now(tz=get_current_timezone()))
         revision.save()
         # The machine_value (value) representation is also returned to accommodate Hyperlinks to Handshapes in gloss_edit.js
         return HttpResponse(

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -22,6 +22,8 @@ from signbank.frequency import configure_corpus_documents, import_corpus_speaker
 from signbank.tools import save_media, MachineValueNotFoundError
 from signbank.tools import get_selected_datasets_for_user, get_default_annotationidglosstranslation, get_dataset_languages, \
     create_gloss_from_valuedict, compare_valuedict_to_gloss, compare_valuedict_to_lemma
+from signbank.dictionary.translate_choice_list import machine_value_to_translated_human_value, fieldname_to_translated_human_value, \
+    check_value_to_translated_human_value
 
 import signbank.settings
 from signbank.settings.base import *
@@ -2848,8 +2850,20 @@ def gloss_revision_history(request,gloss_pk):
     else:
         show_dataset_interface = False
 
+    revisions = []
+    for revision in GlossRevision.objects.filter(gloss=gloss):
+
+        revision_dict = {
+            'gloss' : revision.gloss,
+            'user' : revision.user,
+            'time' : revision.time,
+            'field_name' : fieldname_to_translated_human_value(revision.field_name),
+            'old_value' : check_value_to_translated_human_value(revision.field_name, revision.old_value),
+            'new_value' : check_value_to_translated_human_value(revision.field_name, revision.new_value) }
+        revisions.append(revision_dict)
+
     return render(request, 'dictionary/gloss_revision_history.html',
-                  {'gloss': gloss, 'revisions':GlossRevision.objects.filter(gloss=gloss),
+                  {'gloss': gloss, 'revisions':revisions,
                    'dataset_languages': dataset_languages,
                    'selected_datasets': selected_datasets,
                    'active_id': gloss_pk,

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -2853,11 +2853,29 @@ def gloss_revision_history(request,gloss_pk):
     revisions = []
     for revision in GlossRevision.objects.filter(gloss=gloss):
 
+        # field name qualification is stored separately here
+        # Django was having a bit of trouble translating it when embeded in the field_name string below
+        if revision.field_name == 'Tags':
+            if revision.old_value:
+                # this translation exists in the interface of Gloss Edit View
+                delete_command = str(_('delete this tag'))
+                field_name_qualification = ' (' + delete_command + ')'
+            elif revision.new_value:
+                # this translation exists in the interface of Gloss Edit View
+                add_command = str(_('Add Tag'))
+                field_name_qualification = ' (' + add_command + ')'
+            else:
+                # this shouldn't happen
+                field_name_qualification = ''
+        else:
+            field_name_qualification = ' (' + revision.field_name + ')'
         revision_dict = {
+            'is_tag': revision.field_name == 'Tags',
             'gloss' : revision.gloss,
             'user' : revision.user,
             'time' : revision.time,
             'field_name' : fieldname_to_translated_human_value(revision.field_name),
+            'field_name_qualification' : field_name_qualification,
             'old_value' : check_value_to_translated_human_value(revision.field_name, revision.old_value),
             'new_value' : check_value_to_translated_human_value(revision.field_name, revision.new_value) }
         revisions.append(revision_dict)


### PR DESCRIPTION
This implements issue #800.
The bug was located in saving to GlossRevision when the new value is None (aka Neutral).
This has been repaired by saving the human readable value Neutral in the history.