### PR TITLE
Issue #801: Repaired search field translation equivalents.

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -644,13 +644,11 @@ class GlossListView(ListView):
 
                 # is this needed?
                 if f.name in char_fields_not_null and value and not isinstance(value,str):
-                    print(gloss.id, ' convert value to string: ', value)
                     value = str(value)
 
                 # some legacy glosses have empty text fields of other formats
                 if (f.__class__.__name__ == 'CharField' or f.__class__.__name__ == 'TextField') \
                         and (value == '-' or value == '------' or value == ' '):
-                    # print(gloss.id, ' replace with empty string: ', value)
                     value = ''
 
                 if value is None:
@@ -847,11 +845,8 @@ class GlossListView(ListView):
 
             qs = qs.filter(query)
 
-        print(GlossSearchForm.keyword_search_field_prefix)
         # Evaluate all gloss/language search fields
         for get_key, get_value in get.items():
-            if get_value:
-                print('key, value: ', get_key, get_value)
             if get_key.startswith(GlossSearchForm.gloss_search_field_prefix) and get_value != '':
                 language_code_2char = get_key[len(GlossSearchForm.gloss_search_field_prefix):]
                 language = Language.objects.filter(language_code_2char=language_code_2char)
@@ -863,7 +858,6 @@ class GlossListView(ListView):
                 qs = qs.filter(lemma__lemmaidglosstranslation__text__iregex=get_value,
                                lemma__lemmaidglosstranslation__language=language)
             elif get_key.startswith(GlossSearchForm.keyword_search_field_prefix) and get_value != '':
-                print('search keyword')
                 language_code_2char = get_key[len(GlossSearchForm.keyword_search_field_prefix):]
                 language = Language.objects.filter(language_code_2char=language_code_2char)
                 qs = qs.filter(translation__translation__text__iregex=get_value,

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -847,8 +847,11 @@ class GlossListView(ListView):
 
             qs = qs.filter(query)
 
+        print(GlossSearchForm.keyword_search_field_prefix)
         # Evaluate all gloss/language search fields
         for get_key, get_value in get.items():
+            if get_value:
+                print('key, value: ', get_key, get_value)
             if get_key.startswith(GlossSearchForm.gloss_search_field_prefix) and get_value != '':
                 language_code_2char = get_key[len(GlossSearchForm.gloss_search_field_prefix):]
                 language = Language.objects.filter(language_code_2char=language_code_2char)
@@ -860,6 +863,7 @@ class GlossListView(ListView):
                 qs = qs.filter(lemma__lemmaidglosstranslation__text__iregex=get_value,
                                lemma__lemmaidglosstranslation__language=language)
             elif get_key.startswith(GlossSearchForm.keyword_search_field_prefix) and get_value != '':
+                print('search keyword')
                 language_code_2char = get_key[len(GlossSearchForm.keyword_search_field_prefix):]
                 language = Language.objects.filter(language_code_2char=language_code_2char)
                 qs = qs.filter(translation__translation__text__iregex=get_value,

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -292,7 +292,7 @@ class GlossSearchForm(forms.ModelForm):
     createdBy = forms.CharField(label=_(u'Created by'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
 
     gloss_search_field_prefix = "glosssearch_"
-    keyword_search_field_prefix = "keywords_"
+    keyword_search_field_prefix = "keyword_"
     lemma_search_field_prefix = "lemma_"
 
     class Meta:
@@ -847,7 +847,7 @@ class FocusGlossSearchForm(forms.ModelForm):
     createdBy = forms.CharField(label=_(u'Created by'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
 
     gloss_search_field_prefix = "glosssearch_"
-    keyword_search_field_prefix = "keywords_"
+    keyword_search_field_prefix = "keyword_"
     lemma_search_field_prefix = "lemma_"
 
     class Meta:

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -615,7 +615,7 @@ option:not(:checked) {
                 <th>
                     {% trans "Translation equivalents for" %} {{ lang }}
                 </th>
-                <td class='edit edit_text' id='keywords_{{ lang.language_code_2char }}' >{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td><td/>
+                <td class='edit edit_text' id='keyword_{{ lang.language_code_2char }}' >{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td><td/>
             </tr>
             {% endfor %}
 

--- a/signbank/dictionary/templates/dictionary/gloss_detail_preview.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail_preview.html
@@ -565,7 +565,7 @@ option:not(:checked) {
                 <th>
                     {% trans "Translation equivalents for" %} {{ lang }}
                 </th>
-                <td class='edit edit_text' id='keywords_{{ lang.language_code_2char }}' colspan="2">{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+                <td class='edit edit_text' id='keyword_{{ lang.language_code_2char }}' colspan="2">{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
             </tr>
             {% endfor %}
 

--- a/signbank/dictionary/templates/dictionary/morpheme_detail.html
+++ b/signbank/dictionary/templates/dictionary/morpheme_detail.html
@@ -473,7 +473,7 @@ function checkKey(e)
                 <th>
                     {% trans "Abstract meaning" %} ({{ lang }})
                 </th>
-                <td class='edit edit_text' id='keywords_{{ lang.language_code_2char }}'>{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+                <td class='edit edit_text' id='keyword_{{ lang.language_code_2char }}'>{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
             </tr>
             {% endfor %}
 

--- a/signbank/dictionary/tests.py
+++ b/signbank/dictionary/tests.py
@@ -80,7 +80,7 @@ class BasicCRUDTests(TestCase):
 
         # set up keyword search parameter for default language
         default_language = Language.objects.get(id=get_default_language_id())
-        keyword_search_field_prefix = "keywords_"
+        keyword_search_field_prefix = "keyword_"
         keyword_field_name = keyword_search_field_prefix + default_language.language_code_2char
 
         #We can even add and remove stuff to the keyword table
@@ -308,7 +308,7 @@ class BasicCRUDTests(TestCase):
             annotationIdgloss.save()
 
         # set up keyword search parameter for default language
-        keyword_search_field_prefix = "keywords_"
+        keyword_search_field_prefix = "keyword_"
         keyword_field_name = keyword_search_field_prefix + default_language.language_code_2char
 
         # keywords: this is merely part of the setup for the test

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -467,7 +467,7 @@ def update_keywords(gloss, field, value):
     # Determine the language of the keywords
     language = Language.objects.get(id=get_default_language_id())
     try:
-        language_code_2char = field[len('keywords_'):]
+        language_code_2char = field[len('keyword_'):]
         language = Language.objects.filter(language_code_2char=language_code_2char)[0]
     except:
         pass

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -1618,7 +1618,7 @@ def import_csv_update(request):
                 if languages:
                     language = languages[0]
                     language_code_2char = language.language_code_2char
-                    update_keywords(gloss, "keywords_" + language_code_2char, new_value)
+                    update_keywords(gloss, "keyword_" + language_code_2char, new_value)
                     gloss.save()
                 continue
 


### PR DESCRIPTION
This issue effectively renames a constant defined in forms to match the hard coded usages of it.
Also the reverse is done as both identifiers were being used.

keywords_  => keyword_

Because of the numerous usages, it was easier to modify things to match up with the "keyword_" identifier.