### PR TITLE
Issue #648: Extend Expiry facility added to User Profile.

### DIFF
--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -2562,27 +2562,37 @@ def upload_eaf_files(request):
         return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
 def update_expiry(request):
+
     # if something is wrong with the call, proceed to Signbank Welcome Page
     # This can happen if the user types in the url rather than getting there via the User Profile View
     # And the Extend Expiry button was not shown on their profile
+
+    # Check for request type
     if request.method != "POST":
         return HttpResponseRedirect(settings.URL + settings.PREFIX_URL + '/')
 
+    # Check if we have a username
     if 'username' in request.POST.keys():
         username = request.POST['username']
     else:
         username = ''
 
-    if username and request.user.username == username:
-        try:
-            user_profile = UserProfile.objects.get(user=request.user)
-        except ObjectDoesNotExist:
-            HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+    if not username or request.user.username != username:
+        HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
-        from dateutil.relativedelta import relativedelta
-        expiry = getattr(user_profile, 'expiry_date')
-        if expiry:
-            user_profile.expiry_date = expiry + relativedelta(months=+6)
-            user_profile.save()
+    # Check if user exists
+    try:
+        user_profile = UserProfile.objects.get(user=request.user)
+    except ObjectDoesNotExist:
+        HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
+    from dateutil.relativedelta import relativedelta
+    expiry = getattr(user_profile, 'expiry_date')
+
+    # Check if we have an expiry date
+    if not expiry:
+        return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+    user_profile.expiry_date = expiry + relativedelta(months=+6)
+    user_profile.save()
     return HttpResponseRedirect(request.META.get('HTTP_REFERER'))

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -2560,3 +2560,29 @@ def upload_eaf_files(request):
             messages.add_message(request, messages.INFO, _('Already imported to different folder: ')+message_string)
 
         return HttpResponseRedirect(reverse('admin_dataset_manager'))
+
+def update_expiry(request):
+    # if something is wrong with the call, proceed to Signbank Welcome Page
+    # This can happen if the user types in the url rather than getting there via the User Profile View
+    # And the Extend Expiry button was not shown on their profile
+    if request.method != "POST":
+        return HttpResponseRedirect(settings.URL + settings.PREFIX_URL + '/')
+
+    if 'username' in request.POST.keys():
+        username = request.POST['username']
+    else:
+        username = ''
+
+    if username and request.user.username == username:
+        try:
+            user_profile = UserProfile.objects.get(user=request.user)
+        except ObjectDoesNotExist:
+            HttpResponseRedirect(request.META.get('HTTP_REFERER'))
+
+        from dateutil.relativedelta import relativedelta
+        expiry = getattr(user_profile, 'expiry_date')
+        if expiry:
+            user_profile.expiry_date = expiry + relativedelta(months=+6)
+            user_profile.save()
+
+    return HttpResponseRedirect(request.META.get('HTTP_REFERER'))

--- a/signbank/registration/templates/user_profile.html
+++ b/signbank/registration/templates/user_profile.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<h2>User profile</h2>
+<h2>User Profile</h2>
 
 <table class="table">
     {% if user.is_anonymous %}
@@ -57,6 +57,20 @@
         </td>
         {% endif %}
     </tr>
+    {% if delta.days < 60 %}
+    <tr>
+    <form name='extend_account_expiry' id='extend_account_expiry' action="{{PREFIX_URL}}/update/expiry/" method='POST'>
+            <td>
+            {% csrf_token %}
+            <input type="hidden" name="username" id="username" value="{{user.username}}" />
+            </td>
+            <td/><td/>
+            <td>
+            <input class='btn btn-primary' id='extend_expiry' name='extend_expiry' type='submit' value='{% trans "Extend Expiry" %}'>
+            </td>
+    </form>
+    </tr>
+    {% endif %}
     {% endif %}
 </table>
 

--- a/signbank/urls.py
+++ b/signbank/urls.py
@@ -123,7 +123,7 @@ urlpatterns = [
     url(r'^update/metadata/', signbank.dictionary.update.upload_metadata, name='upload_metadata'),
     url(r'^update/dataset_eafs/', signbank.dictionary.update.upload_eaf_files, name='upload_eaf_files'),
     url(r'^update/remove_eaf_files/', signbank.dictionary.update.remove_eaf_files, name='remove_eaf_files'),
-                  url(r'^__debug__/', include(debug_toolbar.urls))
-
-] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+                  url(r'^__debug__/', include(debug_toolbar.urls)),
+    url(r'^update/expiry/', signbank.dictionary.update.update_expiry, name='update_expiry')
+              ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
This branch adds a button to user profile to extend the expiry date of their account.
The button is shown when there are less than 60 days remaining.
Pushing the button results in extending the expiry by 6 months.
This is done without need for the Admin.