### PR TITLE
Issue #703: Translations, Caps in Feedback pages.

### DIFF
--- a/conf/locale/nl/LC_MESSAGES/django.po
+++ b/conf/locale/nl/LC_MESSAGES/django.po
@@ -7,9 +7,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-08-17 15:20+0200\n"
+"POT-Creation-Date: 2022-06-01 11:35+0200\n"
 "PO-Revision-Date: 2018-03-08 18:54+0100\n"
-"Last-Translator: Richard <r.bankl@let.ru.nl>\n"
+"Last-Translator: susanodd\n"
 "Language-Team: Dutch <LL@li.org>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -18,807 +18,1411 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.5\n"
 
-#: signbank/dictionary/admin.py:57
+#: signbank/attachments/templates/list.html:33
+msgid "File attachments:"
+msgstr ""
+
+#: signbank/attachments/templates/list.html:36
+msgid "File link"
+msgstr ""
+
+#: signbank/attachments/templates/list.html:36 signbank/pages/admin.py:14
+#: signbank/pages/models.py:10
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2292
+msgid "URL"
+msgstr "URL"
+
+#: signbank/dictionary/admin.py:219
 msgid "number of senses"
 msgstr "aantal betekenissen"
 
-#: signbank/dictionary/admin.py:70
+#: signbank/dictionary/admin.py:232
 msgid "No Senses"
 msgstr "Geen betekenissen"
 
-#: signbank/dictionary/admin.py:71
+#: signbank/dictionary/admin.py:233
 msgid "More than one"
 msgstr "Meer dan een"
 
-#: signbank/dictionary/forms.py:23
-msgid "Glosses containing"
+#: signbank/dictionary/admin.py:419
+msgid "The semantic field name is required"
+msgstr ""
+
+#: signbank/dictionary/admin.py:502
+msgid "The derivation history name is required"
+msgstr ""
+
+#: signbank/dictionary/admin.py:677
+msgid "The field name category is required"
+msgstr ""
+
+#: signbank/dictionary/admin.py:682
+msgid "This field category does not exist"
+msgstr ""
+
+#: signbank/dictionary/admin.py:695 signbank/dictionary/admin.py:698
+msgid "This field choice already exists"
+msgstr ""
+
+#: signbank/dictionary/admin.py:1001 signbank/dictionary/admin.py:1029
+#: signbank/dictionary/templates/dictionary/import_csv.html:121
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:127
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:126
+msgid "Make changes"
+msgstr "Wijzig"
+
+#: signbank/dictionary/adminviews.py:530 signbank/dictionary/adminviews.py:4210
+#: signbank/dictionary/adminviews.py:4292
+#: signbank/dictionary/adminviews.py:4443
+#: signbank/dictionary/adminviews.py:4934
+#: signbank/dictionary/adminviews.py:5467
+#: signbank/dictionary/adminviews.py:5506
+#: signbank/dictionary/adminviews.py:5546
+#: signbank/dictionary/adminviews.py:6197
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:107
+#: signbank/frequency.py:1087
+msgid "Please login to use this functionality."
+msgstr "Log alsjeblieft in om deze functionaliteit te gebruiken."
+
+#: signbank/dictionary/adminviews.py:538 signbank/dictionary/adminviews.py:4218
+#: signbank/dictionary/adminviews.py:4300
+#: signbank/dictionary/adminviews.py:4484
+#: signbank/dictionary/adminviews.py:4956
+#: signbank/dictionary/adminviews.py:5475
+#: signbank/dictionary/adminviews.py:5514
+#: signbank/dictionary/adminviews.py:5554
+msgid "Dataset name must be non-empty."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:544 signbank/dictionary/adminviews.py:4962
+msgid "No dataset with that name found."
+msgstr "Geen dataset gevonden."
+
+#: signbank/dictionary/adminviews.py:554 signbank/dictionary/adminviews.py:4316
+msgid "No permission to export dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:561 signbank/dictionary/adminviews.py:4329
+msgid "ECV successfully updated."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:563
+msgid "No ECV created for dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:1135
+#: signbank/dictionary/adminviews.py:1701
+#: signbank/dictionary/adminviews.py:3517
+msgid "The requested gloss does not exist."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:1142
+#: signbank/dictionary/adminviews.py:1708
+#: signbank/dictionary/adminviews.py:3524
+msgid "Requested gloss has no lemma or dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:1159
+#: signbank/dictionary/adminviews.py:1725
+#: signbank/dictionary/adminviews.py:3541
+msgid "The gloss you are trying to view is not in your selected datasets."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:1169
+#: signbank/dictionary/adminviews.py:1735
+#: signbank/dictionary/adminviews.py:3551
+msgid "The gloss you are trying to view is not in a dataset you can view."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:2593
+msgid "Handshape not configured."
+msgstr "Handvorm niet geconfigureerd."
+
+#: signbank/dictionary/adminviews.py:2752
+msgid "SemanticField not configured for this machine value."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:2921
+msgid "DerivationHistory not configured for this machine value."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4224
+#: signbank/dictionary/adminviews.py:4490
+msgid "No dataset found with that name."
+msgstr "Geen dataset gevonden."
+
+#: signbank/dictionary/adminviews.py:4236
+msgid "You can already view this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4281
+msgid "No dataset manager was found. Your request could not be submitted."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4283
+msgid "Your request for view access to the dataset has been submitted."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4306
+msgid "No dataset found with that acronym."
+msgstr "Geen dataset gevonden."
+
+#: signbank/dictionary/adminviews.py:4322
+msgid "The dataset is empty, export ECV is not available."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4331
+msgid "No ECV created for the dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4452
+#: signbank/dictionary/adminviews.py:4808
+#: signbank/dictionary/adminviews.py:4943
+#: signbank/dictionary/adminviews.py:5116 signbank/dictionary/update.py:2157
+msgid "No group Dataset_Manager found."
+msgstr "Geen groep Dataset_Manager gevonden."
+
+#: signbank/dictionary/adminviews.py:4458
+#: signbank/dictionary/adminviews.py:4948
+msgid "You must be in group Dataset Manager to modify dataset permissions."
+msgstr "Je moet in groep Dataset Manager zijn om deze dataset te wijzigen."
+
+#: signbank/dictionary/adminviews.py:4468
+msgid "No permission to modify dataset permissions."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4505
+msgid ""
+"Username must be non-empty. Please make a selection using the drop-down list."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4511
+#: signbank/dictionary/adminviews.py:4976
+msgid "No user with that username found."
+msgstr "Geen gebruikers met username gevonden."
+
+#: signbank/dictionary/adminviews.py:4534
+msgid "The default language of {} is set to {}."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4538
+msgid "{} is not in the set of languages of dataset {}."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4542
+msgid "Something went wrong setting the default language for "
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4573
+msgid ""
+"User already has view permission for this dataset as staff or superuser."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4576
+msgid "User already has view permission for this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4582
+msgid "View permission for user successfully granted."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4611
+msgid "Error assigning view dataset permission to user."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4620
+msgid ""
+"User already has change permission for this dataset as staff or superuser."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4623
+msgid "User already has change permission for this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4628
+msgid ""
+"User does not have view permission for this dataset. Please grant view "
+"permission first."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4648
+msgid "Change permission for user successfully granted."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4650
+msgid "Error assigning change dataset permission to user."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4659
+msgid ""
+"User has view permission for this dataset as staff or superuser. This cannot "
+"be modified here."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4668
+msgid "View (and change) permission for user successfully revoked."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4671
+msgid "Error revoking view dataset permission for user."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4675
+msgid "User currently has no permission to view this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4684
+msgid ""
+"User has change permission for this dataset as staff or superuser. This "
+"cannot be modified here."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4700
+msgid "Change permission for user successfully revoked."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4703
+msgid "Error revoking change dataset permission for user."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4707
+msgid "User currently has no permission to change this dataset."
+msgstr "Gebruiker heeft geen rechten om de geselecteerde dataset te wijzigen."
+
+#: signbank/dictionary/adminviews.py:4711
+msgid "Unrecognised argument to dataset manager url."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4813
+#: signbank/dictionary/adminviews.py:5121
+msgid "You must be in group Dataset Manager to use the requested functionality."
+msgstr "Je moet in groep Dataset Manager zijn om deze functionaliteit te gebruiken."
+
+#: signbank/dictionary/adminviews.py:4859
+#: signbank/dictionary/adminviews.py:5315
+msgid "The requested dataset does not exist."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4970
+msgid "Username must be non-empty."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:4986
+msgid "User successfully made (co-)owner of this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5143
+#: signbank/dictionary/adminviews.py:5291
+msgid "Please login to use the requested functionality."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5287
+msgid "You must be superuser to use the requested functionality."
+msgstr "Je moet superuser zijn om deze functionaliteit te gebruiken."
+
+#: signbank/dictionary/adminviews.py:5329
+msgid "You do not have permission to view this corpus."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5336
+msgid "Please select the dataset first to view its corpus."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5409
+msgid "Modified"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5430
+msgid "Male"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5430
+msgid "Female"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5430
+msgid "Other"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5431
+msgid "Right"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5431
+msgid "Left"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5431
+msgid "Ambidextrous"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5431
+#: venv/lib/python3.6/site-packages/django/forms/widgets.py:699
+msgid "Unknown"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5481
+#: signbank/dictionary/adminviews.py:5520
+#: signbank/dictionary/adminviews.py:5560
+msgid "No dataset with that acronym found."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5489
+msgid "No permission to import speakers for this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5496
+#: signbank/dictionary/adminviews.py:5535
+#: signbank/dictionary/adminviews.py:5579
+msgid "Error processing participants meta data for this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5499
+msgid "Speakers successfully processed."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5528
+msgid "No permission to create a corpus for this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5539
+msgid "Corpus successfully created."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5568
+msgid "No permission to update the corpus for this dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5585
+msgid "Corpus successfully updated."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5709
+msgid "The requested morpheme does not exist."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5716
+msgid "Requested morpheme has no lemma or dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5733
+msgid "The morpheme you are trying to view is not in your selected datasets."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:5740
+msgid "The morpheme you are trying to view is not in a dataset you can view."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6325
+#: signbank/dictionary/adminviews.py:6346 signbank/dictionary/models.py:1677
+#: signbank/dictionary/models.py:1684 signbank/dictionary/models.py:1691
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:67
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:75
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:107
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:262
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:39
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:625
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1050
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1255
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1315
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1383
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:31
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:575
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1000
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1188
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1286
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1354
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:94
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:575
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:654
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:658
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:721
+#: signbank/dictionary/update.py:294 signbank/dictionary/update.py:298
+#: signbank/dictionary/update.py:304 signbank/dictionary/update.py:308
+#: signbank/dictionary/update.py:314 signbank/dictionary/update.py:318
+#: signbank/dictionary/update.py:386
+#: venv/lib/python3.6/site-packages/django/forms/widgets.py:700
+msgid "Yes"
+msgstr "Ja"
+
+#: signbank/dictionary/adminviews.py:6327
+#: signbank/dictionary/adminviews.py:6348 signbank/dictionary/models.py:1677
+#: signbank/dictionary/models.py:1684 signbank/dictionary/models.py:1691
+msgid "Neutral"
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6329
+#: signbank/dictionary/adminviews.py:6350 signbank/dictionary/models.py:1677
+#: signbank/dictionary/models.py:1684 signbank/dictionary/models.py:1691
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:69
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:77
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:109
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:263
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:40
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:625
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1050
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1255
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1315
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1383
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:32
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:575
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1000
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1188
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1286
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1354
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:95
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:575
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:654
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:658
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:721
+#: signbank/dictionary/update.py:300 signbank/dictionary/update.py:310
+#: signbank/dictionary/update.py:320
+#: venv/lib/python3.6/site-packages/django/forms/widgets.py:701
+msgid "No"
+msgstr "Nee"
+
+#: signbank/dictionary/adminviews.py:6761
+msgid "You have no permission to delete lemmas."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6766
+msgid "Incorrect deletion code."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6779
+msgid ""
+"You do not have change permission on the dataset of the lemma you are "
+"atteempting to delete."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6836
+#: signbank/dictionary/adminviews.py:7021
+msgid "Lemma ID Gloss is not unique for that language."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6870
+msgid "The specified gloss does not exist."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:6886
+msgid "Lemma ID Gloss not unique for language."
+msgstr "Lemma-ID-Glos is niet uniek."
+
+#: signbank/dictionary/adminviews.py:6899
+msgid "The form contains errors."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7050
+msgid "The changes to the lemma have been saved."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7057
+msgid "There must be at least one translation for this lemma."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7087
+msgid "The requested lemma does not exist."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7094
+msgid "Requested lemma has no dataset."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7108
+msgid "The lemma you are trying to view is not in your selected datasets."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7115
+msgid "The lemma you are trying to view is not in a dataset you can view."
+msgstr ""
+
+#: signbank/dictionary/adminviews.py:7132
+msgid "There are glosses using this lemma."
+msgstr ""
+
+#: signbank/dictionary/forms.py:49
+msgid "Glosses Containing"
 msgstr "Glossen met"
 
-#: signbank/dictionary/forms.py:24 signbank/dictionary/forms.py:99
-msgid "Translations containing"
+#: signbank/dictionary/forms.py:50 signbank/dictionary/forms.py:131
+msgid "Translations Containing"
 msgstr "Vertaling bevat"
 
-#: signbank/dictionary/forms.py:25
+#: signbank/dictionary/forms.py:51
 msgid "Search"
 msgstr "Zoeken"
 
-#: signbank/dictionary/forms.py:55 signbank/dictionary/forms.py:131
-#: signbank/dictionary/forms.py:375 signbank/dictionary/forms.py:476
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:328
+#: signbank/dictionary/forms.py:85 signbank/dictionary/forms.py:314
+#: signbank/dictionary/forms.py:419 signbank/dictionary/forms.py:869
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:546
 msgid "Gloss"
 msgstr "Glos"
 
-#: signbank/dictionary/forms.py:97
-msgid "Morphemes containing"
+#: signbank/dictionary/forms.py:129
+msgid "Morphemes Containing"
 msgstr "Morfemen met"
 
-#: signbank/dictionary/forms.py:208 signbank/dictionary/forms.py:394
+#: signbank/dictionary/forms.py:167 signbank/dictionary/forms.py:493
+#: signbank/dictionary/forms.py:505 signbank/dictionary/forms.py:519
+msgid "Morpheme"
+msgstr "Morfeem"
+
+#: signbank/dictionary/forms.py:243 signbank/dictionary/forms.py:354
+#: signbank/dictionary/forms.py:833
 msgid "Dutch Gloss"
 msgstr "Nederlandse glos"
 
-#: signbank/dictionary/forms.py:209 signbank/dictionary/forms.py:395
-#: signbank/dictionary/forms.py:606
+#: signbank/dictionary/forms.py:244 signbank/dictionary/forms.py:355
+#: signbank/dictionary/forms.py:608 signbank/dictionary/forms.py:686
+#: signbank/dictionary/forms.py:834
 msgid "Sort Order"
 msgstr "Volgorde"
 
-#: signbank/dictionary/forms.py:210 signbank/dictionary/forms.py:397
+#: signbank/dictionary/forms.py:245 signbank/dictionary/forms.py:356
+#: signbank/dictionary/forms.py:835
 msgid "English Gloss"
 msgstr "Engelse glos"
 
-#: signbank/dictionary/forms.py:211 signbank/dictionary/forms.py:398
-msgid "Lemma Gloss"
-msgstr "Lemma-ID-Glos"
-
-#: signbank/dictionary/forms.py:214 signbank/dictionary/forms.py:381
-#: signbank/dictionary/forms.py:401
+#: signbank/dictionary/forms.py:248 signbank/dictionary/forms.py:320
+#: signbank/dictionary/forms.py:360 signbank/dictionary/forms.py:425
+#: signbank/dictionary/forms.py:836 signbank/dictionary/forms.py:875
+#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:23
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:935
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:817
+#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:23
+#: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:45
+#: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:20
+#: signbank/dictionary/templates/dictionary/semanticfield_detail.html:45
 msgid "Translations"
 msgstr "Mogelijke vertalingen"
 
-#: signbank/dictionary/forms.py:215 signbank/dictionary/forms.py:402
+#: signbank/dictionary/forms.py:249 signbank/dictionary/forms.py:361
 msgid "Has Video"
 msgstr "Video beschikbaar"
 
-#: signbank/dictionary/forms.py:216 signbank/dictionary/forms.py:403
+#: signbank/dictionary/forms.py:250 signbank/dictionary/forms.py:362
 msgid "All Definitions Published"
 msgstr "Alle definities gepubliceerd"
 
-#: signbank/dictionary/forms.py:218 signbank/dictionary/forms.py:405
+#: signbank/dictionary/forms.py:252 signbank/dictionary/forms.py:364
 msgid "Search Definition/Notes"
 msgstr "Zoek Definitie/Aantekeningen"
 
-#: signbank/dictionary/forms.py:220 signbank/dictionary/forms.py:407
+#: signbank/dictionary/forms.py:254
 msgid "Search for gloss of related signs"
 msgstr "Zoek op glos van een verwant gebaar"
 
-#: signbank/dictionary/forms.py:221 signbank/dictionary/forms.py:409
+#: signbank/dictionary/forms.py:255
 msgid "Search for gloss of foreign signs"
 msgstr "Zoek op de glos in een andere gebarentaal"
 
-#: signbank/dictionary/forms.py:222 signbank/dictionary/forms.py:411
+#: signbank/dictionary/forms.py:256
 msgid "Search for gloss with this as morpheme"
 msgstr "Zoek voor een glos met dit morfeem"
 
-#: signbank/dictionary/forms.py:224 signbank/dictionary/models.py:442
-msgid "Abduction change"
+#: signbank/dictionary/forms.py:258 signbank/dictionary/forms.py:838
+msgid "Abduction Change"
 msgstr "Abductieverandering"
 
-#: signbank/dictionary/forms.py:225 signbank/dictionary/models.py:443
-msgid "Flexion change"
+#: signbank/dictionary/forms.py:259 signbank/dictionary/forms.py:839
+msgid "Flexion Change"
 msgstr "Flectieverandering"
 
-#: signbank/dictionary/forms.py:227 signbank/dictionary/forms.py:414
-msgid "Phonology other"
+#: signbank/dictionary/forms.py:261 signbank/dictionary/forms.py:373
+#: signbank/dictionary/models.py:658
+msgid "Phonology Other"
 msgstr "Fonologie: overig"
 
-#: signbank/dictionary/forms.py:229 signbank/dictionary/forms.py:416
+#: signbank/dictionary/forms.py:263 signbank/dictionary/forms.py:375
 msgid "Related to foreign sign or not"
 msgstr "Verwant aan gebaar uit andere taal of niet"
 
-#: signbank/dictionary/forms.py:230 signbank/dictionary/forms.py:419
-msgid "Type of relation"
+#: signbank/dictionary/forms.py:264
+msgid "Type of Relation"
 msgstr "Type relatie"
 
-#: signbank/dictionary/forms.py:232
-msgid "Has compound component type"
+#: signbank/dictionary/forms.py:266
+msgid "Has Compound Component Type"
 msgstr "Heeft samenstelling-deel van type"
 
-#: signbank/dictionary/forms.py:233 signbank/dictionary/forms.py:421
-msgid "Has morpheme type"
+#: signbank/dictionary/forms.py:268
+msgid "Has Morpheme Type"
 msgstr "Heeft morfeem-type"
 
-#: signbank/dictionary/forms.py:235 signbank/dictionary/forms.py:424
+#: signbank/dictionary/forms.py:271 signbank/dictionary/forms.py:381
+#: signbank/dictionary/forms.py:841
 msgid "Repeating Movement"
 msgstr "Herhaalde beweging"
 
-#: signbank/dictionary/forms.py:236 signbank/dictionary/forms.py:426
-#: signbank/dictionary/models.py:482
+#: signbank/dictionary/forms.py:272 signbank/dictionary/forms.py:383
+#: signbank/dictionary/forms.py:842 signbank/dictionary/models.py:643
 msgid "Alternating Movement"
 msgstr "Alternerende beweging"
 
-#: signbank/dictionary/forms.py:237 signbank/dictionary/models.py:409
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:833
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1097
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:681
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:540
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:47
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:126
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:181
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:236
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:291
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:346
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:401
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:456
-msgid "Handedness"
-msgstr "Handigheid"
+#: signbank/dictionary/forms.py:274 signbank/dictionary/models.py:528
+msgid "Weak Prop"
+msgstr "Weak Prop"
 
-#: signbank/dictionary/forms.py:241
-msgid "Weak prop"
-msgstr "Week prop"
+#: signbank/dictionary/forms.py:275 signbank/dictionary/models.py:527
+msgid "Weak Drop"
+msgstr "Week Drop"
 
-#: signbank/dictionary/forms.py:242
-msgid "Weak drop"
-msgstr "Weak drop"
-
-#: signbank/dictionary/forms.py:244 signbank/dictionary/models.py:413
-msgid "Strong Hand"
-msgstr "Sterke hand"
-
-#: signbank/dictionary/forms.py:248 signbank/dictionary/forms.py:254
+#: signbank/dictionary/forms.py:277 signbank/dictionary/forms.py:280
 msgid "letter"
 msgstr "letter"
 
-#: signbank/dictionary/forms.py:249 signbank/dictionary/forms.py:255
+#: signbank/dictionary/forms.py:278 signbank/dictionary/forms.py:281
 #: signbank/pages/models.py:41
 msgid "number"
 msgstr "nummer"
 
-#: signbank/dictionary/forms.py:250 signbank/dictionary/models.py:414
-msgid "Weak Hand"
-msgstr "Zwakke hand"
-
-#: signbank/dictionary/forms.py:257 signbank/dictionary/models.py:425
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:836
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1100
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:543
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:50
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:129
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:184
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:239
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:294
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:349
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:404
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:459
-msgid "Location"
-msgstr "Plaats"
-
-#: signbank/dictionary/forms.py:262 signbank/dictionary/models.py:469
-msgid "Relation between Articulators"
-msgstr "Relatie tussen articulatoren"
-
-#: signbank/dictionary/forms.py:267 signbank/dictionary/models.py:474
-msgid "Relative Orientation: Movement"
-msgstr "Relatieve oriëntatie: beweging"
-
-#: signbank/dictionary/forms.py:272 signbank/dictionary/models.py:475
-msgid "Relative Orientation: Location"
-msgstr "Relatieve oriëntatie: locatie"
-
-#: signbank/dictionary/forms.py:277 signbank/dictionary/models.py:479
-msgid "Handshape Change"
-msgstr "Handvormverandering"
-
-#: signbank/dictionary/forms.py:282 signbank/dictionary/models.py:477
-msgid "Orientation Change"
-msgstr "Oriëntatieverandering"
-
-#: signbank/dictionary/forms.py:287 signbank/dictionary/models.py:487
-msgid "Contact Type"
-msgstr "Type contact"
-
-#: signbank/dictionary/forms.py:292 signbank/dictionary/models.py:484
-msgid "Movement Shape"
-msgstr "Vorm van de beweging"
-
-#: signbank/dictionary/forms.py:297 signbank/dictionary/models.py:485
-msgid "Movement Direction"
-msgstr "Richting van de beweging"
-
-#: signbank/dictionary/forms.py:302 signbank/dictionary/models.py:508
-msgid "Named Entity"
-msgstr "Naam"
-
-#: signbank/dictionary/forms.py:307 signbank/dictionary/models.py:509
-msgid "Semantic Field"
-msgstr "Semantisch veld"
-
-#: signbank/dictionary/forms.py:312 signbank/dictionary/models.py:511
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:327
-msgid "Word class"
-msgstr "Woordsoort"
-
-#: signbank/dictionary/forms.py:317 signbank/dictionary/forms.py:429
+#: signbank/dictionary/forms.py:283 signbank/dictionary/forms.py:386
 msgid "Is a proposed new sign"
 msgstr "Voorstel voor nieuw gebaar"
 
-#: signbank/dictionary/forms.py:318 signbank/dictionary/forms.py:431
-msgid "Is in Web dictionary"
+#: signbank/dictionary/forms.py:284 signbank/dictionary/forms.py:388
+msgid "Is in Web Dictionary"
 msgstr "In woordenboek"
 
-#: signbank/dictionary/forms.py:319 signbank/dictionary/forms.py:433
-msgid "Note type"
+#: signbank/dictionary/forms.py:285 signbank/dictionary/forms.py:390
+msgid "Note Type"
 msgstr "Type aantekening"
 
-#: signbank/dictionary/forms.py:320 signbank/dictionary/forms.py:435
-msgid "Note contains"
+#: signbank/dictionary/forms.py:287 signbank/dictionary/forms.py:393
+msgid "Note Contains"
 msgstr "Aantekening bevat"
 
-#: signbank/dictionary/forms.py:322 signbank/dictionary/forms.py:437
-msgid "Created before"
+#: signbank/dictionary/forms.py:289 signbank/dictionary/forms.py:395
+#: signbank/dictionary/forms.py:844
+msgid "Created Before"
 msgstr "Toegevoegd vóór"
 
-#: signbank/dictionary/forms.py:322 signbank/dictionary/forms.py:323
+#: signbank/dictionary/forms.py:289 signbank/dictionary/forms.py:290
+#: signbank/dictionary/forms.py:844 signbank/dictionary/forms.py:845
 msgid "mm/dd/yyyy"
 msgstr ""
 
-#: signbank/dictionary/forms.py:323 signbank/dictionary/forms.py:438
-msgid "Created after"
+#: signbank/dictionary/forms.py:290 signbank/dictionary/forms.py:396
+#: signbank/dictionary/forms.py:845
+msgid "Created After"
 msgstr "Aangemaakt na"
 
-#: signbank/dictionary/forms.py:325 signbank/dictionary/forms.py:440
-msgid "Created by"
+#: signbank/dictionary/forms.py:292 signbank/dictionary/forms.py:398
+#: signbank/dictionary/forms.py:847
+msgid "Created By"
 msgstr "Toegevoegd door"
 
-#: signbank/dictionary/forms.py:482 signbank/dictionary/forms.py:524
-#: signbank/dictionary/forms.py:550
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1169
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1277
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:449
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:549
+#: signbank/dictionary/forms.py:326 signbank/dictionary/forms.py:685
+#: signbank/dictionary/forms.py:706 signbank/dictionary/forms.py:735
+#: signbank/dictionary/forms.py:779 signbank/dictionary/forms.py:881
+#: signbank/dictionary/templates/dictionary/add_gloss.html:108
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:120
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:844
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:697
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:706
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:552
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:502
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:432
+msgid "Lemma"
+msgstr ""
+
+#: signbank/dictionary/forms.py:330 signbank/dictionary/forms.py:429
+#: signbank/dictionary/forms.py:885
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:114
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:218
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:20
+msgid "Sign Language"
+msgstr "Gebarentaal"
+
+#: signbank/dictionary/forms.py:331 signbank/dictionary/forms.py:430
+#: signbank/dictionary/forms.py:886
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:509
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:461
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:486
+msgid "Dialect"
+msgstr "Dialect"
+
+#: signbank/dictionary/forms.py:357
+msgid "Lemma Gloss"
+msgstr "Lemma-ID-Glos"
+
+#: signbank/dictionary/forms.py:366
+msgid "Search for Gloss of Related Signs"
+msgstr "Zoek op glos van een verwant gebaar"
+
+#: signbank/dictionary/forms.py:368
+msgid "Search for Gloss of Foreign Signs"
+msgstr "Zoek op de glos in een andere gebarentaal"
+
+#: signbank/dictionary/forms.py:370
+msgid "Search for Gloss with This as Morpheme"
+msgstr "Zoek voor een glos met dit morfeem"
+
+#: signbank/dictionary/forms.py:378
+msgid "Type of relation"
+msgstr "Type relatie"
+
+#: signbank/dictionary/forms.py:450 signbank/dictionary/forms.py:492
+#: signbank/dictionary/forms.py:518 signbank/dictionary/models.py:162
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1342
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1444
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1313
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1415
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:681
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:777
 msgid "Type"
 msgstr "Type"
 
-#: signbank/dictionary/forms.py:491 signbank/dictionary/forms.py:502
-#: signbank/dictionary/forms.py:510
+#: signbank/dictionary/forms.py:459 signbank/dictionary/forms.py:470
+#: signbank/dictionary/forms.py:478
 msgid "Source Gloss"
 msgstr "Bron-glos"
 
-#: signbank/dictionary/forms.py:492 signbank/dictionary/forms.py:503
+#: signbank/dictionary/forms.py:460 signbank/dictionary/forms.py:471
 msgid "Target Gloss"
 msgstr "Doel-glos"
 
-#: signbank/dictionary/forms.py:511
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1015
+#: signbank/dictionary/forms.py:479
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1243
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1270
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1176
 msgid "Related Language"
 msgstr "Verwante taal"
 
-#: signbank/dictionary/forms.py:512
+#: signbank/dictionary/forms.py:480
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1244
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1271
 msgid "Gloss in Related Language"
 msgstr "Glos in een verwante taal"
 
-#: signbank/dictionary/forms.py:523 signbank/dictionary/forms.py:549
+#: signbank/dictionary/forms.py:491 signbank/dictionary/forms.py:517
 msgid "Parent Gloss"
 msgstr "Ouder-glos"
 
-#: signbank/dictionary/forms.py:525 signbank/dictionary/forms.py:537
-#: signbank/dictionary/forms.py:551
-msgid "Morpheme"
-msgstr "Morfeem"
-
-#: signbank/dictionary/forms.py:535 signbank/dictionary/forms.py:542
+#: signbank/dictionary/forms.py:503 signbank/dictionary/forms.py:510
 msgid "Host Gloss"
 msgstr "Ouder-glos"
 
-#: signbank/dictionary/forms.py:536
+#: signbank/dictionary/forms.py:504
 msgid "Meaning"
 msgstr "Betekenis"
 
-#: signbank/dictionary/forms.py:543
+#: signbank/dictionary/forms.py:511
 msgid "Role"
 msgstr "Rol"
 
-#: signbank/dictionary/forms.py:544 signbank/dictionary/models.py:403
+#: signbank/dictionary/forms.py:512 signbank/dictionary/models.py:518
 msgid "Blend"
 msgstr "Blend"
 
-#: signbank/dictionary/forms.py:605
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:415
+#: signbank/dictionary/forms.py:547 signbank/dictionary/update.py:1600
+msgid "Please choose a type description when uploading other media."
+msgstr ""
+
+#: signbank/dictionary/forms.py:554
+msgid "Please choose a video or image file to upload."
+msgstr ""
+
+#: signbank/dictionary/forms.py:607
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:422
 msgid "Handshape"
 msgstr "Handvorm"
 
-#: signbank/dictionary/forms.py:609
+#: signbank/dictionary/forms.py:611
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:212
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:424
 msgid "Finger Selection"
 msgstr "Vingerselectie"
 
-#: signbank/dictionary/forms.py:611
+#: signbank/dictionary/forms.py:613
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:425
 msgid "Finger Configuration"
 msgstr "Vingerconfiguratie"
 
-#: signbank/dictionary/forms.py:614 signbank/dictionary/models.py:223
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:427
+#: signbank/dictionary/forms.py:616 signbank/dictionary/models.py:267
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:428
 msgid "Quantity"
 msgstr "Aantal"
 
-#: signbank/dictionary/forms.py:618
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:429
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:192
-msgid "Unselected fingers extended"
+#: signbank/dictionary/forms.py:620
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:430
+msgid "Unselected Fingers Extended"
 msgstr "Gestrekte ongeselecteerde vingers"
 
-#: signbank/dictionary/forms.py:620 signbank/dictionary/models.py:230
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:430
+#: signbank/dictionary/forms.py:622 signbank/dictionary/models.py:287
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:431
 msgid "Spreading"
 msgstr "Spreiding"
 
-#: signbank/dictionary/forms.py:622 signbank/dictionary/models.py:228
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:431
+#: signbank/dictionary/forms.py:624 signbank/dictionary/models.py:282
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:432
 msgid "Aperture"
 msgstr "Opening"
 
-#: signbank/dictionary/models.py:219
+#: signbank/dictionary/forms.py:688
+msgid "Only show results without glosses"
+msgstr ""
+
+#: signbank/dictionary/forms.py:689
+msgid "Only show results with glosses"
+msgstr ""
+
+#: signbank/dictionary/models.py:205 signbank/dictionary/models.py:216
+#: signbank/dictionary/models.py:263
 msgid "Machine value"
 msgstr ""
 
-#: signbank/dictionary/models.py:220
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:421
+#: signbank/dictionary/models.py:264
 msgid "English name"
 msgstr "Engelse naam"
 
-#: signbank/dictionary/models.py:221
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:417
+#: signbank/dictionary/models.py:265
 msgid "Dutch name"
 msgstr "Nederlandse naam"
 
-#: signbank/dictionary/models.py:222
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:419
+#: signbank/dictionary/models.py:266
 msgid "Chinese name"
 msgstr "Chinese naam"
 
-#: signbank/dictionary/models.py:224
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:208
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:423
+#: signbank/dictionary/models.py:270
 msgid "Finger selection"
 msgstr "Vingerselectie"
 
-#: signbank/dictionary/models.py:225
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:425
+#: signbank/dictionary/models.py:273
 msgid "Finger selection 2"
 msgstr "Vingerselectie 2"
 
-#: signbank/dictionary/models.py:226
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:424
+#: signbank/dictionary/models.py:276
 msgid "Finger configuration"
 msgstr "Vingerconfiguratie"
 
-#: signbank/dictionary/models.py:227
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:426
+#: signbank/dictionary/models.py:279
 msgid "Finger configuration 2"
 msgstr "Vingerconfiguratie 2"
 
-#: signbank/dictionary/models.py:229
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:428
+#: signbank/dictionary/models.py:285
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:429
 msgid "Thumb"
 msgstr "Duim"
 
-#: signbank/dictionary/models.py:231
+#: signbank/dictionary/models.py:290
 msgid "Unselected fingers"
 msgstr "Ongeselecteerde vingers"
 
-#: signbank/dictionary/models.py:232
+#: signbank/dictionary/models.py:293
 msgid "T"
 msgstr "D"
 
-#: signbank/dictionary/models.py:233
+#: signbank/dictionary/models.py:294
 msgid "I"
 msgstr "W"
 
-#: signbank/dictionary/models.py:234
+#: signbank/dictionary/models.py:295
 msgid "M"
 msgstr "M"
 
-#: signbank/dictionary/models.py:235
+#: signbank/dictionary/models.py:296
 msgid "R"
 msgstr "R"
 
-#: signbank/dictionary/models.py:236
+#: signbank/dictionary/models.py:297
 msgid "P"
 msgstr "P"
 
-#: signbank/dictionary/models.py:237
+#: signbank/dictionary/models.py:298
 msgid "T2"
 msgstr "D2"
 
-#: signbank/dictionary/models.py:238
+#: signbank/dictionary/models.py:299
 msgid "I2"
 msgstr "W2"
 
-#: signbank/dictionary/models.py:239
+#: signbank/dictionary/models.py:300
 msgid "M2"
 msgstr "M2"
 
-#: signbank/dictionary/models.py:240
+#: signbank/dictionary/models.py:301
 msgid "R2"
 msgstr "R2"
 
-#: signbank/dictionary/models.py:241
+#: signbank/dictionary/models.py:302
 msgid "P2"
 msgstr "P2"
 
-#: signbank/dictionary/models.py:242
+#: signbank/dictionary/models.py:303
 msgid "Tu"
 msgstr "Du"
 
-#: signbank/dictionary/models.py:243
+#: signbank/dictionary/models.py:304
 msgid "Iu"
 msgstr "Wu"
 
-#: signbank/dictionary/models.py:244
+#: signbank/dictionary/models.py:305
 msgid "Mu"
 msgstr "Mu"
 
-#: signbank/dictionary/models.py:245
+#: signbank/dictionary/models.py:306
 msgid "Ru"
 msgstr "Ru"
 
-#: signbank/dictionary/models.py:246
+#: signbank/dictionary/models.py:307
 msgid "Pu"
 msgstr "Pu"
 
-#: signbank/dictionary/models.py:371
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:773
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:824
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1089
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:680
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1119
-#: signbank/dictionary/templates/dictionary/import_csv.html:83
-#: signbank/dictionary/templates/dictionary/import_csv.html:122
-#: signbank/dictionary/templates/dictionary/import_csv.html:151
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:283
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:13
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:123
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:178
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:233
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:288
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:343
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:398
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:453
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:505
-msgid "Dataset"
-msgstr "Dataset"
-
-#: signbank/dictionary/models.py:372
-msgid "Dataset a gloss is part of"
-msgstr "Dataset waar een glos in zit"
-
-#: signbank/dictionary/models.py:374
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:774
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:362
-#: signbank/dictionary/templates/dictionary/import_csv.html:123
-#: signbank/dictionary/templates/dictionary/import_csv.html:152
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:254
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:14
-msgid "Lemma ID Gloss"
-msgstr "Lemma-ID-Glos"
-
-#: signbank/dictionary/models.py:383
+#: signbank/dictionary/models.py:498
 msgid "BSL sign"
 msgstr "BSL-gebaar"
 
-#: signbank/dictionary/models.py:384
+#: signbank/dictionary/models.py:499
 msgid "ASL sign"
 msgstr "ASL-gebaar"
 
-#: signbank/dictionary/models.py:387
+#: signbank/dictionary/models.py:502
 msgid "ASL gloss"
 msgstr "ASL-glos"
 
-#: signbank/dictionary/models.py:388
+#: signbank/dictionary/models.py:503
 msgid "ASL loan sign"
 msgstr "Leengebaar uit ASL"
 
-#: signbank/dictionary/models.py:391
+#: signbank/dictionary/models.py:506
 msgid "BSL gloss"
 msgstr "BSL-glos"
 
-#: signbank/dictionary/models.py:392
+#: signbank/dictionary/models.py:507
 msgid "BSL loan sign"
 msgstr "Leengebaar uit BSL"
 
-#: signbank/dictionary/models.py:394
+#: signbank/dictionary/models.py:509
 msgid "Annotation instructions"
 msgstr "Annotatieinstructies"
 
-#: signbank/dictionary/models.py:395
+#: signbank/dictionary/models.py:510
 msgid "Remarks"
 msgstr "Opmerkingen"
 
-#: signbank/dictionary/models.py:402
+#: signbank/dictionary/models.py:517
 msgid "Blend of"
 msgstr "Blend van"
 
-#: signbank/dictionary/models.py:405
+#: signbank/dictionary/models.py:520
 msgid "Compound of"
 msgstr "Samenstelling van"
 
-#: signbank/dictionary/models.py:406
+#: signbank/dictionary/models.py:521
 msgid "Compound"
 msgstr "Samenstelling"
 
-#: signbank/dictionary/models.py:410
-msgid "Weak Drop"
-msgstr "Week Drop"
+#: signbank/dictionary/models.py:524
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:682
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:764
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:230
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:115
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:182
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:227
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:270
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:313
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:356
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:400
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:444
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:487
+msgid "Handedness"
+msgstr "Handigheid"
 
-#: signbank/dictionary/models.py:411
-msgid "Weak Prop"
-msgstr "Weak Prop"
+#: signbank/dictionary/models.py:530
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:683
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:116
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:183
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:228
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:271
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:314
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:357
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:401
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:445
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:488
+msgid "Strong Hand"
+msgstr "Sterke hand"
 
-#: signbank/dictionary/models.py:417
+#: signbank/dictionary/models.py:533
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:684
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:117
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:184
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:229
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:272
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:315
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:358
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:402
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:446
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:489
+msgid "Weak Hand"
+msgstr "Zwakke hand"
+
+#: signbank/dictionary/models.py:538
 msgid "Strong hand number"
 msgstr "Sterke hand cijfer"
 
-#: signbank/dictionary/models.py:418
+#: signbank/dictionary/models.py:539
 msgid "Strong hand letter"
 msgstr "Sterke hand letter"
 
-#: signbank/dictionary/models.py:419
+#: signbank/dictionary/models.py:540
 msgid "Weak hand number"
 msgstr "Zwakke hand cijfer"
 
-#: signbank/dictionary/models.py:420
+#: signbank/dictionary/models.py:541
 msgid "Weak hand letter"
 msgstr "Zwakke hand letter"
 
-#: signbank/dictionary/models.py:422
+#: signbank/dictionary/models.py:543
 msgid "Final Dominant Handshape"
 msgstr ""
 
-#: signbank/dictionary/models.py:423
+#: signbank/dictionary/models.py:546
 msgid "Final Subordinate Handshape"
 msgstr ""
 
-#: signbank/dictionary/models.py:426
+#: signbank/dictionary/models.py:550
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:765
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:229
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:118
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:185
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:230
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:273
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:316
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:359
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:403
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:447
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:490
+msgid "Location"
+msgstr "Plaats"
+
+#: signbank/dictionary/models.py:553
 msgid "Final Primary Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:427
+#: signbank/dictionary/models.py:556
 msgid "Virtual Object"
 msgstr "Virtueel object"
 
-#: signbank/dictionary/models.py:429
+#: signbank/dictionary/models.py:558
 msgid "Secondary Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:431
+#: signbank/dictionary/models.py:562
 msgid "Initial Subordinate Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:432
+#: signbank/dictionary/models.py:566
 msgid "Final Subordinate Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:434
+#: signbank/dictionary/models.py:570
 msgid "Initial Palm Orientation"
 msgstr ""
 
-#: signbank/dictionary/models.py:435
+#: signbank/dictionary/models.py:571
 msgid "Final Palm Orientation"
 msgstr ""
 
-#: signbank/dictionary/models.py:437
+#: signbank/dictionary/models.py:573
 msgid "Initial Interacting Dominant Hand Part"
 msgstr ""
 
-#: signbank/dictionary/models.py:438
+#: signbank/dictionary/models.py:575
 msgid "Final Interacting Dominant Hand Part"
 msgstr ""
 
-#: signbank/dictionary/models.py:445
+#: signbank/dictionary/models.py:585
+msgid "Abduction change"
+msgstr "Abductieverandering"
+
+#: signbank/dictionary/models.py:586
+msgid "Flexion change"
+msgstr "Flectieverandering"
+
+#: signbank/dictionary/models.py:588
 msgid "In the Web dictionary"
 msgstr "In het woordenboek"
 
-#: signbank/dictionary/models.py:446
+#: signbank/dictionary/models.py:589
 msgid "Is this a proposed new sign?"
 msgstr "Voorstel voor nieuw gebaar?"
 
-#: signbank/dictionary/models.py:447
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1137
+#: signbank/dictionary/models.py:590
 msgid "Exclude from ECV"
 msgstr "Buiten ECV houden"
 
-#: signbank/dictionary/models.py:451
+#: signbank/dictionary/models.py:594
 msgid "Morphemic Analysis"
 msgstr "Morfeemanalyse"
 
-#: signbank/dictionary/models.py:456
+#: signbank/dictionary/models.py:599
 msgid "Signed English definition available"
 msgstr ""
 
-#: signbank/dictionary/models.py:457
+#: signbank/dictionary/models.py:601
 msgid "Signed English gloss"
 msgstr ""
 
-#: signbank/dictionary/models.py:459
+#: signbank/dictionary/models.py:603
 msgid "Sense Number"
 msgstr ""
 
-#: signbank/dictionary/models.py:462
+#: signbank/dictionary/models.py:607
 msgid "Sign Number"
 msgstr "Gebaarnummer"
 
-#: signbank/dictionary/models.py:471
+#: signbank/dictionary/models.py:616
+msgid "Relation between Articulators"
+msgstr "Relatie tussen articulatoren"
+
+#: signbank/dictionary/models.py:620
 msgid "Absolute Orientation: Palm"
 msgstr "Absolute oriëntatie: palm"
 
-#: signbank/dictionary/models.py:472
+#: signbank/dictionary/models.py:623
 msgid "Absolute Orientation: Fingers"
 msgstr "Absolute oriëntatie: vingers"
 
-#: signbank/dictionary/models.py:481
+#: signbank/dictionary/models.py:627
+msgid "Relative Orientation: Movement"
+msgstr "Relatieve oriëntatie: beweging"
+
+#: signbank/dictionary/models.py:630
+msgid "Relative Orientation: Location"
+msgstr "Relatieve oriëntatie: locatie"
+
+#: signbank/dictionary/models.py:634
+msgid "Orientation Change"
+msgstr "Oriëntatieverandering"
+
+#: signbank/dictionary/models.py:638
+msgid "Handshape Change"
+msgstr "Handvormverandering"
+
+#: signbank/dictionary/models.py:642
 msgid "Repeated Movement"
 msgstr "Herhaalde beweging"
 
-#: signbank/dictionary/models.py:486
+#: signbank/dictionary/models.py:645
+msgid "Movement Shape"
+msgstr "Vorm van de beweging"
+
+#: signbank/dictionary/models.py:648
+msgid "Movement Direction"
+msgstr "Richting van de beweging"
+
+#: signbank/dictionary/models.py:651
 msgid "Movement Manner"
 msgstr "Manier van bewegen"
 
-#: signbank/dictionary/models.py:489
-msgid "Phonology Other"
-msgstr "Fonologie: overig"
+#: signbank/dictionary/models.py:654
+msgid "Contact Type"
+msgstr "Type contact"
 
-#: signbank/dictionary/models.py:491
+#: signbank/dictionary/models.py:660
 msgid "Mouth Gesture"
 msgstr "Orale component"
 
-#: signbank/dictionary/models.py:492
+#: signbank/dictionary/models.py:661
 msgid "Mouthing"
 msgstr "Gesproken component"
 
-#: signbank/dictionary/models.py:493
+#: signbank/dictionary/models.py:662
 msgid "Phonetic Variation"
 msgstr "Fonetische variatie"
 
-#: signbank/dictionary/models.py:495
+#: signbank/dictionary/models.py:664
 msgid "Placement Active Articulator LH"
 msgstr ""
 
-#: signbank/dictionary/models.py:496
+#: signbank/dictionary/models.py:667
 msgid "Placement Focal Site RH"
 msgstr ""
 
-#: signbank/dictionary/models.py:497
+#: signbank/dictionary/models.py:668
 msgid "Placement Focal site LH"
 msgstr ""
 
-#: signbank/dictionary/models.py:498
+#: signbank/dictionary/models.py:669
 msgid "Orientation RH (initial)"
 msgstr ""
 
-#: signbank/dictionary/models.py:499
+#: signbank/dictionary/models.py:670
 msgid "Orientation RH (final)"
 msgstr ""
 
-#: signbank/dictionary/models.py:500
+#: signbank/dictionary/models.py:671
 msgid "Orientation LH (initial)"
 msgstr ""
 
-#: signbank/dictionary/models.py:501
+#: signbank/dictionary/models.py:672
 msgid "Orientation LH (final)"
 msgstr ""
 
-#: signbank/dictionary/models.py:505
+#: signbank/dictionary/models.py:676
 msgid "Iconic Image"
 msgstr "Iconisch beeld"
 
-#: signbank/dictionary/models.py:506
+#: signbank/dictionary/models.py:677
 msgid "Type of iconicity"
 msgstr "Type iconiciteit"
 
-#: signbank/dictionary/models.py:512
+#: signbank/dictionary/models.py:681
+msgid "Named Entity"
+msgstr "Naam"
+
+#: signbank/dictionary/models.py:684
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1137
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:596
+msgid "Semantic Field"
+msgstr "Semantisch veld"
+
+#: signbank/dictionary/models.py:690
+msgid "Word class"
+msgstr "Woordsoort"
+
+#: signbank/dictionary/models.py:693
 msgid "Word class 2"
 msgstr "Woordsoort 2"
 
-#: signbank/dictionary/models.py:513
+#: signbank/dictionary/models.py:696
 msgid "Derivation history"
 msgstr "Derivatieachtergrond"
 
-#: signbank/dictionary/models.py:514
+#: signbank/dictionary/models.py:702
 msgid "Lexical category notes"
 msgstr "Opmerkingen over woordsoort"
 
-#: signbank/dictionary/models.py:515
+#: signbank/dictionary/models.py:703
 msgid "Valence"
 msgstr "Valence"
 
-#: signbank/dictionary/models.py:519
+#: signbank/dictionary/models.py:705
+msgid "Conception Concept Set"
+msgstr ""
+
+#: signbank/dictionary/models.py:709
 msgid "Number of Occurrences"
 msgstr "Aantal voorkomens"
 
-#: signbank/dictionary/models.py:520
+#: signbank/dictionary/models.py:710
 msgid "Number of Signers"
 msgstr "Aantal gebaarders"
 
-#: signbank/dictionary/models.py:521
+#: signbank/dictionary/models.py:711
 msgid "Number of Occurrences in Amsterdam"
 msgstr "Aantal voorkomens in Amsterdam"
 
-#: signbank/dictionary/models.py:522
+#: signbank/dictionary/models.py:712
 msgid "Number of Occurrences in Voorburg"
 msgstr "Aantal voorkomens in Voorburg"
 
-#: signbank/dictionary/models.py:523
+#: signbank/dictionary/models.py:713
 msgid "Number of Occurrences in Rotterdam"
 msgstr "Aantal voorkomens in Rotterdam"
 
-#: signbank/dictionary/models.py:524
+#: signbank/dictionary/models.py:714
 msgid "Number of Occurrences in Gestel"
 msgstr "Aantal voorkomens in Gestel"
 
-#: signbank/dictionary/models.py:525
+#: signbank/dictionary/models.py:715
 msgid "Number of Occurrences in Groningen"
 msgstr "Aantal voorkomens in Groningen"
 
-#: signbank/dictionary/models.py:526
+#: signbank/dictionary/models.py:716
 msgid "Number of Occurrences in Other Regions"
 msgstr "Aantal voorkomens in andere regio's"
 
-#: signbank/dictionary/models.py:528
+#: signbank/dictionary/models.py:718
 msgid "Number of Amsterdam Signers"
 msgstr "Aantal gebaarders uit Amsterdam"
 
-#: signbank/dictionary/models.py:529
+#: signbank/dictionary/models.py:719
 msgid "Number of Voorburg Signers"
 msgstr "Aantal gebaarders uit Voorburg"
 
-#: signbank/dictionary/models.py:530
+#: signbank/dictionary/models.py:720
 msgid "Number of Rotterdam Signers"
 msgstr "Aantal gebaarders uit Rotterdam"
 
-#: signbank/dictionary/models.py:531
+#: signbank/dictionary/models.py:721
 msgid "Number of Gestel Signers"
 msgstr "Aantal gebaarders uit Gestel"
 
-#: signbank/dictionary/models.py:532
+#: signbank/dictionary/models.py:722
 msgid "Number of Groningen Signers"
 msgstr "Aantal gebaarders uit Groningen"
 
-#: signbank/dictionary/models.py:533
+#: signbank/dictionary/models.py:723
 msgid "Number of Other Region Signers"
 msgstr "Aantal gebaarders uit andere regio's"
 
-#: signbank/dictionary/models.py:535
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:17
+#: signbank/dictionary/models.py:725
 msgid "Creation date"
 msgstr "Aanmaakdatum"
 
-#: signbank/dictionary/models.py:536
+#: signbank/dictionary/models.py:726
 msgid "Last updated"
 msgstr "Laatste update"
 
-#: signbank/dictionary/models.py:561 signbank/dictionary/models.py:1667
-#: signbank/dictionary/templates/dictionary/add_gloss.html:70
-#: signbank/dictionary/templates/dictionary/add_morpheme.html:82
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:776
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:827
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1093
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:678
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:487
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:535
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:370
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:983
-#: signbank/dictionary/templates/dictionary/import_csv.html:84
-#: signbank/dictionary/templates/dictionary/import_csv.html:126
-#: signbank/dictionary/templates/dictionary/import_csv.html:155
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:259
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:15
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:42
-#: signbank/dictionary/templates/dictionary/word.html:104
+#: signbank/dictionary/models.py:806 signbank/dictionary/models.py:2441
+#: signbank/dictionary/templates/dictionary/add_gloss.html:130
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:142
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:793
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:931
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:675
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:813
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:679
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:655
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:754
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:583
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:728
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1072
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1092
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1112
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1211
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:533
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:678
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1022
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1042
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1062
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1144
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1329
+#: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:14
+#: signbank/dictionary/templates/dictionary/import_csv.html:90
+#: signbank/dictionary/templates/dictionary/import_csv.html:134
+#: signbank/dictionary/templates/dictionary/import_csv.html:169
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:98
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:137
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:96
+#: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:6
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:464
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:22
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:110
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:178
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:223
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:266
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:309
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:352
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:396
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:440
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:483
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:534
+#: signbank/dictionary/templates/dictionary/update_lemma.html:79
+#: signbank/dictionary/templates/dictionary/word.html:109
 msgid "Annotation ID Gloss"
 msgstr "Annotatie-ID-Glos"
 
-#: signbank/dictionary/models.py:1581
+#: signbank/dictionary/models.py:1984
+msgid "Has morpheme type"
+msgstr "Heeft morfeem-type"
+
+#: signbank/dictionary/models.py:2191
 msgid "View dataset"
 msgstr "Toon dataset"
 
-#: signbank/dictionary/models.py:1653
+#: signbank/dictionary/models.py:2406
 msgid ""
 "Language code (2 characters long) of a written language. This also includes "
 "codes of the form zh-Hans, cf. IETF BCP 47"
@@ -826,178 +1430,365 @@ msgstr ""
 "Taalcode (2 karakters) van een geschreven taal. Dit omvat ook codes zoals zh-"
 "Hans, cf. IETF BCP 47"
 
-#: signbank/dictionary/models.py:1655
+#: signbank/dictionary/models.py:2408
 msgid "ISO 639-3 language code (3 characters long) of a written language."
 msgstr "ISO 639-3 taalcode (3 karakters) van een geschreven taal."
 
-#: signbank/dictionary/templates/dictionary/add_gloss.html:48
+#: signbank/dictionary/models.py:2488
+#: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:297
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:259
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:787
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:928
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:672
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:810
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:681
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:155
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:285
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:652
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:112
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:216
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1308
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1279
+#: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:31
+#: signbank/dictionary/templates/dictionary/import_csv.html:89
+#: signbank/dictionary/templates/dictionary/import_csv.html:128
+#: signbank/dictionary/templates/dictionary/import_csv.html:163
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:91
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:130
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:95
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:94
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:649
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:20
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:179
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:224
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:267
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:310
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:353
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:397
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:441
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:484
+#: signbank/dictionary/templates/dictionary/unused_videos.html:23
+#: signbank/dictionary/templates/dictionary/update_lemma.html:72
+msgid "Dataset"
+msgstr "Dataset"
+
+#: signbank/dictionary/models.py:2489
+msgid "Dataset a lemma is part of"
+msgstr "Dataset waar een lemma in zit"
+
+#: signbank/dictionary/models.py:2507
+msgid "Lemma ID Gloss translation"
+msgstr "Lemma-ID-Glos vertaling"
+
+#: signbank/dictionary/templates/dictionary/add_gloss.html:9
+msgid "Signbank: Add New Sign"
+msgstr "Signbank: Voeg nieuw gebaar toe"
+
+#: signbank/dictionary/templates/dictionary/add_gloss.html:69
+#: signbank/dictionary/templates/dictionary/add_lemma.html:51
 msgid "Please provide some initial data"
 msgstr "Geef hier wat data om mee te beginnen"
 
-#: signbank/dictionary/templates/dictionary/add_gloss.html:65
-#: signbank/dictionary/templates/dictionary/add_morpheme.html:77
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:842
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:862
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:882
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:122
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:177
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:232
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:287
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:342
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:397
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:452
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:504
-msgid "ID Gloss"
-msgstr "ID-Glos"
+#: signbank/dictionary/templates/dictionary/add_gloss.html:93
+#: signbank/dictionary/templates/dictionary/add_lemma.html:68
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:103
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:791
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:927
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:673
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:157
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:653
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:512
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:462
+#: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:17
+#: signbank/dictionary/templates/dictionary/import_csv.html:131
+#: signbank/dictionary/templates/dictionary/import_csv.html:166
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:95
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:134
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:416
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:21
+msgid "Lemma ID Gloss"
+msgstr "Lemma-ID-Glos"
 
-#: signbank/dictionary/templates/dictionary/add_gloss.html:79
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:766
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:798
+#: signbank/dictionary/templates/dictionary/add_gloss.html:111
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:847
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:709
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:528
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:442
+msgid "Create New"
+msgstr "Maak nieuw"
+
+#: signbank/dictionary/templates/dictionary/add_gloss.html:122
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:134
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:858
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:711
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:720
+msgid "Select"
+msgstr "Selecteer"
+
+#: signbank/dictionary/templates/dictionary/add_gloss.html:139
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:780
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:867
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:665
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:720
 msgid "Add New Sign"
 msgstr "Voeg nieuw gebaar toe"
 
-#: signbank/dictionary/templates/dictionary/add_morpheme.html:59
+#: signbank/dictionary/templates/dictionary/add_lemma.html:7
+msgid "Signbank: Create New Lemma"
+msgstr "Signbank: Voeg nieuw lemma toe"
+
+#: signbank/dictionary/templates/dictionary/add_lemma.html:77
+msgid "Add New Lemma"
+msgstr "Voeg nieuw lemma toe"
+
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:9
+msgid "Signbank: Add New Morpheme"
+msgstr "Signbank: Voeg nieuw morfeem toe"
+
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:78
 msgid "Please provide some initial data for this new morpheme"
 msgstr "Geef hier wat begininformatie over dit nieuwe morfeem"
 
-#: signbank/dictionary/templates/dictionary/add_morpheme.html:90
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:539
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:276
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:123
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:700
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:478
+msgid "Create new"
+msgstr "Maak een nieuwe"
+
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:150
 msgid "Morpheme type"
 msgstr "Morfeem-type"
 
-#: signbank/dictionary/templates/dictionary/add_morpheme.html:99
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:477
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:511
+#: signbank/dictionary/templates/dictionary/add_morpheme.html:159
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:645
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:730
 msgid "Add New Morpheme"
 msgstr "Voeg nieuw morfeem toe"
 
-#: signbank/dictionary/templates/dictionary/add_morpheme.html:102
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:519
-msgid "You are not authorized to add a morpheme"
-msgstr "Je hebt niet genoeg rechten om een morfeem toe te voegen"
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:8
+msgid "Configure Derivation History"
+msgstr "Derivatieachtergrond"
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:17
+msgid "Derivation History is not supported by your Signbank configuration."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:19
+msgid "You do not have permission to configure Derivation Histories."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:21
+msgid "Derivation History has already been configured."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:23
+msgid "No choices found for Derivation History in FieldChoice."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:25
+msgid ""
+"The following field choices have been set up for derivation histories. They "
+"can be modified in Admin."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:30
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:30
+msgid "Machine Value"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:31
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:31
+msgid "English Name"
+msgstr "Engelse naam"
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:32
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:32
+msgid "Dutch Name"
+msgstr "Nederlandse naam"
+
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:33
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:33
+msgid "Chinese Name"
+msgstr "Chinese naam"
+
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:8
+msgid "Configure Handshapes"
+msgstr "Configureer handvormen"
+
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:17
+msgid "Handshapes are not supported by your Signbank configuration."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:19
+msgid "You do not have permission to configure Handshapes."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:21
+msgid "Handshapes are already configured."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:23
+msgid "No choices found for Handshape in FieldChoice."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:25
+msgid ""
+"The following field choices have been set up for handshapes. They can be "
+"modified in Admin."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:9
+msgid "Signbank: Available Datasets"
+msgstr "Signbank: Beschikbare datasets"
 
 #: signbank/dictionary/templates/dictionary/admin_dataset_list.html:15
-msgid "View available datasets"
-msgstr "Toon beschikbare datasets"
+msgid "Available Datasets"
+msgstr "Beschikbare datasets"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:18
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:33
-#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:18
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:22
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:43
+msgid "Dataset Acronym"
+msgstr "Dataset-acroniem"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:23
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:66
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:44
 msgid "Dataset Name"
 msgstr "Dataset-naam"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:19
-msgid "View Dataset"
-msgstr "Toon dataset"
-
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:20
-msgid "Change Dataset"
-msgstr "Verander dataset"
-
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:21
-msgid "Number of signs or morphemes"
-msgstr "Aantal gebaren of morfemen"
-
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:22
-#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:19
-msgid "Selected"
-msgstr "Geselecteerd"
-
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:23
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:24
 msgid "Languages"
 msgstr "Talen"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:24
-msgid "Export dataset"
-msgstr "Exporteer dataset"
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:26
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:29
+msgid "Number of Signs or Morphemes"
+msgstr "Aantal gebaren of morfemen"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:27
+msgid "Number of Public Glosses"
+msgstr "Aantal openbare glossen"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:32
+msgid "View Dataset"
+msgstr "Toon dataset"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:33
+msgid "Change Dataset"
+msgstr "Verander dataset"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:34
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:134
+msgid "Request Access"
+msgstr "Toegang vragen"
 
 #: signbank/dictionary/templates/dictionary/admin_dataset_list.html:36
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:44
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:54
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:31
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:410
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:820
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:899
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:901
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1124
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1132
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1140
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1211
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:25
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:360
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:415
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:423
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:490
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:536
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:538
-#: signbank/dictionary/update.py:249 signbank/dictionary/update.py:253
-#: signbank/dictionary/update.py:260 signbank/dictionary/update.py:264
-#: signbank/dictionary/update.py:270 signbank/dictionary/update.py:274
-#: signbank/dictionary/update.py:326
-msgid "Yes"
-msgstr "Ja"
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:42
+msgid "Selected"
+msgstr "Geselecteerd"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:38
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:46
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:56
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:32
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:410
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:820
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:899
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:901
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1126
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1134
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1142
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1213
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:26
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:360
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:417
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:425
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:492
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:536
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:538
-#: signbank/dictionary/update.py:255 signbank/dictionary/update.py:266
-#: signbank/dictionary/update.py:276
-msgid "No"
-msgstr "Nee"
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:37
+msgid "Export Dataset"
+msgstr "Exporteer dataset"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:72
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:85
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:97
+msgid "Request View Access"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:93
+msgid "Motivation"
+msgstr "Motivatie"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:121
 msgid "ECV"
 msgstr "ECV"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:82
-#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:39
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:132
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:91
 msgid "No datasets found."
 msgstr "Geen datasets gevonden."
 
 #: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:15
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:19
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:22
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:21
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:29
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:27
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:24
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:29
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:22
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:93
 msgid "Saving..."
 msgstr "Opslaan..."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:30
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:52
+msgid "Signbank: Manage Datasets"
+msgstr "Signbank: Datasets beheren"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:56
 msgid "Manage Datasets"
 msgstr "Datasets beheren"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:34
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:61
+msgid "Exclude field choices for datasets"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:67
 msgid "Users who can View Dataset (Group permissions excluded)"
 msgstr "Gebruikers die dataset kunnen zien (Groepsrechten uitgesloten)"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:35
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:68
 msgid "Users who can Change Dataset (Group permissions excluded)"
 msgstr "Gebruikers die dataset kunnen wijzigen (Groepsrechten uitgesloten)"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:48
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:112
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:69
+msgid "Default Language"
+msgstr "Standaard taal"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:71
+msgid "Hyperlinks"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:74
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:122
+msgid "Metadata CSV"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:78
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:139
+msgid "Used in Dataset EAF files"
+msgstr "Gebruikt in dataset EAF bestanden"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:81
+msgid "Geographical region"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:84
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:145
+msgid "Age at time of recording"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:87
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:148
+msgid "Male (m), Female (f), Other (o)"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:90
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:151
+msgid "Right (r), Left (l), Ambidextrous (a), Unknown"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:94
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:168
+msgid "EAF Files"
+msgstr "EAF bestanden"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:107
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:171
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:265
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:294
 msgid "Manage"
 msgstr "Beheer"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:57
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:116
 #, python-format
 msgid ""
 "\n"
@@ -1006,30 +1797,30 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:70
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:134
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:129
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:193
 msgid "No users found."
 msgstr "Geen gebruikers gevonden."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:80
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:97
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:144
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:161
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:72
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:139
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:156
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:203
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:220
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:79
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:84
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:148
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:143
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:207
 msgid "Grant"
 msgstr "Verleen toegang"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:101
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:165
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:160
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:224
 msgid "Revoke"
 msgstr "Toegang intrekken"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:121
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:180
 #, python-format
 msgid ""
 "\n"
@@ -1038,721 +1829,1604 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:183
-msgid "Manage datasets"
-msgstr "Datasets beheren"
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:248
+msgid "Set"
+msgstr "Instellen"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:185
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:273
+msgid "No metadata CSV file found."
+msgstr "Geen metadata CSV-bestand gevonden."
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:282
+msgid "Update CSV"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:284
+msgid "Upload Metadata CSV"
+msgstr "Upload metadata CSV-bestand"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:288
+msgid "Upload CSV"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:305
+msgid "No EAF files found."
+msgstr "Geen EAF-bestanden gevonden."
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:313
+msgid "Upload EAF"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:316
+msgid "Folder"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:319
+msgid "Files"
+msgstr "Bestanden"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:322
+msgid "Upload EAF Files"
+msgstr "Upload EAF-bestanden"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:335
+#: signbank/dictionary/templates/dictionary/dataset_field_choices.html:111
 msgid "You must be in group Dataset Manager to use this functionality."
-msgstr "Je moet in groep Dataset Manager zijn om deze functionaliteit te gebruiken."
+msgstr ""
+"Je moet in groep Dataset Manager zijn om deze functionaliteit te gebruiken."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:15
-msgid "Select datasets"
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:8
+msgid "Signbank: Dataset Selection"
+msgstr "Signbank: Datasetselectie"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:31
+msgid "Select Datasets"
 msgstr "Selecteer datasets"
 
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:35
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:85
+msgid "Select All"
+msgstr "Alles selecteren"
+
 #: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:36
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:86
+msgid "Select None"
+msgstr "Niets selecteren"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:37
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:87
 msgid "Save selection"
 msgstr "Bewaar selectie"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:376
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:161
-msgid "Form your query"
-msgstr "Formuleer zoek-opdracht"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:381
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:178
-#: templates/global-templates/menu.html:87
-#: templates/global-templates/menu.html:113
-msgid "contains A"
-msgstr "bevat A"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:384
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:181
-#: templates/global-templates/menu.html:90
-#: templates/global-templates/menu.html:116
-msgid "starts with A"
-msgstr "begint met A"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:387
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:184
-#: templates/global-templates/menu.html:93
-#: templates/global-templates/menu.html:119
-msgid "ends with A"
-msgstr "eindigt op A"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:390
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:187
-#: templates/global-templates/menu.html:96
-#: templates/global-templates/menu.html:122
-msgid "A or B"
-msgstr "A of B"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:393
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:190
-#: templates/global-templates/menu.html:99
-#: templates/global-templates/menu.html:125
-msgid "find all strings in this field"
-msgstr "vind alle strings in dit veld"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:396
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:193
-#: templates/global-templates/menu.html:102
-#: templates/global-templates/menu.html:128
-msgid "use backslash to find <br/>special characters in field"
-msgstr "gebruik backslash om <br/>speciale karakters te zoeken"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:444
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:220
-msgid "Search by Language and Basic Properties"
-msgstr "Zoek op Taal en Basiseigenschappen"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:474
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:249
-msgid "Search by Morphology"
-msgstr "Zoek op Morfologie"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:485
-msgid "Morpheme Gloss"
-msgstr "Morfeem-Glos"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:500
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:267
-msgid "Search by Phonology"
-msgstr "Zoek op Fonologie"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:537
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:290
-msgid "Search by Semantics"
-msgstr "Zoek op Semantiek"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:562
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:315
-msgid "Search by Relation"
-msgstr "Zoek op Relaties"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:607
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:360
-msgid "Search by Publication Status and Notes"
-msgstr "Zoek op Publicatiestatus en Aantekeningen"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:694
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:701
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:712
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:440
-msgid "Search sign"
-msgstr "Zoek gebaar"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:696
-msgid "Search sign or morpheme"
-msgstr "Zoek gebaar of morfeem"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:702
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:437
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:441
-msgid "Search morpheme"
-msgstr "Zoek morfeem"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:704
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:442
-msgid "Sign or morpheme"
-msgstr "Gebaar of morfeem"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:725
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:393
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:453
-msgid "Reset"
-msgstr "Reset"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:729
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:457
-msgid "Results per page"
-msgstr "Hits per pagina"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:745
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:749
-msgid "List View"
-msgstr "Lijst"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:746
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:748
-msgid "Lemma View"
-msgstr "Lemmalijst"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:752
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:816
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:403
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:664
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:527
-msgid "Number of matches:"
-msgstr "Aantal hits:"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:752
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:816
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:403
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:664
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:527
-msgid "out of"
-msgstr "van"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:755
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:666
-msgid "Datasets:"
-msgstr "Datasets:"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:830
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1088
-msgid "Lemma ID gloss"
-msgstr "Lemma-ID-Glos"
-
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:46
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:125
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:180
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:235
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:290
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:345
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:400
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:455
-msgid "Translation equivalents"
-msgstr "Mogelijke vertalingen"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:555
-msgid "Translation equivalents for"
-msgstr "Mogelijke vertalingen in het"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:834
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1098
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:682
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:541
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:48
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:127
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:182
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:237
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:292
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:347
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:402
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:457
-msgid "Strong hand"
-msgstr "Sterke hand"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:835
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1099
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:683
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:542
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:49
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:128
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:183
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:238
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:293
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:348
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:403
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:458
-msgid "Weak hand"
-msgstr "Zwakke hand"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:837
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1101
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:544
-#: signbank/dictionary/templates/dictionary/morphemetags.html:5
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:51
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:130
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:185
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:240
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:295
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:350
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:405
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:460
-msgid "Tags"
-msgstr "Labels"
-
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1140
-msgid "morphemes"
-msgstr "morfemen"
-
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:17
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:19
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:38
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:26
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:214
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:25
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:116
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:21
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:149
-msgid "Edit"
-msgstr "Bewerk"
-
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:18
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:20
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:27
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:26
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:22
-msgid "Turn off edit mode"
-msgstr "Zet edit-stand uit"
-
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:173
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:174
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:184
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:185
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:195
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:196
-msgid "Handshape name"
-msgstr "Handvorm-naam"
-
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:374
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:381
-msgid "Search handshape"
-msgstr "Zoek handvorm"
-
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:376
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:383
-msgid "Search sign by handshape"
-msgstr "Zoek gebaar met handvorm"
-
-#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:19
-msgid "Focus Gloss"
-msgstr "Focus glos"
-
-#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:20
-msgid "Homonym Relations (SAVED)"
-msgstr "Homoniem-relaties (bewaard)"
-
-#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:21
-msgid "Homonym Relations (SAME PHONOLOGY)"
-msgstr "Homoniem-relateis (zelfde fonologie)"
-
-#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:51
-msgid "No homonyms found."
-msgstr "Geen homoniemen gevonden."
-
-#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:538
-msgid "Abstract Meaning"
-msgstr "Mogelijke vertalingen"
-
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:44
-msgid "Dataset name"
-msgstr "Dataset-naam"
-
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:45
-msgid "Acronym"
-msgstr "Acroniem"
-
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:47
-msgid "Accessible by others"
-msgstr "Toegankelijk voor anderen"
-
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:52
-msgid "Owner &amp; Contact person(s)"
-msgstr "Eigenaar &amp; contactperso(o)n(en)"
-
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:76
-msgid "Add Owner"
-msgstr "Eigenaar toevoegen"
-
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:85
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:87
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:45
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:100
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:102
+#: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:41
+#: signbank/dictionary/templates/dictionary/semanticfield_detail.html:41
 msgid "Description"
 msgstr "Omschrijving"
 
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:88
+#: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:46
+msgid "Copyright"
+msgstr "Auteursrechten"
+
+#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:9
+msgid "Signbank: Available Derivation Histories"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:15
+msgid "Available Derivation Histories"
+msgstr "Beschikbare derivatieachtergronden"
+
+#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:22
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:423
+#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:22
+msgid "Name"
+msgstr "Naam"
+
+#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:47
+msgid "No derivation histories found."
+msgstr "Geen derivatieachtergronden gevonden."
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:291
+msgid "Hide empty frequencies"
+msgstr "Verberg lege frequencies"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:293
+msgid "Sort by frequency"
+msgstr "Sorteer op frequentie"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:298
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1063
+#: signbank/dictionary/templates/dictionary/glosslist_table.html:7
+msgid "Field name"
+msgstr "Veldnaam"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:299
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:261
+msgid "Frequencies"
+msgstr "Frequenties"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:350
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:312
+msgid "No frequency data available."
+msgstr "Geen frequentie data beschikbaar"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:6
+msgid "Signbank: Frequency List"
+msgstr "Signbank: Frequentie-lijst"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:230
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:918
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:868
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:566
+msgid "Phonology"
+msgstr "Fonologie"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:240
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1126
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1076
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:590
+msgid "Semantics"
+msgstr "Semantiek"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:253
+msgid "Hide Empty Frequencies"
+msgstr "Verberg lege frequenties"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:255
+msgid "Sort by Frequency"
+msgstr "Sorteer op frequentie"
+
+#: signbank/dictionary/templates/dictionary/admin_frequency_list.html:260
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:288
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1113
+#: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:7
+msgid "Field Name"
+msgstr "Veldnaam"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:9
+msgid "Signbank: Search Signs"
+msgstr "Signbank: Zoek gebaren"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:414
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:165
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:32
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:331
+msgid "Form Your Query"
+msgstr "Formuleer zoek-opdracht"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:473
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:424
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:356
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:396
+msgid "Search by Language and Basic Properties"
+msgstr "Zoek op Taal en Basiseigenschappen"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:502
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:454
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:386
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:424
+msgid "Search by Morphology"
+msgstr "Zoek op Morfologie"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:512
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:465
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:397
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:749
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:756
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:819
+msgid "Morpheme Gloss"
+msgstr "Morfeem-Glos"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:527
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:480
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:412
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:438
+msgid "Search by Phonology"
+msgstr "Zoek op Fonologie"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:564
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:517
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:449
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:461
+msgid "Search by Semantics"
+msgstr "Zoek op Semantiek"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:589
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:542
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:474
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:486
+msgid "Search by Relation"
+msgstr "Zoek op Relaties"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:634
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:587
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:519
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:531
+msgid "Search by Publication Status and Notes"
+msgstr "Zoek op Publicatiestatus en Aantekeningen"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:721
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:728
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:738
+msgid "Search Sign"
+msgstr "Zoek gebaar"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:723
+msgid "Search Sign or Morpheme"
+msgstr "Zoek gebaar of morfeem"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:730
+msgid "Sign or Morpheme"
+msgstr "Gebaar of morfeem"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:751
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:672
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:636
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:397
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:114
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:276
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:622
+msgid "Reset"
+msgstr "Reset"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:759
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:763
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:644
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:648
+msgid "List View"
+msgstr "Lijst"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:760
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:762
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:645
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:647
+msgid "Lemma View"
+msgstr "Lemmalijst"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:766
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:409
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:665
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:120
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:746
+msgid "Number of Matches:"
+msgstr "Aantal hits:"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:766
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:678
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:651
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:409
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:665
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:120
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:746
+msgid "out of"
+msgstr "van"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:769
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:681
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:654
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:667
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:123
+msgid "Datasets:"
+msgstr "Datasets:"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:881
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:627
+msgid "Results Per Page"
+msgstr "Hits per pagina"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:890
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:701
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:743
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:165
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:636
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:304
+msgid "Refresh"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:947
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:829
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:766
+#: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:61
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:119
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:186
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:231
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:274
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:317
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:360
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:404
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:448
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:491
+msgid "Tags"
+msgstr "Labels"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:9
+msgid "Signbank: Search Signs (Preview Colors)"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:344
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:281
+msgid "Form your query"
+msgstr "Formuleer zoek-opdracht"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:351
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:286
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:39
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:336
+#: templates/global-templates/tooltip.html:10
+msgid "contains A"
+msgstr "bevat A"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:354
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:289
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:42
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:339
+#: templates/global-templates/tooltip.html:13
+msgid "starts with A"
+msgstr "begint met A"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:357
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:292
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:45
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:342
+#: templates/global-templates/tooltip.html:16
+msgid "ends with A"
+msgstr "eindigt op A"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:360
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:295
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:48
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:345
+#: templates/global-templates/tooltip.html:19
+msgid "A or B"
+msgstr "A of B"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:363
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:298
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:51
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:348
+#: templates/global-templates/tooltip.html:22
+msgid "find all strings in this field"
+msgstr "vind alle strings in dit veld"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:366
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:301
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:54
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:351
+#: templates/global-templates/tooltip.html:25
+msgid "use backslash to find <br/>special characters in field"
+msgstr "gebruik backslash om <br/>speciale karakters te zoeken"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:669
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:606
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:613
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:623
+msgid "Search sign"
+msgstr "Zoek gebaar"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:678
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:651
+msgid "Number of matches:"
+msgstr "Aantal hits:"
+
+#: signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html:692
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:734
+msgid "Results per page"
+msgstr "Hits per pagina"
+
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:608
+msgid "Search sign or morpheme"
+msgstr "Zoek gebaar of morfeem"
+
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:615
+msgid "Sign or morpheme"
+msgstr "Gebaar of morfeem"
+
+#: signbank/dictionary/templates/dictionary/admin_glosslist_list.html:809
+msgid "Lemma ID gloss"
+msgstr "Lemma-ID-Glos"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:6
+msgid "Signbank: Search Handshapes"
+msgstr "Signbank: Zoek handvormen"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:20
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:19
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:44
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:26
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:348
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:26
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:300
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:20
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:75
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:90
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:300
+msgid "Edit"
+msgstr "Bewerk"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:21
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:27
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:91
+msgid "Turn Off Edit Mode"
+msgstr "Zet edit-stand uit"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:177
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:178
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:188
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:189
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:199
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:200
+msgid "Handshape Name"
+msgstr "Handvorm-naam"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:378
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:385
+msgid "Search Handshape"
+msgstr "Zoek handvorm"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:380
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:387
+msgid "Search Sign by Handshape"
+msgstr "Zoek gebaar met handvorm"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:426
+msgid "Finger Selection 2"
+msgstr "Vingerselectie 2"
+
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:427
+msgid "Finger Configuration 2"
+msgstr "Vingerconfiguratie 2"
+
+#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:6
+msgid "Signbank: Homonym List"
+msgstr "Signbank: Lijst homoniemen"
+
+#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:62
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:286
+msgid "Focus Gloss"
+msgstr "Focus-glos"
+
+#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:63
+msgid "Homonym Relations (SAVED)"
+msgstr "Homoniem-relaties (bewaard)"
+
+#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:64
+msgid "Homonym Relations (SAME PHONOLOGY)"
+msgstr "Homoniem-relateis (zelfde fonologie)"
+
+#: signbank/dictionary/templates/dictionary/admin_homonyms_list.html:89
+msgid "No homonyms found."
+msgstr "Geen homoniemen gevonden."
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:8
+msgid "Signbank: Lemmas"
+msgstr "Signbank: Lemmata"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:111
+msgid "Search Lemma"
+msgstr "Zoek lemma"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:117
+msgid "Lemmas"
+msgstr "Lemmata"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:133
+msgid "Create New Lemma"
+msgstr "Voeg nieuw lemma toe"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:143
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:274
+msgid "Delete Lemmas with No Glosses"
+msgstr "Verwijder lemmata zonder glossen"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:159
+msgid "Number of Glosses"
+msgstr "Aantal gebaren"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:160
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:187
+#: signbank/dictionary/templates/dictionary/update_lemma.html:65
+msgid "Update"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:191
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:375
+#: signbank/feedback/templates/feedback/show.html:74
+#: signbank/feedback/templates/feedback/show.html:133
+#: signbank/feedback/templates/feedback/show.html:196
+#: venv/lib/python3.6/site-packages/django/forms/formsets.py:393
+msgid "Delete"
+msgstr "Verwijder"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:250
+msgid "Warning"
+msgstr "Waarschuwing"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:253
+msgid "Are you sure you want to delete this entry?"
+msgstr "Weet je zeker dat je dit wilt verwijderen?"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:277
+msgid ""
+"This action will delete all lemmas without glosses and all associated "
+"translations belonging to those lemmas. It cannot be undone."
+msgstr ""
+"Je verwijdert zo alle lemmata zonder glossen. Het kan niet ongedaan gemaakt worden."
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:278
+msgid "You have chosen to delete"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:278
+msgid "lemmas."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:285
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:442
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:372
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:560
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:574
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:692
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:784
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:865
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1371
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1470
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:324
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:510
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:524
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:642
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:734
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:815
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1342
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1441
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:441
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:456
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:506
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:709
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:803
+#: signbank/dictionary/templates/dictionary/update_video.html:78
+#: signbank/feedback/templates/feedback/show.html:92
+#: signbank/feedback/templates/feedback/show.html:151
+#: signbank/feedback/templates/feedback/show.html:215
+msgid "Cancel"
+msgstr "Annuleer"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:287
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:373
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:693
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:785
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:866
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1372
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1471
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:325
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:643
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:735
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:816
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1343
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1442
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:507
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:710
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:804
+#: signbank/feedback/templates/feedback/show.html:93
+#: signbank/feedback/templates/feedback/show.html:152
+#: signbank/feedback/templates/feedback/show.html:216
+msgid "Confirm Delete"
+msgstr "Bevestig verwijderen"
+
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:298
+msgid "No lemmas found."
+msgstr "Geen lemmata gevonden."
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:9
+msgid "Signbank: Minimal Pairs list"
+msgstr "Signbank: Lijst minimale paren"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:158
+msgid "Glosses Per Page"
+msgstr "Glossen per pagina"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:169
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1104
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1054
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:522
+msgid "Minimal Pairs"
+msgstr "Minimale paren"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:173
+msgid "Construct Filter"
+msgstr "Bouw filter"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:184
+msgid "Filter Focus Gloss by Annotation"
+msgstr "Filtreer focus-glos op annotatie"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:227
+msgid "Filter Focus Gloss by Phonology"
+msgstr "Filtreer focus-glos op fonologie"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:246
+msgid "Filter Focus Gloss by Semantics"
+msgstr "Filtreer focus-glos op semantiek"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:287
+msgid "Minimal Pair Gloss"
+msgstr "Andere glos"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:289
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1114
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1064
+#: signbank/dictionary/templates/dictionary/glosslist_table.html:8
+#: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:8
+msgid "Source Sign Value"
+msgstr "Dit gebaar"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:290
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1115
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1065
+#: signbank/dictionary/templates/dictionary/glosslist_table.html:9
+#: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:9
+msgid "Contrasting Sign Value"
+msgstr "Ander gebaar"
+
+#: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:301
+msgid "No minimal pairs found."
+msgstr "Geen minimale paren gevonden."
+
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:9
+msgid "Signbank: Search Morphemes"
+msgstr "Signbank: Zoek morfeem"
+
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:608
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:611
+msgid "Search Morpheme"
+msgstr "Zoek morfeem"
+
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:738
+msgid "You are not authorized to add a morpheme"
+msgstr "Je hebt niet genoeg rechten om een morfeem toe te voegen"
+
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:756
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:481
+msgid "Morpheme Type"
+msgstr "Morfeem-type"
+
+#: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:758
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:474
+msgid "Abstract Meaning"
+msgstr "Mogelijke vertalingen"
+
+#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:9
+msgid "Signbank: Available Semantic Fields"
+msgstr "Signbank: Beschikbare semantische velden"
+
+#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:15
+msgid "Available Semantic Fields"
+msgstr "Beschikbare semantische velden"
+
+#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:47
+msgid "No semantic fields found."
+msgstr "Geen semantische velden gevonden."
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:20
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:27
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:21
+msgid "Turn off edit mode"
+msgstr "Zet edit-stand uit"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:32
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:37
+msgid "Dataset Details"
+msgstr "Dataset detailbeeld"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:50
+msgid "Dataset name"
+msgstr "Dataset-naam"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:51
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:113
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:217
+msgid "Acronym"
+msgstr "Acroniem"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:54
+msgid "Accessible by others"
+msgstr "Toegankelijk voor anderen"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:59
+msgid "Owner &amp; Contact person(s)"
+msgstr "Eigenaar &amp; contactperso(o)n(en)"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:83
+msgid "Add Owner"
+msgstr "Eigenaar toevoegen"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:93
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:117
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1334
+msgid "Corpus"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:96
+msgid "Corpus Overview"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:104
 msgid "Sign language"
 msgstr "Gebarentaal"
 
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:89
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:105
 msgid "Translation languages"
 msgstr "Mogelijke vertaaltalen"
 
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:91
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:93
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:107
+msgid "Default language"
+msgstr "Standaard taal"
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:111
+msgid "Conditions for data citation and usage"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:113
 msgid "Conditions of use by others"
 msgstr "Gebruiksvoorwaarden door anderen"
 
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:94
-#: signbank/dictionary/templates/dictionary/dataset_detail.html:96
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:116
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:118
 msgid "Copyright statement"
 msgstr "Copyright verklaring"
 
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:120
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:122
+msgid "Reference"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_detail.html:129
+msgid "To view this dataset, please create an account or login."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:217
+msgid "Signbank: Manage Field Choice Colors"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:222
+msgid "Manage Field Choice Colors"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:226
+msgid "Here you can alter the display color of field choices."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:234
+#: signbank/dictionary/templates/dictionary/dataset_field_choices.html:71
+msgid "Field Choice Category"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:235
+msgid "Preview"
+msgstr "Voorvertoning"
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:236
+msgid "Field Choice"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:237
+msgid "Color"
+msgstr "Kleur"
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:311
+msgid "You must be a superuser to use this functionality."
+msgstr ""
+"Je moet superuser zijn om deze functionaliteit te gebruiken."
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choices.html:53
+msgid "Signbank: Manage Field Choices"
+msgstr "Signbank: Beheer Field Choices"
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choices.html:58
+msgid "Manage Field Choices"
+msgstr "Beheer Field Choices"
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choices.html:62
+msgid ""
+"Here you can exclude field choices for datasets you manage. Excluded field "
+"choices are checked."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_field_choices.html:71
+msgid "Field Choice [Frequency in Selected Managed Datasets]"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:98
+msgid "Signbank: Corpus Overview"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:103
+msgid "Dataset Corpus Overview"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:118
+msgid "There is no corpus for this dataset."
+msgstr "Er is geen corpus voor deze dataset."
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:130
+msgid "There is no metadata CSV file for this dataset."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:132
+msgid ""
+"A metadata file can be uploaded by the Dataset Manager via the Manage "
+"Datasets page."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:134
+msgid "The metadata CSV currently supports:"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:142
+msgid "Geographical Region"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:156
+msgid "The header row of the CSV file should be (using tab as separator):"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:175
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:464
+#: venv/lib/python3.6/site-packages/django/db/models/fields/files.py:229
+msgid "File"
+msgstr "Bestand"
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:182
+msgid "There are no EAF files for this dataset."
+msgstr "Er zijn geen EAF-bestanden voor deze dataset."
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:183
+msgid ""
+"EAF files can be uploaded by the Dataset Manager via the Manage Datasets "
+"page."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:197
+msgid "Create Corpus"
+msgstr "Maak een nieuwe corpus"
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:206
+msgid "Update Corpus"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:221
+msgid "Speakers in Metadata"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:226
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:258
+msgid "Identifier"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:227
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1419
+msgid "Gender"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:228
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1438
+msgid "Age"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:247
+msgid "No speakers imported."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:253
+msgid "Speakers in Documents"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:259
+msgid "Appears in Documents"
+msgstr "Komt voor in documenten"
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:273
+msgid ""
+"Speakers in metafile not found in documents. Update corpus, update metafile, "
+"or upload more documents."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:288
+msgid "Refresh Metadata"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:288
+msgid "Process Metadata"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:296
+msgid "Documents"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:301
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:370
+msgid "Document"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:302
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1295
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1266
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:635
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:24
+msgid "Creation Date"
+msgstr "Aanmaakdatum"
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:303
+msgid "Number of Annotations"
+msgstr "Aantal annotaties"
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:305
+msgid "Comment"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:337
+msgid "No documents found."
+msgstr "Geen documenten gevonden."
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:345
+msgid ""
+"\n"
+"            <p style=\"color:red;\">Some eaf files have been uploaded to "
+"more than one location.\n"
+"                Please identify the unwanted copies in the list below.</p>\n"
+"            "
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:364
+msgid "Overview EAF Files"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:371
+msgid "Path"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:428
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:434
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:443
+msgid "Remove EAF Files"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:437
+msgid "Please make sure to leave one copy of the documents you want."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:438
+msgid ""
+"If all copies of a file are removed, the associated document and its "
+"frequency data will be removed."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:457
+msgid "Unprocessed EAF Files"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:481
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:487
+msgid "Refresh All Documents"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:490
+msgid ""
+"Depending on how many files and annotations you have, this could take some "
+"time."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:491
+msgid ""
+"Once your corpus has been created, its files are refreshed in a cron job "
+"during the night."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:501
+msgid "Cron Job"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:502
+msgid "Refresh Now"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:7
+msgid "Signbank: Derivation History Details"
+msgstr "Signbank: Detailbeeld derivatieachtergrond"
+
+#: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:22
+msgid "Derivation History Detail View"
+msgstr "Detailbeeld derivatieachtergrond"
+
+#: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:29
+msgid "Derivation Histories List"
+msgstr "Lijst Derivatieachtergronden"
+
+#: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:39
+msgid "Derivation History "
+msgstr "Derivatieachtergrond"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:8
+#: signbank/dictionary/templates/dictionary/word.html:14
+#, python-format
+msgid "Sign for %(gloss)s"
+msgstr "Gebaar voor %(gloss)s"
+
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:28
-msgid "Delete this gloss"
+msgid "Delete This Gloss"
 msgstr "Verwijder deze glos"
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:30
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:29
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:30
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:96
 msgid "This idgloss already exists"
 msgstr "Deze idgloss bestaat al"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:184
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:124
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:311
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:263
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:40
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:273
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:68
+#, python-format
 msgid "\"Sign %(glossposn)s of %(glosscount)s in the dictionary\" "
 msgstr "\"Gebaar %(glossposn)s van %(glosscount)s in het lexicon\" "
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:188
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:128
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:315
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:267
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:44
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:277
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:72
 msgid "Next Sign &raquo;"
 msgstr "Volgende gebaar&raquo;"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:195
-msgid "Relations View"
-msgstr "Relaties"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:197
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:135
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:30
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:322
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:274
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1299
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:51
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:285
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:79
+#: signbank/dictionary/templates/dictionary/word.html:77
 msgid "Public View"
 msgstr "Publieke Versie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:201
-msgid "Delete Sign"
-msgstr "Verwijder gebaar"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:325
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:277
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1302
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:54
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:288
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:82
+#: signbank/dictionary/templates/dictionary/word.html:80
+msgid "Detail View"
+msgstr "Detailbeeld"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:212
-msgid "Edit next gloss"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:328
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:280
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1305
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:57
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:85
+#: signbank/dictionary/templates/dictionary/word.html:84
+msgid "Relations View"
+msgstr "Relaties"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:332
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:284
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1309
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:61
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:89
+#: signbank/dictionary/templates/dictionary/word.html:88
+msgid "Frequency View"
+msgstr "Detailbeeld frequentie"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:336
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:288
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1313
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:65
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:93
+#: signbank/dictionary/templates/dictionary/word.html:92
+msgid "Revision History"
+msgstr "Revisie-achtergrond"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:346
+msgid "Edit Next Gloss"
 msgstr "Bewerk volgende glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:228
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:362
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:314
 msgid "Delete This Sign"
 msgstr "Verwijder dit gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:231
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:365
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:317
 msgid ""
 "This action will delete this sign and all associated records. It cannot be "
 "undone."
 msgstr ""
 "Je verwijdert zo deze aantekening. Het kan niet ongedaan gemaakt worden."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:238
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:477
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:569
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:650
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1198
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1303
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:301
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:477
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:573
-#: signbank/dictionary/templates/dictionary/update_video.html:78
-#: signbank/feedback/templates/feedback/show.html:99
-#: signbank/feedback/templates/feedback/show.html:159
-#: signbank/feedback/templates/feedback/show.html:223
-msgid "Cancel"
-msgstr "Annuleer"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:239
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:478
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:570
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:651
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1199
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1304
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:302
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:478
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:574
-#: signbank/feedback/templates/feedback/show.html:100
-#: signbank/feedback/templates/feedback/show.html:160
-#: signbank/feedback/templates/feedback/show.html:224
-msgid "Confirm Delete"
-msgstr "Bevestig verwijderen"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:278
-msgid "Provide feedback about this sign"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:412
+msgid "Provide Feedback About This Sign"
 msgstr "Geef feedback over dit gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:286
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:192
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:420
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:372
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:344
 msgid "Upload New Video"
 msgstr "Nieuwe video uploaden"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:288
-#, python-format
-msgid " We have %(gloss_video_count)s videos for this sign. "
-msgstr " We hebben %(gloss_video_count)s video's voor dit gebaar"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:312
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:228
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:444
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:396
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:380
 msgid "Upload New Citation Form Image"
 msgstr "Upload een nieuwe foto"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:335
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:465
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:417
+msgid "Create Citation Form Image from Current Video"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:475
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:427
 msgid "Delete Media"
 msgstr "Verwijder media"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:361
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:281
-msgid "Dialect"
-msgstr "Dialect"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:493
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:494
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:445
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:446
+msgid "Delete Sign"
+msgstr "Verwijder gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:436
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:516
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:419
+msgid "Show Lemma Group"
+msgstr "Toon lemma-groep"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:524
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:537
+msgid "Edit Lemma"
+msgstr "Bewerk lemma"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:526
+msgid "Choose Other"
+msgstr "Kies andere"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:559
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:440
+msgid "Set Lemma"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:573
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:455
+msgid "Add Lemma"
+msgstr "Voeg lemma toe"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:616
+msgid "Translation Equivalents for"
+msgstr "Mogelijke vertalingen in het"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:651
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:601
 msgid "Morphology"
 msgstr "Morfologie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:445
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:660
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:610
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:535
 msgid "Sequential Morphology"
 msgstr "Sequentiële morfologie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:450
-msgid "Compound part"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:665
+msgid "Compound Part"
 msgstr "Samenstelling-deel"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:451
-msgid "Component sign"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:666
+msgid "Component Sign"
 msgstr "Deelgebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:466
-msgid "Delete This Compound part"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:681
+msgid "Delete This Compound Part"
 msgstr "Verwijder dit deel van de samenstelling"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:470
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:562
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:643
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1296
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:566
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:685
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:777
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:858
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1463
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:635
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:727
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:808
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1434
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:796
 msgid "Are you sure you want to delete this? This cannot be undone."
 msgstr ""
 "Weet je zeker dat je dit wilt verwijderen? Het kan niet ongedaan gemaakt "
 "worden."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:495
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:710
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:660
 msgid "If this is a compound, use [Edit] to define its components"
 msgstr ""
 "Als dit een compound is, kun je de delen specificeren door op [Bewerk] te "
 "klikken"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:513
-msgid "Annotation ID gloss"
-msgstr "Annotatie-ID-Glos"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:516
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:731
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:681
 msgid "Add Component"
 msgstr "Voeg deel toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:524
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:739
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:689
 msgid "Simultaneous Morphology"
 msgstr "Simultane morfologie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:529
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:744
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:694
 msgid "There are no morphemes in the dataset of this gloss."
 msgstr "Er zitten geen morfemen in de dataset voor deze glos."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:534
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:541
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:604
-msgid "Morpheme gloss"
-msgstr "Morfeem-glos"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:535
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:542
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:607
-msgid "Meaning in this sign"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:750
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:757
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:822
+msgid "Meaning in This Sign"
 msgstr "Betekenis in dit gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:558
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:291
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:773
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:723
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:92
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:496
 msgid "Delete This Morpheme"
 msgstr "Verwijder dit morfeem"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:608
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:823
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:773
 msgid "Add Morpheme"
 msgstr "Voeg morfeem toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:619
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:834
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:784
 msgid "Blend Morphology"
 msgstr "Blend-morfologie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:623
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:683
-msgid "Blend gloss"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:838
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:898
+msgid "Blend Gloss"
 msgstr "Blend-glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:624
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:686
-msgid "Role in this sign"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:839
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:901
+msgid "Role in This Sign"
 msgstr "Rol in dit gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:639
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:854
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:804
 msgid "Delete This Blend"
 msgstr "Verwijder deze blend"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:687
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:902
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:852
 msgid "Add Blend"
 msgstr "Blend toevoegen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:703
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:354
-msgid "Phonology"
-msgstr "Fonologie"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:836
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1066
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1016
 msgid "Identical phonology but not marked as homonym"
 msgstr "Identieke fonologie maar niet gemarkeerd als homoniem"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:856
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1086
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1036
 msgid "Marked as homonym but different phonology"
 msgstr "Gemarkeerd als homoniem maar verschillende fonologie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:874
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:502
-msgid "Minimal Pairs"
-msgstr "Minimale paren"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1144
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:603
+msgid "Derivation History"
+msgstr "Derivatieachtergrond"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:883
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:507
-msgid "Field name"
-msgstr "Veldnaam"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:884
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:508
-msgid "Source Sign Value"
-msgstr "Dit gebaar"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:885
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:509
-msgid "Contrasting Sign Value"
-msgstr "Ander gebaar"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:921
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:371
-msgid "Semantics"
-msgstr "Semantiek"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:944
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1172
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1105
 msgid "Relations to Other Signs"
 msgstr "Relaties met andere gebaren"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1002
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1230
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1163
 msgid "Relations to Foreign Signs"
 msgstr "Relaties met gebaren uit andere talen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1014
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1242
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1175
 msgid "Loan"
 msgstr "Leenwoord"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1016
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1042
-msgid "Gloss in related language"
-msgstr "Glos in een verwante taal"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1041
-msgid "Related language"
-msgstr "Verwante taal"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1043
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1272
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1205
 msgid "Add Relation to Foreign Sign"
 msgstr "Voeg relatie toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1059
-msgid "Frequency"
-msgstr "Frequentie"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1098
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:391
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1289
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1260
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:627
 msgid "Publication Status"
 msgstr "Publicatiestatus"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1106
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:399
-msgid "Creation Date"
-msgstr "Aanmaakdatum"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1107
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:400
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:16
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1296
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1267
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:636
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:23
 msgid "Creator"
 msgstr "Toegevoegd door"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1121
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:412
-msgid "In Web Dictionary"
-msgstr "In woordenboek"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1129
-msgid "Proposed New Sign"
-msgstr "Voorstel voor nieuw gebaar"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1154
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:437
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1327
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1298
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:669
 msgid "Notes"
 msgstr "Aantekeningen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1167
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:447
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1340
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1311
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:679
 msgid "Published"
 msgstr "Gepubliceerd"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1168
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:448
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1341
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1312
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:680
 msgid "Index"
 msgstr "Index"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1170
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:450
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1343
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1314
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:682
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2133
 msgid "Text"
 msgstr "Tekst"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1187
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:466
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1360
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1331
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:698
 msgid "Delete This Note"
 msgstr "Verwijder deze aantekening"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1191
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:470
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1364
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1335
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:702
 msgid "This action will delete this note. It cannot be undone."
 msgstr ""
 "Je verwijdert zo deze aantekening. Het kan niet ongedaan gemaakt worden."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1196
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:475
-msgid "confirmed"
-msgstr "bevestigd"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1238
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:516
-msgid "Enter new note"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1405
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:743
+msgid "Enter New Note"
 msgstr "Vul nieuwe aantekening in"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1245
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:523
-msgid "Save new note"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1412
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:750
+msgid "Save New Note"
 msgstr "Bewaar nieuwe aantekening"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1262
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:540
-msgid "Other media"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1429
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:767
+msgid "Other Media"
 msgstr "Andere media"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1275
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:548
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1442
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1413
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:775
 msgid "Image/Video"
 msgstr "Afbeelding/video"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1276
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1443
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1414
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:776
 msgid "File Type"
 msgstr "Bestandstype"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1278
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1337
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:550
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:603
-msgid "Alternative gloss"
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1445
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1508
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:778
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:840
+msgid "Alternative Gloss"
 msgstr "Alternatieve glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1292
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:562
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1459
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1430
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:792
 msgid "Delete This Media"
 msgstr "Verwijder dit bestand"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1335
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:601
-msgid "Upload media"
-msgstr "Upload media"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1342
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:608
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1513
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1484
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:845
 msgid "Save"
 msgstr "Bewaar"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:8
+#, python-format
+msgid "Sign for %(gloss)s (Preview Colors)"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:28
+msgid "Delete this gloss"
+msgstr "Verwijder deze glos"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:298
+msgid "Edit next gloss"
+msgstr "Bewerk volgende glos"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:364
+msgid "Provide feedback about this sign"
+msgstr "Geef feedback over dit gebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:466
+msgid "Show lemma group"
+msgstr "Toon lemma-groep"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:474
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:487
+msgid "Edit lemma"
+msgstr "Bewerk lemma"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:476
+msgid "Choose other"
+msgstr "Kies andere"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:509
+msgid "Set lemma"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:523
+msgid "Add lemma"
+msgstr "Lemma toevoegen"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:566
+msgid "Translation equivalents for"
+msgstr "Mogelijke vertalingen in het"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:615
+msgid "Compound part"
+msgstr "Samenstelling-deel"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:616
+msgid "Component sign"
+msgstr "Deelgebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:631
+msgid "Delete This Compound part"
+msgstr "Verwijder dit deel van de samenstelling"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:699
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:706
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:769
+msgid "Morpheme gloss"
+msgstr "Morfeem-glos"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:700
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:707
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:772
+msgid "Meaning in this sign"
+msgstr "Betekenis in dit gebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:788
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:848
+msgid "Blend gloss"
+msgstr "Blend-glos"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:789
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:851
+msgid "Role in this sign"
+msgstr "Rol in dit gebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1177
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1204
+msgid "Gloss in related language"
+msgstr "Glos in een verwante taal"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1203
+msgid "Related language"
+msgstr "Verwante taal"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1221
+msgid "Frequency"
+msgstr "Frequentie"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1340
+msgid "confirmed"
+msgstr "bevestigd"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1376
+msgid "Enter new note"
+msgstr "Vul nieuwe aantekening in"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1383
+msgid "Save new note"
+msgstr "Bewaar nieuwe aantekening"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1400
+msgid "Other media"
+msgstr "Andere media"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1416
+#: signbank/dictionary/templates/dictionary/gloss_detail_preview.html:1479
+msgid "Alternative gloss"
+msgstr "Alternatieve glos"
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:6
+msgid "Signbank: Gloss Frequency"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1322
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:106
+msgid "Source Sign"
+msgstr "Bron-gebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1344
+msgid "Gloss Regions"
+msgstr "Regio's van glos"
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1355
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1407
+msgid "Speakers"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1363
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1415
+msgid "Raw View"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1382
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:481
+msgid "Variants"
+msgstr "Varianten"
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1390
+msgid "Age Distribution"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1460
+msgid "There is no frequency data available for this gloss in dataset"
+msgstr ""
 
 #: signbank/dictionary/templates/dictionary/gloss_list.html:43
 #: signbank/dictionary/templates/dictionary/search_result.html:94
 msgid "Jump to results page:"
 msgstr "Ga naar de resultatenlijst:"
 
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:8
+#, python-format
+msgid "Revision History for %(gloss)s"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:75
+msgid "User"
+msgstr "Gebruiker"
+
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:76
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2164
+msgid "Time"
+msgstr "Tijd"
+
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:77
+#: signbank/dictionary/templates/dictionary/import_csv.html:91
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:97
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:96
+msgid "Field"
+msgstr "Veld"
+
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:78
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:97
+msgid "Old value"
+msgstr "Oud"
+
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:79
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:98
+msgid "New value"
+msgstr "Nieuw"
+
+#: signbank/dictionary/templates/dictionary/glosslist_table.html:6
+msgid "ID Gloss"
+msgstr "ID-Glos"
+
 #: signbank/dictionary/templates/dictionary/glosstags.html:22
-#: signbank/dictionary/templates/dictionary/morphemetags.html:20
+#: signbank/dictionary/templates/dictionary/morphemetags.html:22
 msgid "delete this tag"
 msgstr "verwijder dit label"
 
@@ -1760,64 +3434,92 @@ msgstr "verwijder dit label"
 msgid "Add Tag"
 msgstr "Voeg label toe"
 
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:109
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:7
+msgid "Signbank: Handshape Details"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:64
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:66
 msgid "Handshapes List"
 msgstr "Handvormlijst"
 
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:138
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:97
 msgid "Upload New Handshape Image"
 msgstr "Upload een nieuwe handvormfoto"
 
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:161
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:120
 msgid "Handshape "
 msgstr "Handvorm "
 
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:171
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:201
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:217
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:130
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:160
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:176
 msgid "True"
 msgstr "Ja"
 
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:173
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:203
-#: signbank/dictionary/templates/dictionary/handshape_detail.html:219
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:132
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:162
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:178
 msgid "False"
 msgstr "Nee"
 
+#: signbank/dictionary/templates/dictionary/handshape_detail.html:151
+msgid "Unselected fingers extended"
+msgstr "Gestrekte ongeselecteerde vingers"
+
 #: signbank/dictionary/templates/dictionary/import_csv.html:33
-msgid "Upload your changed CSV here::"
+msgid "Import CSV"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv.html:37
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:39
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:39
+msgid "Upload your changed CSV here:"
 msgstr "Upload hier het gewijzigde CSV-bestand:"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:54
+#: signbank/dictionary/templates/dictionary/import_csv.html:58
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:54
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:58
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:57
 msgid "Browse&hellip;"
 msgstr "Blader&hellip;"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:57
+#: signbank/dictionary/templates/dictionary/import_csv.html:61
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:57
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:61
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:60
 #: signbank/dictionary/templates/dictionary/search_result.html:20
+#: signbank/feedback/templates/feedback/generalfeedback.html:45
 msgid "Submit"
 msgstr "Bevestig"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:79
+#: signbank/dictionary/templates/dictionary/import_csv.html:67
+msgid ""
+"To speed up processing of updates, remove columns that will not be updated."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv.html:85
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:91
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:90
 msgid "The following changes were detected:"
 msgstr "De volgende wijzigingen zijn vastgesteld:"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:84
+#: signbank/dictionary/templates/dictionary/import_csv.html:90
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:96
+#: signbank/dictionary/templates/dictionary/update_lemma.html:77
 msgid "Signbank ID"
 msgstr "Signbank-ID"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:85
-msgid "Field"
-msgstr "Veld"
-
-#: signbank/dictionary/templates/dictionary/import_csv.html:86
+#: signbank/dictionary/templates/dictionary/import_csv.html:92
 msgid "Old"
 msgstr "Oud"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:87
+#: signbank/dictionary/templates/dictionary/import_csv.html:93
 msgid "New"
 msgstr "Nieuw"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:93
+#: signbank/dictionary/templates/dictionary/import_csv.html:99
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:105
 #, python-format
 msgid ""
 "\n"
@@ -1828,7 +3530,8 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:98
+#: signbank/dictionary/templates/dictionary/import_csv.html:104
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:110
 #, python-format
 msgid ""
 "\n"
@@ -1839,7 +3542,8 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:104
+#: signbank/dictionary/templates/dictionary/import_csv.html:110
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:116
 #, python-format
 msgid ""
 "\n"
@@ -1851,32 +3555,161 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:115
-msgid "Make changes"
-msgstr "Wijzig"
-
-#: signbank/dictionary/templates/dictionary/import_csv.html:119
+#: signbank/dictionary/templates/dictionary/import_csv.html:125
 msgid "Already existing Annotation ID Glosses:"
 msgstr "Al bestaande Annotatie-ID-Glossen:"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:148
+#: signbank/dictionary/templates/dictionary/import_csv.html:160
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:127
 msgid "Glosses to Create:"
 msgstr "Aan te maken glossen:"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:180
+#: signbank/dictionary/templates/dictionary/import_csv.html:206
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:177
 msgid "Create glosses"
 msgstr "Maak glossen aan"
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:183
+#: signbank/dictionary/templates/dictionary/import_csv.html:209
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:180
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:130
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:129
 msgid "No changes were found."
 msgstr "Geen veranderingen gevonden."
 
-#: signbank/dictionary/templates/dictionary/import_csv.html:190
+#: signbank/dictionary/templates/dictionary/import_csv.html:216
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:198
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:148
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:147
 msgid "Changes are live."
 msgstr "Wijzigingen zijn gepubliceerd."
 
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:9
+msgid "Signbank: Import CSV"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:35
+msgid "Import CSV Create"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:39
+msgid "Upload your CSV here:"
+msgstr "Upload hier het gewijzigde CSV-bestand:"
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:62
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:66
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:65
+msgid "Comma"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:64
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:68
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:67
+msgid "Tab"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:66
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:70
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:69
+msgid "Semicolon"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:77
+#: signbank/dictionary/templates/dictionary/import_media.html:59
+msgid "Errors"
+msgstr "Foutmeldingen"
+
+#: signbank/dictionary/templates/dictionary/import_csv_create.html:88
+msgid "Already Existing Annotation ID Glosses:"
+msgstr "Al bestaande Annotatie-ID-Glossen:"
+
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:9
+msgid "Signbank: Import CSV Update"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:35
+msgid "Import CSV Update"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:98
+msgid "Old Value"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update.html:99
+msgid "New Value"
+msgstr "Nieuwe video"
+
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:9
+msgid "Signbank: Import CSV Update Lemmas"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:35
+msgid "Import CSV Update Lemmas"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:95
+msgid "Lemma ID"
+msgstr "Lemma-ID"
+
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:104
+#, python-format
+msgid ""
+"\n"
+"            <tr><td>%(dataset)s</td><td>%(pk)s</td><td><em>%(human_key)s</"
+"em></td>\n"
+"                <td>%(original_human_value)s</td><td>%(new_human_value)s</"
+"td></tr>\n"
+"                    "
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:109
+#, python-format
+msgid ""
+"\n"
+"\n"
+"            <tr><td>%(dataset)s</td><td>%(pk)s</td><td><em>%(human_key)s</"
+"em></td><td>&nbsp;</td><td>%(new_human_value)s</td></tr>\n"
+"                    "
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:115
+#, python-format
+msgid ""
+"\n"
+"\n"
+"            <tr><td>%(dataset)s</td><td>%(pk)s</td><td><em>%(human_key)s</"
+"em></td><td>%(original_human_value)s</td>\n"
+"                                <td>%(new_human_value)s</td></tr>\n"
+"                    "
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_media.html:9
+msgid "Signbank: Import Media"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_media.html:14
+msgid "Imported Media"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_media.html:19
+msgid "No media found to import."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_media.html:31
+msgid "Empty Folder"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/import_media.html:40
+#: signbank/dictionary/templates/dictionary/unused_videos.html:23
+msgid "Filename"
+msgstr "Bestandsnaam"
+
+#: signbank/dictionary/templates/dictionary/import_media.html:41
+msgid "Status"
+msgstr ""
+
 #. Translators: Welcome message
 #: signbank/dictionary/templates/dictionary/index.html:7
+#, python-format
 msgid ""
 "Welcome to the Sign Search section of the %(language)s SignBank. Here you "
 "can search for a sign using a translation in the search box above, or browse "
@@ -1886,53 +3719,64 @@ msgstr ""
 "   kun je zoeken naar een gebaar op basis van de vertaling,\n"
 "   of gebaren bekijken in de lijst hieronder."
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:23
-msgid "Delete this morpheme"
-msgstr "Verwijder dit morfeem"
+#: signbank/dictionary/templates/dictionary/lemma_frequency.html:6
+msgid "Signbank: Lemma Frequency"
+msgstr ""
 
-#. Translators: Navigation
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:121
-#: signbank/dictionary/templates/dictionary/word.html:48
+#: signbank/dictionary/templates/dictionary/lemma_frequency.html:83
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:152
+msgid "Lemma Group"
+msgstr "Lemma-groep"
+
+#: signbank/dictionary/templates/dictionary/lemma_frequency.html:93
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:162
+#: signbank/dictionary/templates/dictionary/update_lemma.html:76
+msgid "Glosses"
+msgstr "Glossen"
+
+#: signbank/dictionary/templates/dictionary/lemma_frequency.html:104
+msgid "No lemma group for this gloss."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:8
+#, python-format
+msgid "Morpheme for %(morpheme)s"
+msgstr "Morfeem voor %(morpheme)s"
+
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:270
 msgid "Previous Sign"
 msgstr "Vorige gebaar"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:138
-msgid "Delete Morpheme"
-msgstr "Verwijder dit morfeem"
-
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:148
-msgid "Edit next morpheme"
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:299
+msgid "Edit Next Morpheme"
 msgstr "Bewerk volgende morfeem"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:185
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:337
 msgid "Provide feedback about this morpheme"
 msgstr "Geef feedback over dit morfeem"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:194
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:346
 #, python-format
 msgid " We have %(morpheme_video_count)s videos for this morpheme. "
 msgstr "We hebben %(morpheme_video_count)s video's voor dit morfeem. "
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:213
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:365
 msgid "Delete/Revert Video"
 msgstr "Verwijder video"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:216
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:368
 msgid ""
 "This will delete the most recent upload and restore the most recent earlier "
 "version."
 msgstr ""
 "Zo wordt de meest recente video verwijderd en de vorige versie getoond."
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:269
-msgid "Abstract meaning"
-msgstr "Abstracte betekenis"
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:402
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:403
+msgid "Delete Morpheme"
+msgstr "Verwijder dit morfeem"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:279
-msgid "Language"
-msgstr "Taal"
-
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:294
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:499
 msgid ""
 "This action will delete this morpheme and all associated records. It cannot "
 "be undone."
@@ -1940,67 +3784,91 @@ msgstr ""
 "Je verwijdert zo dit morfeem en alle verwante records, dit kan niet ongedaan "
 "gemaakt worden."
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:317
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:536
 msgid "Appears in"
 msgstr "Komt voor in"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:340
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:545
+msgid "Word Class"
+msgstr "Woordsoort"
+
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:556
 msgid "This morpheme does not occur in any sign"
 msgstr "Dit morfeem komt in geen enkel gebaar voor"
 
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:420
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:652
+msgid "In Web Dictionary"
+msgstr "In woordenboek"
+
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:656
 msgid "Proposed New Morpheme"
 msgstr "Voorstel voor nieuw morfeem"
 
-#: signbank/dictionary/templates/dictionary/morphemetags.html:36
+#: signbank/dictionary/templates/dictionary/morphemetags.html:39
 msgid "Add morpheme Tag"
 msgstr "Voeg morfeem-label toe"
 
-#. Translators: Navigation detailed view
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:27
-#: signbank/dictionary/templates/dictionary/word.html:90
-msgid "Detail View"
-msgstr "Detailbeeld"
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:10
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:15
+msgid "Recently Added Signs"
+msgstr "Recent toegevoegd gebaren"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:38
-msgid "Source Sign"
-msgstr "Bron-gebaar"
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:68
+msgid "No recently added signs for the selected datasets"
+msgstr "Geen recent toegevoegd gebaren in de geselecteerde datasets."
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:96
-msgid "Lemma Group"
-msgstr "Lemma-groep"
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:68
+msgid "days"
+msgstr ""
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:106
-msgid "Glosses"
-msgstr "Glossen"
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:9
+#, python-format
+msgid "Relations for %(gloss)s"
+msgstr "Relaties voor %(gloss)s"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:120
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:114
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:181
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:226
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:269
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:312
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:355
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:399
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:443
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:486
+msgid "Translation Equivalents"
+msgstr "Mogelijke vertalingen"
+
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:176
 msgid "Homonyms"
 msgstr "Homoniemen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:175
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:221
 msgid "Synonyms"
 msgstr "Synoniemen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:230
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:264
 msgid "Antonyms"
 msgstr "Antoniemen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:285
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:307
 msgid "Hyponyms"
 msgstr "Hyponiemen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:340
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:350
 msgid "Hypernyms"
 msgstr "Hyperoniemen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:395
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:394
+msgid "Handshape Paradigm"
+msgstr "Handvorm paradigma"
+
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:438
 msgid "See Also"
 msgstr "Zie ook"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:450
-msgid "Variants"
-msgstr "Varianten"
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:532
+msgid "Compounds"
+msgstr "Samenstellingen"
 
 #: signbank/dictionary/templates/dictionary/search_result.html:27
 msgid "There is no exact match to the word you typed."
@@ -2042,7 +3910,7 @@ msgid ""
 "\n"
 "            requested that these type of words/signs be only visible to "
 "registered users.) If you\n"
-"            <a href=\"/accounts/login/\">login or register \n"
+"            <a href=\"%(PREFIX_URL)s/accounts/login/\">login or register\n"
 "\n"
 "            with %(language)s Signbank</a>,  you will then be able to find "
 "these\n"
@@ -2071,34 +3939,83 @@ msgstr ""
 msgid "Start"
 msgstr "Start"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:18
-msgid "Sign Language"
-msgstr "Gebarentaal"
+#: signbank/dictionary/templates/dictionary/semanticfield_detail.html:17
+msgid "Signbank: Semantic Field Details"
+msgstr "Signbank: Semantisch veld detailbeeld"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:21
-msgid "Number of unassigned glosses"
+#: signbank/dictionary/templates/dictionary/semanticfield_detail.html:22
+msgid "Semantic Field Detail View"
+msgstr "Semantisch veld detailbeeld"
+
+#: signbank/dictionary/templates/dictionary/semanticfield_detail.html:29
+msgid "Semantic Fields List"
+msgstr "Lijst semantische velden"
+
+#: signbank/dictionary/templates/dictionary/semanticfield_detail.html:39
+msgid "Semantic Field "
+msgstr "Semantisch veld"
+
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:7
+msgid "Signbank: Unassigned Glosses"
+msgstr "Signbank: Niet-toegewezen glossen"
+
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:23
+msgid "Number of Unassigned Glosses"
 msgstr "Aantal niet-toegewezen glossen"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:24
-msgid "Possible datasets"
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:26
+msgid "Possible Datasets"
 msgstr "Mogelijke datasets"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:34
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:36
 msgid "No sign language"
 msgstr "Geen gebarentaal"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:48
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:76
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:50
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:78
 msgid "No datasets for this sign language"
 msgstr "Geen datasets voor deze gebarentaal"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:86
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:88
 msgid "Assign glosses"
 msgstr "Glossen toewijzen"
 
-#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:90
+#: signbank/dictionary/templates/dictionary/unassigned_glosses.html:92
 msgid "No unassigned glosses found."
 msgstr "Geen niet-toegewezen glossen gevonden."
+
+#: signbank/dictionary/templates/dictionary/unused_videos.html:12
+msgid "Signbank: Unused Video Files"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/unused_videos.html:17
+msgid "Unused video files and other unlinked files"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/unused_videos.html:19
+msgid "Number of unused video files"
+msgstr "Aantal niet-toegewezen video bestanden"
+
+#: signbank/dictionary/templates/dictionary/unused_videos.html:23
+msgid "Folder (Gloss Prefix)"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/update_lemma.html:7
+msgid "Signbank: Update Lemma"
+msgstr "Signbank: Update lemma"
+
+#: signbank/dictionary/templates/dictionary/update_lemma.html:43
+msgid "Update Lemma"
+msgstr "Update lemma"
+
+#: signbank/dictionary/templates/dictionary/update_lemma.html:49
+#: signbank/dictionary/templates/dictionary/update_lemma.html:51
+msgid "Return to Lemma List"
+msgstr "Terug naar lemmata-lijst"
+
+#: signbank/dictionary/templates/dictionary/update_lemma.html:54
+msgid "Return to Gloss Detail View"
+msgstr ""
 
 #: signbank/dictionary/templates/dictionary/update_result.html:9
 msgid "The update to the gloss {{ gloss }} was successful"
@@ -2150,95 +4067,290 @@ msgstr "Upload video"
 msgid "Click here to go back."
 msgstr "Klik hier om terug te gaan."
 
-#. Translators: Page title
-#: signbank/dictionary/templates/dictionary/word.html:9
-msgid "Sign for %(translation)s"
-msgstr "Gebaar voor %(translation)s"
-
-#. Translators: Sign x of n(signs)
-#: signbank/dictionary/templates/dictionary/word.html:52
-msgid "Sign %(glossposn)s of %(glosscount)s <span class='hidden-xs'>in the dictionary"
-msgstr "Gebaar %(glossposn)s van %(glosscount)s <span class='hidden-xs'>in het lexicon"
-
-#: signbank/dictionary/templates/dictionary/word.html:57
-msgid "Next Sign"
-msgstr "Volgende gebaar"
-
-#. Translators: Navbar text
-#: signbank/dictionary/templates/dictionary/word.html:68
+#: signbank/dictionary/templates/dictionary/word.html:12
 #, python-format
-msgid "Matches for the word <em>%(translation|safe)s"
-msgstr "Resultaten voor het woord <em>%(translation|safe)s"
-
-#. Translators: Navigation
-#: signbank/dictionary/templates/dictionary/word.html:81
-msgid "Return to Matches"
-msgstr "Terug naar de zoekresultaten"
+msgid "Morpheme for %(gloss)s"
+msgstr "Morfeem voor %(gloss)s"
 
 #. Translators: Keywords
-#: signbank/dictionary/templates/dictionary/word.html:129
-msgid "Translation equivalents:"
-msgstr "Mogelijke vertalingen in het Nederlands:"
+#: signbank/dictionary/templates/dictionary/word.html:117
+msgid "Translation equivalents"
+msgstr "Mogelijke vertalingen"
+
+#: signbank/dictionary/templates/dictionary/word.html:126
+msgid "Note(s)"
+msgstr "Aantekening(en)"
 
 #. Translators: Header4
-#: signbank/dictionary/templates/dictionary/word.html:139
+#: signbank/dictionary/templates/dictionary/word.html:161
 msgid "Sign Distribution"
 msgstr "Gebaarverdeling"
 
 #. Translators: Header2
-#: signbank/dictionary/templates/dictionary/word.html:152
+#: signbank/dictionary/templates/dictionary/word.html:174
 msgid "Sign Definition"
 msgstr "Gebaardefinitie"
 
-#: signbank/dictionary/update.py:51 signbank/dictionary/update.py:1413
+#: signbank/dictionary/update.py:72 signbank/dictionary/update.py:1699
+msgid "The given Lemma Idgloss ID is unknown."
+msgstr ""
+
+#: signbank/dictionary/update.py:79 signbank/dictionary/update.py:1679
 msgid "You are not authorized to change the selected dataset."
 msgstr "Je hebt niet genoeg rechten om de geselecteerde dataset te wijzigen."
 
-#: signbank/dictionary/update.py:55 signbank/dictionary/update.py:1417
+#: signbank/dictionary/update.py:83 signbank/dictionary/update.py:1683
 msgid "Please provide a dataset."
 msgstr "Specificeer hier een dataset"
 
-#: signbank/dictionary/update.py:259
-msgid "yes"
-msgstr "ja"
+#: signbank/dictionary/update.py:97 signbank/dictionary/update.py:1710
+msgid "Annotation ID Gloss not unique."
+msgstr "Annotatie-ID-Glos is niet uniek"
 
-#: signbank/feedback/templates/feedback/generalfeedbacksummary.html:10
-msgid "General feedback summary"
-msgstr "Algemene feedback samenvatting"
+#: signbank/dictionary/update.py:336
+msgid "The dataset of the gloss is not the same as that of the lemma."
+msgstr ""
 
-#: signbank/feedback/templates/feedback/show.html:49
-msgid "General feedback"
+#: signbank/dictionary/update.py:338 signbank/dictionary/update.py:1914
+msgid "The specified lemma does not exist."
+msgstr ""
+
+#: signbank/dictionary/update.py:1325
+msgid ""
+"Edit Simultaneuous Morphology: The dataset of this gloss has no morphemes."
+msgstr ""
+
+#: signbank/dictionary/update.py:1328
+msgid "Edit Simultaneuous Morphology: No morpheme selected."
+msgstr "Bewerk Simultane morfologie: Geen morfeem geselecteerd."
+
+#: signbank/dictionary/update.py:1340
+msgid "Simultaneuous morphology: no morpheme found with identifier {}."
+msgstr ""
+
+#: signbank/dictionary/update.py:1522 signbank/dictionary/update.py:1583
+msgid "Upload other media failed: The file has an unknown type."
+msgstr ""
+
+#: signbank/dictionary/update.py:1530
+msgid "Upload other media failed: The file has no extension."
+msgstr ""
+
+#: signbank/dictionary/update.py:1566
+msgid "The destination filename for other media could not be created."
+msgstr ""
+
+#: signbank/dictionary/update.py:1589
+msgid "Upload other media failed: The file extension does not match its type."
+msgstr ""
+
+#: signbank/dictionary/update.py:1912
+msgid "The dataset of the morpheme is not the same as that of the lemma."
+msgstr ""
+
+#: signbank/dictionary/update.py:2163
+msgid "You must be in group Dataset Manager to modify dataset details."
+msgstr ""
+"Je moet in groep Dataset Manager zijn om deze dataset te wijzigen."
+
+#: signbank/dictionary/update.py:2416 signbank/dictionary/update.py:2467
+msgid "No acronym for dataset."
+msgstr ""
+
+#: signbank/dictionary/update.py:2424 signbank/dictionary/update.py:2475
+msgid "Dataset does not exist."
+msgstr "Dataset bestaat niet."
+
+#: signbank/dictionary/update.py:2430
+msgid "You are not authorized to remove eaf files."
+msgstr "Je hebt niet genoeg rechten om EAF-bestanden te verwijderen."
+
+#: signbank/dictionary/update.py:2450
+msgid "No eaf files found."
+msgstr "Geen EAF-bestanden gevonden."
+
+#: signbank/dictionary/update.py:2481
+msgid "You are not authorized to upload eaf files."
+msgstr "Je hebt niet genoeg rechten om EAF-bestanden te uploaden."
+
+#: signbank/dictionary/update.py:2570
+msgid "Non-EAF file(s) ignored: "
+msgstr ""
+
+#: signbank/dictionary/update.py:2574
+msgid "File(s) encountered twice: "
+msgstr ""
+
+#: signbank/dictionary/update.py:2578
+msgid "Already imported to different folder: "
+msgstr ""
+
+#: signbank/dictionary/views.py:850 signbank/dictionary/views.py:1313
+#: signbank/dictionary/views.py:1799
+msgid ""
+"Unrecognised text encoding. Please export your file to UTF-8 format using e."
+"g. LibreOffice."
+msgstr ""
+
+#: signbank/dictionary/views.py:852 signbank/dictionary/views.py:1315
+#: signbank/dictionary/views.py:1801
+msgid "Unrecognised format in selected CSV file."
+msgstr ""
+
+#: signbank/dictionary/views.py:898 signbank/dictionary/views.py:1361
+#: signbank/dictionary/views.py:1845
+msgid "Incorrect Delimiter: "
+msgstr ""
+
+#: signbank/dictionary/views.py:902 signbank/dictionary/views.py:1365
+#: signbank/dictionary/views.py:1849
+msgid "Empty Column Header Found."
+msgstr ""
+
+#: signbank/dictionary/views.py:906 signbank/dictionary/views.py:1369
+#: signbank/dictionary/views.py:1853
+msgid "Duplicate Column Header Found."
+msgstr ""
+
+#: signbank/dictionary/views.py:910
+msgid "Signbank ID column found."
+msgstr "Signbank-ID kolom gevonden."
+
+#: signbank/dictionary/views.py:914 signbank/dictionary/views.py:1377
+#: signbank/dictionary/views.py:1861
+msgid "The Dataset column is required."
+msgstr "De kolom 'Dataset' is verplicht."
+
+#: signbank/dictionary/views.py:1373
+msgid "The Signbank ID column is required."
+msgstr "De kolom 'Signbank ID' is verplicht."
+
+#: signbank/dictionary/views.py:1857
+msgid "The Lemma ID column is required."
+msgstr "De kolom 'Lemma ID' is verplicht."
+
+#: signbank/feedback/templates/feedback/generalfeedback.html:18
+#: signbank/feedback/templates/feedback/show.html:45
+msgid "General Feedback"
 msgstr "Algemene feedback"
 
-#: signbank/feedback/templates/feedback/show.html:81
-#: signbank/feedback/templates/feedback/show.html:141
-#: signbank/feedback/templates/feedback/show.html:204
-msgid "Delete"
-msgstr "Verwijder"
+#: signbank/feedback/templates/feedback/generalfeedback.html:20
+msgid ""
+"Please enter any comments you may have about this site and click \"submit\" "
+"to send your feedback to us. We value your contributions and comments."
+msgstr ""
 
-#: signbank/feedback/templates/feedback/show.html:89
-#: signbank/feedback/templates/feedback/show.html:149
-#: signbank/feedback/templates/feedback/show.html:213
-msgid "Delete This Comment"
-msgstr "Verwijder deze aantekening"
+#: signbank/feedback/templates/feedback/generalfeedback.html:28
+msgid "General comments, suggestions, or anything you feel like telling us."
+msgstr ""
 
-#: signbank/feedback/templates/feedback/show.html:92
-#: signbank/feedback/templates/feedback/show.html:152
-#: signbank/feedback/templates/feedback/show.html:216
-msgid "This action will delete this comment. It cannot be undone."
-msgstr "Je verwijdert zo deze aantekening. Het kan niet ongedaan gemaakt worden."
+#: signbank/feedback/templates/feedback/generalfeedback.html:34
+msgid " Upload your feedback as a video."
+msgstr ""
 
-#: signbank/feedback/templates/feedback/show.html:112
-msgid "Sign Feedback"
-msgstr "Gebaar feedback"
+#: signbank/feedback/templates/feedback/generalfeedback.html:37
+#: signbank/feedback/templates/feedback/missingsign.html:87
+msgid ""
+"NOTE: Video files can be quite large, and may take a long time to send. "
+"Please be patient when submitting this feedback."
+msgstr ""
 
-#: signbank/feedback/templates/feedback/show.html:170
+#: signbank/feedback/templates/feedback/generalfeedbacksummary.html:10
+msgid "General Feedback Summary"
+msgstr "Algemene feedback samenvatting"
+
+#: signbank/feedback/templates/feedback/missingsign.html:51
+#: signbank/feedback/templates/feedback/show.html:162
 msgid "Missing Sign Feedback"
 msgstr "Feedback over ontbrekend gebaar"
 
-#: signbank/pages/admin.py:14 signbank/pages/models.py:10
-msgid "URL"
-msgstr "URL"
+#: signbank/feedback/templates/feedback/missingsign.html:56
+msgid "Thank you for your feedback."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:60
+msgid "Please submit a video comment showing the sign you think is missing."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:61
+msgid "Please produce the sign in isolation and then in an example sentence."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:62
+msgid ""
+"Please also type in the English translation equivalent below as well as your "
+"contact information (name and email address) so we can contact you for a "
+"follow up if need be."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:66
+msgid "Thank you for taking the time to contact us and help SignBank grow."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:70
+msgid ""
+"You may either upload a video that shows the missing sign or fill in details "
+"below. In either case, you should enter a meaning and any comments you might "
+"have in the text boxes at the bottom of the form."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:77
+msgid "Video Comment"
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:80
+msgid "Video Upload"
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:83
+msgid "Upload a video of the sign."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:96
+msgid "Details"
+msgstr "Details"
+
+#: signbank/feedback/templates/feedback/missingsign.html:98
+msgid ""
+"Please explain the meaning of the new or missing sign, or enter individual "
+"English words that have the same meaning as this sign (i.e. keywords)."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:107
+msgid ""
+"Are there any other comments you would like to give about this sign? For "
+"example, do you think there are other or extra keyword/s that belong with "
+"this sign? If so, please include your comments below."
+msgstr ""
+
+#: signbank/feedback/templates/feedback/missingsign.html:118
+msgid "Submit Feedback"
+msgstr "Verstuur feedback"
+
+#: signbank/feedback/templates/feedback/show.html:82
+#: signbank/feedback/templates/feedback/show.html:141
+#: signbank/feedback/templates/feedback/show.html:205
+msgid "Delete This Comment"
+msgstr "Verwijder deze aantekening"
+
+#: signbank/feedback/templates/feedback/show.html:85
+#: signbank/feedback/templates/feedback/show.html:144
+#: signbank/feedback/templates/feedback/show.html:208
+msgid "This action will delete this comment. It cannot be undone."
+msgstr ""
+"Je verwijdert zo deze aantekening. Het kan niet ongedaan gemaakt worden."
+
+#: signbank/feedback/templates/feedback/show.html:105
+msgid "Sign Feedback"
+msgstr "Gebaar feedback"
+
+#: signbank/frequency.py:1090
+msgid "No permission to update corpus."
+msgstr ""
+
+#: signbank/frequency.py:1100
+msgid "Document does not exist: "
+msgstr "Document bestaat niet: "
 
 #: signbank/pages/admin.py:15
 msgid ""
@@ -2250,7 +4362,7 @@ msgstr ""
 msgid "Uploaded video will be converted to Flash"
 msgstr "De geüploade video zal naar Flash worden geconverteerd"
 
-#: signbank/pages/admin.py:54 signbank/pages/admin.py:59
+#: signbank/pages/admin.py:53 signbank/pages/admin.py:58
 msgid "Advanced options"
 msgstr "Geavanceerde opties"
 
@@ -2335,24 +4447,32 @@ msgstr "pagina's"
 msgid "title"
 msgstr "titel"
 
-#: signbank/settings/server_specific/asl.py:20
-msgid "American English"
-msgstr "Amerikaans Engels"
-
-#: signbank/settings/server_specific/global_sb.py:35
-#: signbank/settings/server_specific/global_sb_new_aj.py:35
+#: signbank/settings/server_specific/default.py:64
+#: signbank/settings/server_specific/global_sb_local.py:24
+#: signbank/settings/server_specific/global_sb_new_aj.py:14
+#: signbank/settings/server_specific/server_specific.py:24
 msgid "English"
 msgstr "Engels"
 
-#: signbank/settings/server_specific/global_sb.py:36
-#: signbank/settings/server_specific/global_sb_new_aj.py:36
+#: signbank/settings/server_specific/global_sb_local.py:25
+#: signbank/settings/server_specific/global_sb_new_aj.py:15
+#: signbank/settings/server_specific/server_specific.py:25
 msgid "Dutch"
 msgstr "Nederlands"
 
-#: signbank/settings/server_specific/global_sb.py:37
-#: signbank/settings/server_specific/global_sb_new_aj.py:37
+#: signbank/settings/server_specific/global_sb_local.py:26
+#: signbank/settings/server_specific/global_sb_new_aj.py:16
+#: signbank/settings/server_specific/server_specific.py:26
 msgid "Chinese"
 msgstr "Chinees"
+
+#: signbank/settings/server_specific/global_sb_new_aj.py:17
+msgid "Hebrew"
+msgstr "Hebreeuws"
+
+#: signbank/settings/server_specific/global_sb_new_aj.py:18
+msgid "Arabic"
+msgstr "Arabisch"
 
 #: templates/ASL-templates/baselayout.html:50
 msgid "The ASL Signbank</span> is licensed under a "
@@ -2363,7 +4483,7 @@ msgid "Creative Commons BY-NC-SA 4.0 International License"
 msgstr "Creative Commons BY-NC-SA 4.0 International-Licentie"
 
 #: templates/ASL-templates/baselayout.html:53
-#: templates/global-templates/baselayout.html:51
+#: templates/global-templates/baselayout.html:49
 msgid "Provide feedback on the site"
 msgstr "Geef feedback over dit gebaar"
 
@@ -2378,34 +4498,34 @@ msgid "User name"
 msgstr "Gebruikersnaam"
 
 #: templates/ASL-templates/loginform.html:20
-#: templates/global-templates/loginform.html:20
+#: templates/global-templates/loginform.html:18
 msgid "Password"
 msgstr "Wachtwoord"
 
 #: templates/ASL-templates/loginform.html:27
-#: templates/global-templates/loginform.html:27
+#: templates/global-templates/loginform.html:23
 msgid "Sign in"
 msgstr "Inloggen"
 
 #: templates/ASL-templates/loginform.html:38
 #: templates/ASL-templates/loginform.html:41
-#: templates/global-templates/loginform.html:43
-#: templates/global-templates/loginform.html:46
+#: templates/global-templates/loginform.html:37
+#: templates/global-templates/loginform.html:40
 msgid "Register"
 msgstr "Aanmelden"
 
 #: templates/ASL-templates/loginform.html:40
-#: templates/global-templates/loginform.html:45
+#: templates/global-templates/loginform.html:39
 msgid "Register for free to provide feedback on the Signbank."
 msgstr "Meld je gratis aan om feedback op Signbank te kunnen geven."
 
 #: templates/ASL-templates/loginform.html:47
-#: templates/global-templates/loginform.html:52
+#: templates/global-templates/loginform.html:46
 msgid "Lost Password"
 msgstr "Wachtwoord vergeten"
 
 #: templates/ASL-templates/loginform.html:48
-#: templates/global-templates/loginform.html:53
+#: templates/global-templates/loginform.html:47
 msgid ""
 "If you've lost or forgotten your password, enter your email address here and "
 "we'll reset it and send you a reminder."
@@ -2414,22 +4534,23 @@ msgstr ""
 "toegestuurd te krijgen."
 
 #: templates/ASL-templates/loginform.html:53
-#: templates/global-templates/loginform.html:58
+#: templates/global-templates/loginform.html:52
 msgid "Email"
 msgstr "E-mail"
 
 #: templates/ASL-templates/loginform.html:57
-#: templates/global-templates/loginform.html:62
+#: templates/global-templates/loginform.html:56
 msgid "Request Password"
 msgstr "Stel mijn wachtwoord opnieuw in"
 
-#: templates/ASL-templates/menu.html:46 templates/global-templates/menu.html:81
-msgid "Search gloss"
+#: templates/ASL-templates/menu.html:46
+#: templates/global-templates/menu.html:116
+msgid "Search Gloss"
 msgstr "Glos zoeken"
 
 #: templates/ASL-templates/menu.html:48
-#: templates/global-templates/menu.html:107
-msgid "Search translation"
+#: templates/global-templates/menu.html:121
+msgid "Search Translation"
 msgstr "Vertaling zoeken"
 
 #: templates/ASL-templates/menu.html:50
@@ -2437,12 +4558,12 @@ msgid "Sign search"
 msgstr "Gebaar zoeken"
 
 #: templates/ASL-templates/menu.html:55
-#: templates/global-templates/menu.html:139
+#: templates/global-templates/menu.html:138
 msgid "Logout"
 msgstr "Uitloggen"
 
 #: templates/ASL-templates/menu.html:57
-#: templates/global-templates/menu.html:142
+#: templates/global-templates/menu.html:140
 msgid "Login"
 msgstr "Inloggen"
 
@@ -2537,7 +4658,6 @@ msgstr ""
 "opnieuw in wilt stellen."
 
 #: templates/ASL-templates/registration/password_reset_email.html:4
-#: templates/global-templates/registration/password_reset_email.html:4
 msgid "Please go to the following page and choose a new password:"
 msgstr "Ga naar de volgende pagina om een nieuw wachtwoord in te stellen:"
 
@@ -2580,8 +4700,1387 @@ msgstr "Stel mijn wachtwoord opnieuw in"
 msgid "Password reset for Signbank"
 msgstr "Wachtwoord opnieuw ingesteld"
 
-#~ msgid "Users View Dataset"
-#~ msgstr "Dataset inzien"
+#: templates/global-templates/menu.html:131
+msgid "Profile"
+msgstr ""
+
+#: templates/global-templates/registration/password_reset_email.html:4
+msgid ""
+"Please go to the following page and choose a new password for the username"
+msgstr "Ga naar de volgende pagina om een nieuw wachtwoord in te stellen"
+
+#: templates/global-templates/tooltip.html:7
+msgid "In many text fields, you can use patterns as follows:"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/contrib/messages/apps.py:7
+msgid "Messages"
+msgstr "Berichten"
+
+#: venv/lib/python3.6/site-packages/django/contrib/sitemaps/apps.py:7
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/contrib/staticfiles/apps.py:7
+msgid "Static Files"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/contrib/syndication/apps.py:7
+msgid "Syndication"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/core/paginator.py:43
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/core/paginator.py:45
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/core/paginator.py:50
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:34
+msgid "Enter a valid value."
+msgstr "Vul een geldige waarde in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:107
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:667
+msgid "Enter a valid URL."
+msgstr "Vul een geldige URL in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:160
+msgid "Enter a valid integer."
+msgstr "Vul een geldig getal in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:171
+msgid "Enter a valid email address."
+msgstr "Vul een geldig e-mailadres in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:245
+msgid ""
+"Enter a valid 'slug' consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+"Vul een geldige regel in, bestaande uit letters, cijfers, underscores of "
+"streepjes."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:252
+msgid ""
+"Enter a valid 'slug' consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+"Vul een geldige regel in, bestaande uit Unicode letters, cijfers, underscores of "
+"streepjes."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:257
+#: venv/lib/python3.6/site-packages/django/core/validators.py:277
+msgid "Enter a valid IPv4 address."
+msgstr "Vul een geldig IPv4-adres in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:262
+#: venv/lib/python3.6/site-packages/django/core/validators.py:278
+msgid "Enter a valid IPv6 address."
+msgstr "Vul een geldig IPv6-adres in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:272
+#: venv/lib/python3.6/site-packages/django/core/validators.py:276
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr "Vul een geldig IPv4- of IPv6-adres in."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:308
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1127
+msgid "Enter only digits separated by commas."
+msgstr "Vul alleen cijfers in, gescheiden door komma's"
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:314
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr "Zorg dat deze waarde %(limit_value)s is (nu %(show_value)s)."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:345
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr "Zorg dat deze waarde kleiner of gelijk aan %(limit_value)s is."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:354
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr "Zorg dat deze waarde groter of gelijk aan %(limit_value)s is."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:364
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+"Zorg dat deze waarde tenminste %(limit_value)d teken heeft (heeft nu "
+"%(show_value)d)."
+msgstr[1] ""
+"Zorg dat deze waarde tenminste %(limit_value)d tekens heeft (heeft nu "
+"%(show_value)d)."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:379
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+"Zorg dat deze waarde hooguit %(limit_value)d teken heeft (heeft nu "
+"%(show_value)d)."
+msgstr[1] ""
+"Zorg dat deze waarde hooguit %(limit_value)d tekens heeft (heeft nu "
+"%(show_value)d)."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:399
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] "Zorg dat er niet meer dan %(max)s cijfer is."
+msgstr[1] "Zorg dat er niet meer dan %(max)s cijfers zijn."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:404
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] "Zorg dat er niet meer dan %(max)s cijfer achter de komma is."
+msgstr[1] "Zorg dat er niet meer dan %(max)s cijfers achter de komma zijn"
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:409
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] "Zorg dat er niet meer dan %(max)s cijfer voor de komma is."
+msgstr[1] "Zorg dat er niet meer dan %(max)s cijfers voor de komma zijn."
+
+#: venv/lib/python3.6/site-packages/django/core/validators.py:463
+#, python-format
+msgid ""
+"File extension '%(extension)s' is not allowed. Allowed extensions are: "
+"'%(allowed_extensions)s'."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/db/models/base.py:1207
+#: venv/lib/python3.6/site-packages/django/forms/models.py:732
+msgid "and"
+msgstr "en"
+
+#: venv/lib/python3.6/site-packages/django/db/models/base.py:1209
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr "%(model_name)s met dit %(field_labels)s bestaat al."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:116
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr "Waarde %(value)r is geen geldige keuze."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:117
+msgid "This field cannot be null."
+msgstr "Dit veld mag niet leeg zijn."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:118
+msgid "This field cannot be blank."
+msgstr "Dit veld mag niet leeg zijn."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:119
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr "%(model_name)s met dit %(field_label)s bestaat al"
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:123
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr "%(field_label)s moet uniek zijn voor %(date_field_label)s %(lookup_type)s."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:140
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr "Veldtype: %(field_type)s"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:897
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1805
+msgid "Integer"
+msgstr "Geheel getal"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:901
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1803
+#, python-format
+msgid "'%(value)s' value must be an integer."
+msgstr "'%(value)s' waarde moet een geheel getal zijn."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:974
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1874
+msgid "Big (8 byte) integer"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:986
+#, python-format
+msgid "'%(value)s' value must be either True or False."
+msgstr "'%(value)s' waarde moet True of False zijn."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:988
+msgid "Boolean (Either True or False)"
+msgstr "Boolean (True of False)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1054
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr "String (maximaal %(max_length)s tekens)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1111
+msgid "Comma-separated integers"
+msgstr "Komma-gescheiden gehele getallen"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1168
+#, python-format
+msgid ""
+"'%(value)s' value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+"'%(value)s' waarde is ongeldig als datumindeling, het moet in YYYY-MM-DD "
+"indeling."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1170
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1315
+#, python-format
+msgid ""
+"'%(value)s' value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+"'%(value)s' waarde heeft de juiste indeling (YYYY-MM-DD) maar is een "
+"ongeldige datum."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1173
+msgid "Date (without time)"
+msgstr "Datum (zonder tijd)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1313
+#, python-format
+msgid ""
+"'%(value)s' value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+"'%(value)s' waarde heeft een ongeldige indeling. De indeling moet zijn: YYYY-"
+"MM-DD HH:MM[:ss[.uuuuuu]][TZ]."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1317
+#, python-format
+msgid ""
+"'%(value)s' value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+"'%(value)s' waarde heeft de juiste indeling (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]), maar is een ongeldige datum/tijd."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1321
+msgid "Date (with time)"
+msgstr "Datum (met tijd)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1471
+#, python-format
+msgid "'%(value)s' value must be a decimal number."
+msgstr "'%(value)s' waarde moet een decimaal getal zijn."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1473
+msgid "Decimal number"
+msgstr "Decimaal getal"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1624
+#, python-format
+msgid ""
+"'%(value)s' value has an invalid format. It must be in [DD] [HH:[MM:]]ss[."
+"uuuuuu] format."
+msgstr ""
+"'%(value)s' waarde heeft een ongeldige indeling, het moet in [DD] [HH:[MM:]]ss[."
+"uuuuuu]] indeling."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1627
+msgid "Duration"
+msgstr "Looptijd"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1679
+msgid "Email address"
+msgstr "E-mailadres"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1703
+msgid "File path"
+msgstr "Bestandspad"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1769
+#, python-format
+msgid "'%(value)s' value must be a float."
+msgstr "'%(value)s' waarde moet een float zijn (zwevendekommagetal)."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1771
+msgid "Floating point number"
+msgstr "Zwevendekommagetal"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1889
+msgid "IPv4 address"
+msgstr "IPv4-adres"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:1920
+msgid "IP address"
+msgstr "IP-adres"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2002
+#, python-format
+msgid "'%(value)s' value must be either None, True or False."
+msgstr "'%(value)s' waarde moet None, True of False zijn."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2004
+msgid "Boolean (Either True, False or None)"
+msgstr "Boolean (True, False of None)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2067
+msgid "Positive integer"
+msgstr "Positief geheel getal"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2079
+msgid "Positive small integer"
+msgstr "Positief klein geheel getal"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2092
+#, python-format
+msgid "Slug (up to %(max_length)s)"
+msgstr "Regel (maximaal %(max_length)s)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2126
+msgid "Small integer"
+msgstr "Klein geheel getal"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2159
+#, python-format
+msgid ""
+"'%(value)s' value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
+msgstr ""
+"'%(value)s' waarde heeft een ongeldige indeling, het moet in HH:MM[:ss[."
+"uuuuuu]] indeling."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2161
+#, python-format
+msgid ""
+"'%(value)s' value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
+msgstr ""
+"'%(value)s' waarde heeft de juiste indeling (HH:MM[:ss[.uuuuuu]]) maar is "
+"ongeldig als tijd."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2315
+msgid "Raw binary data"
+msgstr "Ruwe binaire data"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/__init__.py:2362
+#, python-format
+msgid "'%(value)s' is not a valid UUID."
+msgstr "'%(value)s' is geen geldig UUID."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/files.py:393
+msgid "Image"
+msgstr "Afbeelding"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/related.py:788
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
+msgstr "%(model)s-instantie met %(field)s %(value)r bestaat niet."
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/related.py:790
+msgid "Foreign Key (type determined by related field)"
+msgstr "Foreign key (type bepaald door verwant veld)"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/related.py:1029
+msgid "One-to-one relationship"
+msgstr "Een-op-een relatie"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/related.py:1104
+#, python-format
+msgid "%(from)s-%(to)s relationship"
+msgstr "%(from)s-%(to)s relatie"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/related.py:1105
+#, python-format
+msgid "%(from)s-%(to)s relationships"
+msgstr "%(from)s-%(to)s relaties"
+
+#: venv/lib/python3.6/site-packages/django/db/models/fields/related.py:1147
+msgid "Many-to-many relationship"
+msgstr "Veel-op-veel relatie"
+
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.6/site-packages/django/forms/boundfield.py:174
+msgid ":?.!"
+msgstr ":?.!"
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:56
+msgid "This field is required."
+msgstr "Dit veld is verplicht."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:257
+msgid "Enter a whole number."
+msgstr "Vul een geheel getal in."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:302
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:339
+msgid "Enter a number."
+msgstr "Vul een nummer in."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:417
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:1139
+msgid "Enter a valid date."
+msgstr "Vul een geldige datum in. "
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:441
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:1140
+msgid "Enter a valid time."
+msgstr "Vul een geldige tijd in."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:463
+msgid "Enter a valid date/time."
+msgstr "Vul een geldige datum/tijd in."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:492
+msgid "Enter a valid duration."
+msgstr "Vul een geldige looptijd in. "
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:546
+msgid "No file was submitted. Check the encoding type on the form."
+msgstr ""
+"Er werd geen bestand verstuurd. Controleer het coderingstype in het "
+"formulier."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:547
+msgid "No file was submitted."
+msgstr "Er werd geen bestand verstuurd."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:548
+msgid "The submitted file is empty."
+msgstr "Het verstuurde bestand is leeg."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:550
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+"Zorg dat de bestandsnaam hooguit %(max)d teken bevat (is nu %(length)d)."
+msgstr[1] ""
+"Zorg dat de bestandsnaam hooguit %(max)d tekens bevat (is nu %(length)d)."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:553
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr "Verstuur een file of vink het clear-vakje aan, niet beide."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:615
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+"Upload een geldige afbeelding. Het bestand dat werd geüpload is geen "
+"afbeelding, of een beschadigd bestand"
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:770
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:866
+#: venv/lib/python3.6/site-packages/django/forms/models.py:1241
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr "Selecteer een geldige keuze. %(value)s is niet beschikbaar als keuze."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:867
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:982
+#: venv/lib/python3.6/site-packages/django/forms/models.py:1240
+msgid "Enter a list of values."
+msgstr "Voor een lijst met waardes in."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:983
+msgid "Enter a complete value."
+msgstr "Vul een geldige waarde in."
+
+#: venv/lib/python3.6/site-packages/django/forms/fields.py:1198
+msgid "Enter a valid UUID."
+msgstr "Vul een geldige URL in."
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.6/site-packages/django/forms/forms.py:87
+msgid ":"
+msgstr ":"
+
+#: venv/lib/python3.6/site-packages/django/forms/forms.py:213
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr "(Verborgen veld %(name)s) %(error)s"
+
+#: venv/lib/python3.6/site-packages/django/forms/formsets.py:97
+msgid "ManagementForm data is missing or has been tampered with"
+msgstr "ManagementForm-data ontbreekt of er is mee geknoeid. "
+
+#: venv/lib/python3.6/site-packages/django/forms/formsets.py:354
+#, python-format
+msgid "Please submit %d or fewer forms."
+msgid_plural "Please submit %d or fewer forms."
+msgstr[0] "Verstuur %d of minder formulieren."
+msgstr[1] "Verstuur %d of minder formulieren."
+
+#: venv/lib/python3.6/site-packages/django/forms/formsets.py:361
+#, python-format
+msgid "Please submit %d or more forms."
+msgid_plural "Please submit %d or more forms."
+msgstr[0] "Verstuur %d of meer formulieren."
+msgstr[1] "Verstuur %d of meer formulieren."
+
+#: venv/lib/python3.6/site-packages/django/forms/formsets.py:389
+#: venv/lib/python3.6/site-packages/django/forms/formsets.py:391
+msgid "Order"
+msgstr "Volgorde"
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:727
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr "Corrigeer de dubbele gegevens voor %(field)s."
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:731
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr "Corrigeer de dubbele gegevens voor %(field)s, moet uniek zijn."
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:737
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+"Corrigeer de dubbele gegevens voor %(field_name)s, moet uniek zijn voor de "
+"%(lookup)s in %(date_field)s."
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:746
+msgid "Please correct the duplicate values below."
+msgstr "Corrigeer de dubbele gegevens voor onderstaande waardes. "
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:1071
+msgid "The inline foreign key did not match the parent instance primary key."
+msgstr ""
+"De inline foreign key komt niet overeen met de parent instance primary key."
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:1132
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr "Maak een geldige keuze. Deze keuze behoort niet tot de mogelijkheden."
+
+#: venv/lib/python3.6/site-packages/django/forms/models.py:1243
+#, python-format
+msgid "\"%(pk)s\" is not a valid value for a primary key."
+msgstr "\"%(pk)s\" is geen geldige waarde voor een primary key."
+
+#: venv/lib/python3.6/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn't be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+"%(datetime)s kon niet als tijdzone %(current_timezone)s worden "
+"geïnterpreteerd; het kan dubbelzinnig zijn of het bestaat niet. "
+
+#: venv/lib/python3.6/site-packages/django/forms/widgets.py:377
+msgid "Clear"
+msgstr "Wis"
+
+#: venv/lib/python3.6/site-packages/django/forms/widgets.py:378
+msgid "Currently"
+msgstr "Huidig"
+
+#: venv/lib/python3.6/site-packages/django/forms/widgets.py:379
+msgid "Change"
+msgstr "Verander"
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:849
+msgid "yes,no,maybe"
+msgstr "ja,nee,misschien"
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:878
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:895
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:897
+#, python-format
+msgid "%s KB"
+msgstr "%s KB"
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:899
+#, python-format
+msgid "%s MB"
+msgstr "%s MB"
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:901
+#, python-format
+msgid "%s GB"
+msgstr "%s GB"
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:903
+#, python-format
+msgid "%s TB"
+msgstr "%s TB"
+
+#: venv/lib/python3.6/site-packages/django/template/defaultfilters.py:905
+#, python-format
+msgid "%s PB"
+msgstr "%s PB"
+
+#: venv/lib/python3.6/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr "p.m."
+
+#: venv/lib/python3.6/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr "a.m."
+
+#: venv/lib/python3.6/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr "PM"
+
+#: venv/lib/python3.6/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr "AM"
+
+#: venv/lib/python3.6/site-packages/django/utils/dateformat.py:158
+msgid "midnight"
+msgstr "middernacht"
+
+#: venv/lib/python3.6/site-packages/django/utils/dateformat.py:160
+msgid "noon"
+msgstr "'s middags"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr "maandag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr "dinsdag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr "woensdag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr "donderdag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr "vrijdag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr "zaterdag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr "zondag"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr "ma"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr "di"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr "wo"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr "do"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr "vr"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:11
+msgid "Sat"
+msgstr "za"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr "zo"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:18
+msgid "January"
+msgstr "januari"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:18
+msgid "February"
+msgstr "februari"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:18
+msgid "March"
+msgstr "maart"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:18
+msgid "April"
+msgstr "april"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:18
+msgid "May"
+msgstr "mei"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:18
+msgid "June"
+msgstr "juni"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:19
+msgid "July"
+msgstr "juli"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:19
+msgid "August"
+msgstr "augustus"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:19
+msgid "September"
+msgstr "september"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:19
+msgid "October"
+msgstr "oktober"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:19
+msgid "November"
+msgstr "november"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:20
+msgid "December"
+msgstr "december"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:23
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:23
+msgid "feb"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:23
+msgid "mar"
+msgstr "mrt"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:23
+msgid "apr"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:23
+msgid "may"
+msgstr "mei"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:23
+msgid "jun"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:24
+msgid "jul"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:24
+msgid "aug"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:24
+msgid "sep"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:24
+msgid "oct"
+msgstr "okt"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:24
+msgid "nov"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:24
+msgid "dec"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Jan."
+msgstr "jan."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr "feb."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "March"
+msgstr "maart"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "April"
+msgstr "april"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:35
+msgctxt "abbrev. month"
+msgid "May"
+msgstr "mei"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:36
+msgctxt "abbrev. month"
+msgid "June"
+msgstr "juni"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:37
+msgctxt "abbrev. month"
+msgid "July"
+msgstr "juli"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:38
+msgctxt "abbrev. month"
+msgid "Aug."
+msgstr "aug."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:39
+msgctxt "abbrev. month"
+msgid "Sept."
+msgstr "sep."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:40
+msgctxt "abbrev. month"
+msgid "Oct."
+msgstr "okt."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:41
+msgctxt "abbrev. month"
+msgid "Nov."
+msgstr "nov."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:42
+msgctxt "abbrev. month"
+msgid "Dec."
+msgstr "dec."
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "January"
+msgstr "januari"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "February"
+msgstr "februari"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "March"
+msgstr "maart"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "April"
+msgstr "april"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:49
+msgctxt "alt. month"
+msgid "May"
+msgstr "mei"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:50
+msgctxt "alt. month"
+msgid "June"
+msgstr "juni"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:51
+msgctxt "alt. month"
+msgid "July"
+msgstr "juli"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:52
+msgctxt "alt. month"
+msgid "August"
+msgstr "augustus"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:53
+msgctxt "alt. month"
+msgid "September"
+msgstr "september"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:54
+msgctxt "alt. month"
+msgid "October"
+msgstr "oktober"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:55
+msgctxt "alt. month"
+msgid "November"
+msgstr "november"
+
+#: venv/lib/python3.6/site-packages/django/utils/dates.py:56
+msgctxt "alt. month"
+msgid "December"
+msgstr "december"
+
+#: venv/lib/python3.6/site-packages/django/utils/ipv6.py:12
+msgid "This is not a valid IPv6 address."
+msgstr "Dit is geen geldig IPv6-adres."
+
+#: venv/lib/python3.6/site-packages/django/utils/text.py:81
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s..."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/utils/text.py:251
+msgid "or"
+msgstr "of"
+
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.6/site-packages/django/utils/text.py:270
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:71
+msgid ", "
+msgstr ", "
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] "%d jaar"
+msgstr[1] "%d jaar"
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "%d maand"
+msgstr[1] "%d maanden"
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] "%d week"
+msgstr[1] "%d weken"
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] "%d dag"
+msgstr[1] "%d dagen"
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:15
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d uur"
+msgstr[1] "%d uur"
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:16
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuut"
+msgstr[1] "%d minuten"
+
+#: venv/lib/python3.6/site-packages/django/utils/timesince.py:60
+msgid "0 minutes"
+msgstr "0 minuten"
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:109
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:110
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:114
+msgid ""
+"You are seeing this message because this HTTPS site requires a 'Referer "
+"header' to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:119
+msgid ""
+"If you have configured your browser to disable 'Referer' headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for 'same-"
+"origin' requests."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:124
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:129
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for 'same-origin' requests."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/csrf.py:134
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/debug.py:520
+msgid "Welcome to Django"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/debug.py:521
+msgid "It worked!"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/debug.py:522
+msgid "Congratulations on your first Django-powered page."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/debug.py:524
+msgid ""
+"Next, start your first app by running <code>python manage.py startapp "
+"[app_label]</code>."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/debug.py:527
+msgid ""
+"You're seeing this message because you have <code>DEBUG = True</code> in "
+"your Django settings file and you haven't configured any URLs. Get to work!"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:48
+msgid "No year specified"
+msgstr "Geen jaar opgegeven"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:104
+msgid "No month specified"
+msgstr "Geen maand opgegeven"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:163
+msgid "No day specified"
+msgstr "Geen dag opgegeven"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:219
+msgid "No week specified"
+msgstr "Geen week opgegeven"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:378
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:406
+#, python-format
+msgid "No %(verbose_name_plural)s available"
+msgstr "Geen %(verbose_name_plural)s beschikbaar"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:660
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
+msgstr ""
+"Toekomstige %(verbose_name_plural)s is niet beschikbaar omdat %(class_name)s "
+"allow_future False is."
+
+#: venv/lib/python3.6/site-packages/django/views/generic/dates.py:694
+#, python-format
+msgid "Invalid date string '%(datestr)s' given format '%(format)s'"
+msgstr "Ongeldige datumstring '%(datestr)s' opgegeven, indeling '%(format)s'"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/detail.py:55
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
+msgstr "Geen %(verbose_name)s gevonden die de query matched"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/list.py:76
+msgid "Page is not 'last', nor can it be converted to an int."
+msgstr "Pagina is niet 'last', kan ook niet worden omgezet in een int."
+
+#: venv/lib/python3.6/site-packages/django/views/generic/list.py:81
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
+msgstr "Ongeldige pagina (%(page_number)s): %(message)s"
+
+#: venv/lib/python3.6/site-packages/django/views/generic/list.py:171
+#, python-format
+msgid "Empty list and '%(class_name)s.allow_empty' is False."
+msgstr "Lege lijst en '%(class_name)s.allow_empty' is False."
+
+#: venv/lib/python3.6/site-packages/django/views/static.py:44
+msgid "Directory indexes are not allowed here."
+msgstr "Directory indexen zijn hier niet toegestaan."
+
+#: venv/lib/python3.6/site-packages/django/views/static.py:46
+#, python-format
+msgid "\"%(path)s\" does not exist"
+msgstr "\"%(path)s\" bestaat niet"
+
+#: venv/lib/python3.6/site-packages/django/views/static.py:86
+#, python-format
+msgid "Index of %(directory)s"
+msgstr "Index van %(directory)s"
+
+#: venv/lib/python3.6/site-packages/django_summernote/views.py:32
+msgid "Only POST method is allowed"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django_summernote/views.py:36
+msgid "Only authenticated users are allowed"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django_summernote/views.py:39
+msgid "No files were requested"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django_summernote/views.py:55
+msgid "File size exceeds the limit allowed and cannot be saved"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/django_summernote/views.py:70
+msgid "Failed to save attachment"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/modeltranslation/widgets.py:26
+msgid "None"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/apps.py:14
+msgid "Tagging"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/fields.py:73
+#, python-format
+msgid "%s can only be set on instances."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/forms.py:21
+msgid "Multiple tags were given."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/forms.py:35
+#, python-format
+msgid "Each tag may be no more than %s characters long."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:62
+#, python-format
+msgid "No tags were given: \"%s\"."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:65
+#, python-format
+msgid "Multiple tags were given: \"%s\"."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:479
+msgid "name"
+msgstr "naam"
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:486
+#: venv/lib/python3.6/site-packages/tagging/models.py:500
+msgid "tag"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:487
+msgid "tags"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:506
+msgid "content type"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:510
+msgid "object id"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:521
+msgid "tagged item"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/models.py:522
+msgid "tagged items"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:30
+#, python-format
+msgid "tags_for_model tag was given an invalid model: %s"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:47
+#, python-format
+msgid "tag_cloud_for_model tag was given an invalid model: %s"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:75
+#, python-format
+msgid "tagged_objects tag was given an invalid model: %s"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:111
+#, python-format
+msgid "%s tag requires either three or five arguments"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:114
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:175
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:244
+#, python-format
+msgid "second argument to %s tag must be 'as'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:118
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:180
+#, python-format
+msgid "if given, fourth argument to %s tag must be 'with'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:122
+#, python-format
+msgid "if given, fifth argument to %s tag must be 'counts'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:171
+#, python-format
+msgid "%s tag requires either three or between five and seven arguments"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:190
+#, python-format
+msgid "%(tag)s tag's '%(option)s' option was not a valid integer: '%(value)s'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:202
+#, python-format
+msgid "%(tag)s tag's '%(option)s' option was not a valid choice: '%(value)s'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:210
+#, python-format
+msgid "%(tag)s tag was given an invalid option: '%(option)s'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:217
+#, python-format
+msgid "%(tag)s tag was given a badly formatted option: '%(option)s'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:241
+#, python-format
+msgid "%s tag requires exactly three arguments"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:269
+#, python-format
+msgid "%s tag requires exactly five arguments"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:272
+#, python-format
+msgid "second argument to %s tag must be 'in'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/templatetags/tagging_tags.py:275
+#, python-format
+msgid "fourth argument to %s tag must be 'as'"
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/utils.py:197
+msgid ""
+"If a list or tuple of tags is provided, they must all be tag names, Tag "
+"objects or Tag ids."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/utils.py:200
+msgid "The tag input given was invalid."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/utils.py:248
+#, python-format
+msgid "Invalid distribution algorithm specified: %s."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/views.py:42
+msgid "TaggedObjectList must be called with a tag."
+msgstr ""
+
+#: venv/lib/python3.6/site-packages/tagging/views.py:46
+#, python-format
+msgid "No Tag found matching \"%s\"."
+msgstr ""
+
+#~ msgid "Weak prop"
+#~ msgstr "Week prop"
+
+#~ msgid "Weak drop"
+#~ msgstr "Weak drop"
+
+#~ msgid "Manage datasets"
+#~ msgstr "Datasets beheren"
+
+#~ msgid "Strong hand"
+#~ msgstr "Sterke hand"
+
+#~ msgid "Weak hand"
+#~ msgstr "Zwakke hand"
+
+#~ msgid "morphemes"
+#~ msgstr "morfemen"
+
+#~ msgid " We have %(gloss_video_count)s videos for this sign. "
+#~ msgstr " We hebben %(gloss_video_count)s video's voor dit gebaar"
+
+#~ msgid "Annotation ID gloss"
+#~ msgstr "Annotatie-ID-Glos"
+
+#~ msgid "Proposed New Sign"
+#~ msgstr "Voorstel voor nieuw gebaar"
+
+#~ msgid "Delete this morpheme"
+#~ msgstr "Verwijder dit morfeem"
+
+#~ msgid "Abstract meaning"
+#~ msgstr "Abstracte betekenis"
+
+#~ msgid "Language"
+#~ msgstr "Taal"
+
+#~ msgid ""
+#~ "Sign %(glossposn)s of %(glosscount)s <span class='hidden-xs'>in the "
+#~ "dictionary"
+#~ msgstr ""
+#~ "Gebaar %(glossposn)s van %(glosscount)s <span class='hidden-xs'>in het "
+#~ "lexicon"
+
+#~ msgid "Next Sign"
+#~ msgstr "Volgende gebaar"
+
+#~ msgid "Matches for the word <em>%(translation|safe)s"
+#~ msgstr "Resultaten voor het woord <em>%(translation|safe)s"
+
+#~ msgid "Translation equivalents:"
+#~ msgstr "Mogelijke vertalingen in het Nederlands:"
+
+#~ msgid "yes"
+#~ msgstr "ja"
+
+#~ msgid "American English"
+#~ msgstr "Amerikaans Engels"
 
 #~ msgid "Users Change Dataset"
 #~ msgstr "Dataset bewerken"
@@ -2613,17 +6112,11 @@ msgstr "Wachtwoord opnieuw ingesteld"
 #~ msgid "Language & Dialect"
 #~ msgstr "Taal & dialect"
 
-#~ msgid "Annotation ID Gloss not unique."
-#~ msgstr "Annotatie-ID-Glos is niet uniek"
-
 #~ msgid "English annotation ID gloss not unique."
 #~ msgstr "Annotatie-ID-Glos: Engels is niet uniek"
 
 #~ msgid "Dutch annotation ID gloss cannot be empty."
 #~ msgstr "Annotatie-ID-glos: Nederlands mag niet leeg zijn"
-
-#~ msgid "Arabic"
-#~ msgstr "Arabisch"
 
 #~ msgid "Azerbaijani"
 #~ msgstr "Azerbeidzjaans"
@@ -2696,9 +6189,6 @@ msgstr "Wachtwoord opnieuw ingesteld"
 
 #~ msgid "Galician"
 #~ msgstr "Galicisch"
-
-#~ msgid "Hebrew"
-#~ msgstr "Hebreeuws"
 
 #~ msgid "Croatian"
 #~ msgstr "Kroatisch"
@@ -2820,676 +6310,14 @@ msgstr "Wachtwoord opnieuw ingesteld"
 #~ msgid "Traditional Chinese"
 #~ msgstr "Traditioneel Chinees"
 
-#~ msgid "Enter a valid value."
-#~ msgstr "Vul een geldige waarde in."
-
-#~ msgid "Enter a valid URL."
-#~ msgstr "Vul een geldige URL in."
-
-#~ msgid "Enter a valid integer."
-#~ msgstr "Vul een geldig getal in."
-
-#~ msgid "Enter a valid email address."
-#~ msgstr "Vul een geldig e-mailadres in."
-
-#~ msgid ""
-#~ "Enter a valid 'slug' consisting of letters, numbers, underscores or "
-#~ "hyphens."
-#~ msgstr ""
-#~ "Vul een geldige regel in, bestaande uit letters, cijfers, underscores of "
-#~ "streepjes."
-
-#~ msgid "Enter a valid IPv4 address."
-#~ msgstr "Vul een geldig IPv4-adres in."
-
-#~ msgid "Enter a valid IPv6 address."
-#~ msgstr "Vul een geldig IPv6-adres in."
-
-#~ msgid "Enter a valid IPv4 or IPv6 address."
-#~ msgstr "Vul een geldig IPv4- of IPv6-adres in."
-
-#~ msgid "Enter only digits separated by commas."
-#~ msgstr "Vul alleen cijfers in, gescheiden door komma's"
-
-#~ msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
-#~ msgstr "Zorg dat deze waarde %(limit_value)s is (nu %(show_value)s)."
-
-#~ msgid "Ensure this value is less than or equal to %(limit_value)s."
-#~ msgstr "Zorg dat deze waarde kleiner of gelijk aan %(limit_value)s is."
-
-#~ msgid "Ensure this value is greater than or equal to %(limit_value)s."
-#~ msgstr "Zorg dat deze waarde groter of gelijk aan %(limit_value)s is."
-
-#~ msgid ""
-#~ "Ensure this value has at least %(limit_value)d character (it has "
-#~ "%(show_value)d)."
-#~ msgid_plural ""
-#~ "Ensure this value has at least %(limit_value)d characters (it has "
-#~ "%(show_value)d)."
-#~ msgstr[0] ""
-#~ "Zorg dat deze waarde tenminste %(limit_value)d teken heeft (heeft nu "
-#~ "%(show_value)d)."
-#~ msgstr[1] ""
-#~ "Zorg dat deze waarde tenminste %(limit_value)d tekens heeft (heeft nu "
-#~ "%(show_value)d)."
-
-#~ msgid ""
-#~ "Ensure this value has at most %(limit_value)d character (it has "
-#~ "%(show_value)d)."
-#~ msgid_plural ""
-#~ "Ensure this value has at most %(limit_value)d characters (it has "
-#~ "%(show_value)d)."
-#~ msgstr[0] ""
-#~ "Zorg dat deze waarde hooguit %(limit_value)d teken heeft (heeft nu "
-#~ "%(show_value)d)."
-#~ msgstr[1] ""
-#~ "Zorg dat deze waarde hooguit %(limit_value)d tekens heeft (heeft nu "
-#~ "%(show_value)d)."
-
-#~ msgid "%(field_name)s must be unique for %(date_field)s %(lookup)s."
-#~ msgstr "%(field_name)s moet uniek zijn voor %(date_field)s %(lookup)s."
-
-#~ msgid "and"
-#~ msgstr "en"
-
-#~ msgid "%(model_name)s with this %(field_label)s already exists."
-#~ msgstr "%(model_name)s met dit %(field_label)s bestaat al"
-
-#~ msgid "Value %(value)r is not a valid choice."
-#~ msgstr "Waarde %(value)r is geen geldige keuze."
-
-#~ msgid "This field cannot be null."
-#~ msgstr "Dit veld mag niet leeg zijn."
-
-#~ msgid "This field cannot be blank."
-#~ msgstr "Dit veld mag niet leeg zijn."
-
-#~ msgid "Field of type: %(field_type)s"
-#~ msgstr "Veldtype: %(field_type)s"
-
-#~ msgid "Integer"
-#~ msgstr "Geheel getal"
-
-#~ msgid "'%(value)s' value must be an integer."
-#~ msgstr "'%(value)s' waarde moet een geheel getal zijn."
-
-#~ msgid "'%(value)s' value must be either True or False."
-#~ msgstr "'%(value)s' waarde moet True of False zijn."
-
-#~ msgid "Boolean (Either True or False)"
-#~ msgstr "Boolean (True of False)"
-
-#~ msgid "String (up to %(max_length)s)"
-#~ msgstr "String (maximaal %(max_length)s tekens)"
-
-#~ msgid "Comma-separated integers"
-#~ msgstr "Komma-gescheiden gehele getallen"
-
-#~ msgid ""
-#~ "'%(value)s' value has an invalid date format. It must be in YYYY-MM-DD "
-#~ "format."
-#~ msgstr ""
-#~ "'%(value)s' waarde is ongeldig als datumindeling, het moet in YYYY-MM-DD "
-#~ "indeling."
-
-#~ msgid ""
-#~ "'%(value)s' value has the correct format (YYYY-MM-DD) but it is an "
-#~ "invalid date."
-#~ msgstr ""
-#~ "'%(value)s' waarde heeft de juiste indeling (YYYY-MM-DD) maar is een "
-#~ "ongeldige datum."
-
-#~ msgid "Date (without time)"
-#~ msgstr "Datum (zonder tijd)"
-
-#~ msgid ""
-#~ "'%(value)s' value has an invalid format. It must be in YYYY-MM-DD HH:MM[:"
-#~ "ss[.uuuuuu]][TZ] format."
-#~ msgstr ""
-#~ "'%(value)s' waarde heeft een ongeldige indeling. De indeling moet zijn: "
-#~ "YYYY-MM-DD HH:MM[:ss[.uuuuuu]][TZ]."
-
-#~ msgid ""
-#~ "'%(value)s' value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
-#~ "[TZ]) but it is an invalid date/time."
-#~ msgstr ""
-#~ "'%(value)s' waarde heeft de juiste indeling (YYYY-MM-DD HH:MM[:ss[."
-#~ "uuuuuu]][TZ]), maar is een ongeldige datum/tijd."
-
-#~ msgid "Date (with time)"
-#~ msgstr "Datum (met tijd)"
-
-#~ msgid "'%(value)s' value must be a decimal number."
-#~ msgstr "'%(value)s' waarde moet een decimaal getal zijn."
-
-#~ msgid "Decimal number"
-#~ msgstr "Decimaal getal"
-
-#~ msgid "Email address"
-#~ msgstr "E-mailadres"
-
-#~ msgid "'%(value)s' value must be a float."
-#~ msgstr "'%(value)s' waarde moet een float zijn (zwevendekommagetal)."
-
-#~ msgid "Floating point number"
-#~ msgstr "Zwevendekommagetal"
-
-#~ msgid "IPv4 address"
-#~ msgstr "IPv4-adres"
-
-#~ msgid "IP address"
-#~ msgstr "IP-adres"
-
-#~ msgid "'%(value)s' value must be either None, True or False."
-#~ msgstr "'%(value)s' waarde moet None, True of False zijn."
-
-#~ msgid "Boolean (Either True, False or None)"
-#~ msgstr "Boolean (True, False of None)"
-
-#~ msgid "Positive integer"
-#~ msgstr "Positief geheel getal"
-
-#~ msgid "Positive small integer"
-#~ msgstr "Positief klein geheel getal"
-
-#~ msgid "Slug (up to %(max_length)s)"
-#~ msgstr "Regel (maximaal %(max_length)s)"
-
-#~ msgid "Small integer"
-#~ msgstr "Klein geheel getal"
-
-#~ msgid ""
-#~ "'%(value)s' value has an invalid format. It must be in HH:MM[:ss[."
-#~ "uuuuuu]] format."
-#~ msgstr ""
-#~ "'%(value)s' waarde heeft een ongeldige indeling, het moet in HH:MM[:ss[."
-#~ "uuuuuu]] indeling."
-
-#~ msgid ""
-#~ "'%(value)s' value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is "
-#~ "an invalid time."
-#~ msgstr ""
-#~ "'%(value)s' waarde heeft de juiste indeling (HH:MM[:ss[.uuuuuu]]) maar is "
-#~ "ongeldig als tijd."
-
-#~ msgid "Time"
-#~ msgstr "Tijd"
-
-#~ msgid "Raw binary data"
-#~ msgstr "Ruwe binaire data"
-
-#~ msgid "File"
-#~ msgstr "Bestand"
-
-#~ msgid "Image"
-#~ msgstr "Afbeelding"
-
-#~ msgid "%(model)s instance with pk %(pk)r does not exist."
-#~ msgstr "%(model)s-instantie met pk %(pk)r bestaat niet."
-
-#~ msgid "Foreign Key (type determined by related field)"
-#~ msgstr "Foreign key (type bepaald door verwant veld)"
-
-#~ msgid "One-to-one relationship"
-#~ msgstr "Een-op-een relatie"
-
-#~ msgid "Many-to-many relationship"
-#~ msgstr "Veel-op-veel relatie"
-
-#~ msgid "This field is required."
-#~ msgstr "Dit veld is verplicht."
-
-#~ msgid "Enter a whole number."
-#~ msgstr "Vul een geheel getal in."
-
-#~ msgid "Enter a number."
-#~ msgstr "Vul een nummer in."
-
-#~ msgid "Ensure that there are no more than %(max)s digit in total."
-#~ msgid_plural "Ensure that there are no more than %(max)s digits in total."
-#~ msgstr[0] "Zorg dat er niet meer dan %(max)s cijfer is."
-#~ msgstr[1] "Zorg dat er niet meer dan %(max)s cijfers zijn."
-
-#~ msgid "Ensure that there are no more than %(max)s decimal place."
-#~ msgid_plural "Ensure that there are no more than %(max)s decimal places."
-#~ msgstr[0] "Zorg dat er niet meer dan %(max)s cijfer achter de komma is."
-#~ msgstr[1] "Zorg dat er niet meer dan %(max)s cijfers achter de komma zijn"
-
-#~ msgid ""
-#~ "Ensure that there are no more than %(max)s digit before the decimal point."
-#~ msgid_plural ""
-#~ "Ensure that there are no more than %(max)s digits before the decimal "
-#~ "point."
-#~ msgstr[0] "Zorg dat er niet meer dan %(max)s cijfer voor de komma is."
-#~ msgstr[1] "Zorg dat er niet meer dan %(max)s cijfers voor de komma zijn."
-
-#~ msgid "Enter a valid date."
-#~ msgstr "Vul een geldige datum in. "
-
-#~ msgid "Enter a valid time."
-#~ msgstr "Vul een geldige tijd in."
-
-#~ msgid "Enter a valid date/time."
-#~ msgstr "Vul een geldige datum/tijd in."
-
-#~ msgid "No file was submitted. Check the encoding type on the form."
-#~ msgstr ""
-#~ "Er werd geen bestand verstuurd. Controleer het coderingstype in het "
-#~ "formulier."
-
-#~ msgid "No file was submitted."
-#~ msgstr "Er werd geen bestand verstuurd."
-
-#~ msgid "The submitted file is empty."
-#~ msgstr "Het verstuurde bestand is leeg."
-
-#~ msgid ""
-#~ "Ensure this filename has at most %(max)d character (it has %(length)d)."
-#~ msgid_plural ""
-#~ "Ensure this filename has at most %(max)d characters (it has %(length)d)."
-#~ msgstr[0] ""
-#~ "Zorg dat de bestandsnaam hooguit %(max)d teken bevat (is nu %(length)d)."
-#~ msgstr[1] ""
-#~ "Zorg dat de bestandsnaam hooguit %(max)d tekens bevat (is nu %(length)d)."
-
-#~ msgid "Please either submit a file or check the clear checkbox, not both."
-#~ msgstr "Verstuur een file of vink het clear-vakje aan, niet beide."
-
-#~ msgid ""
-#~ "Upload a valid image. The file you uploaded was either not an image or a "
-#~ "corrupted image."
-#~ msgstr ""
-#~ "Upload een geldige afbeelding. Het bestand dat werd geüpload is geen "
-#~ "afbeelding, of een beschadigd bestand"
-
-#~ msgid ""
-#~ "Select a valid choice. %(value)s is not one of the available choices."
-#~ msgstr ""
-#~ "Selecteer een geldige keuze. %(value)s is niet beschikbaar als keuze."
-
-#~ msgid "Enter a list of values."
-#~ msgstr "Voor een lijst met waardes in."
-
-#~ msgid ":"
-#~ msgstr ":"
-
-#~ msgid "(Hidden field %(name)s) %(error)s"
-#~ msgstr "(Verborgen veld %(name)s) %(error)s"
-
-#~ msgid ":?.!"
-#~ msgstr ":?.!"
-
-#~ msgid "ManagementForm data is missing or has been tampered with"
-#~ msgstr "ManagementForm-data ontbreekt of er is mee geknoeid. "
-
-#~ msgid "Please submit %d or fewer forms."
-#~ msgid_plural "Please submit %d or fewer forms."
-#~ msgstr[0] "Verstuur %d of minder formulieren."
-#~ msgstr[1] "Verstuur %d of minder formulieren."
-
-#~ msgid "Order"
-#~ msgstr "Volgorde"
-
-#~ msgid "Please correct the duplicate data for %(field)s."
-#~ msgstr "Corrigeer de dubbele gegevens voor %(field)s."
-
-#~ msgid ""
-#~ "Please correct the duplicate data for %(field)s, which must be unique."
-#~ msgstr "Corrigeer de dubbele gegevens voor %(field)s, moet uniek zijn."
-
-#~ msgid ""
-#~ "Please correct the duplicate data for %(field_name)s which must be unique "
-#~ "for the %(lookup)s in %(date_field)s."
-#~ msgstr ""
-#~ "Corrigeer de dubbele gegevens voor %(field_name)s, moet uniek zijn voor "
-#~ "de %(lookup)s in %(date_field)s."
-
-#~ msgid "Please correct the duplicate values below."
-#~ msgstr "Corrigeer de dubbele gegevens voor onderstaande waardes. "
-
-#~ msgid ""
-#~ "The inline foreign key did not match the parent instance primary key."
-#~ msgstr ""
-#~ "De inline foreign key komt niet overeen met de parent instance primary "
-#~ "key."
-
-#~ msgid ""
-#~ "Select a valid choice. That choice is not one of the available choices."
-#~ msgstr ""
-#~ "Maak een geldige keuze. Deze keuze behoort niet tot de mogelijkheden."
-
-#~ msgid "\"%(pk)s\" is not a valid value for a primary key."
-#~ msgstr "\"%(pk)s\" is geen geldige waarde voor een primary key."
-
 #~ msgid ""
 #~ "Hold down \"Control\", or \"Command\" on a Mac, to select more than one."
 #~ msgstr ""
 #~ "Houdt \"Control\", of \"Command\" op een Mac, ingedrukt om meer dan een "
 #~ "te selecteren."
 
-#~ msgid ""
-#~ "%(datetime)s couldn't be interpreted in time zone %(current_timezone)s; "
-#~ "it may be ambiguous or it may not exist."
-#~ msgstr ""
-#~ "%(datetime)s kon niet als tijdzone %(current_timezone)s worden "
-#~ "geïnterpreteerd; het kan dubbelzinnig zijn of het bestaat niet. "
-
-#~ msgid "Currently"
-#~ msgstr "Huidig"
-
-#~ msgid "Clear"
-#~ msgstr "Wis"
-
-#~ msgid "Unknown"
-#~ msgstr "Onbekend"
-
-#~ msgid "yes,no,maybe"
-#~ msgstr "ja,nee,misschien"
-
-#~ msgid "%s KB"
-#~ msgstr "%s KB"
-
-#~ msgid "%s MB"
-#~ msgstr "%s MB"
-
-#~ msgid "%s GB"
-#~ msgstr "%s GB"
-
-#~ msgid "%s TB"
-#~ msgstr "%s TB"
-
-#~ msgid "%s PB"
-#~ msgstr "%s PB"
-
-#~ msgid "p.m."
-#~ msgstr "p.m."
-
-#~ msgid "a.m."
-#~ msgstr "a.m."
-
-#~ msgid "AM"
-#~ msgstr "AM"
-
-#~ msgid "midnight"
-#~ msgstr "middernacht"
-
-#~ msgid "noon"
-#~ msgstr "'s middags"
-
-#~ msgid "Monday"
-#~ msgstr "maandag"
-
-#~ msgid "Tuesday"
-#~ msgstr "dinsdag"
-
-#~ msgid "Wednesday"
-#~ msgstr "woensdag"
-
-#~ msgid "Thursday"
-#~ msgstr "donderdag"
-
-#~ msgid "Friday"
-#~ msgstr "vrijdag"
-
-#~ msgid "Saturday"
-#~ msgstr "zaterdag"
-
-#~ msgid "Sunday"
-#~ msgstr "zondag"
-
-#~ msgid "Mon"
-#~ msgstr "ma"
-
-#~ msgid "Wed"
-#~ msgstr "wo"
-
-#~ msgid "Thu"
-#~ msgstr "do"
-
-#~ msgid "Fri"
-#~ msgstr "vrij"
-
-#~ msgid "Sat"
-#~ msgstr "za"
-
-#~ msgid "Sun"
-#~ msgstr "zo"
-
-#~ msgid "January"
-#~ msgstr "januari"
-
-#~ msgid "February"
-#~ msgstr "februari"
-
-#~ msgid "March"
-#~ msgstr "maart"
-
-#~ msgid "April"
-#~ msgstr "april"
-
-#~ msgid "May"
-#~ msgstr "mei"
-
-#~ msgid "June"
-#~ msgstr "juni"
-
-#~ msgid "July"
-#~ msgstr "juli"
-
-#~ msgid "August"
-#~ msgstr "augustus"
-
-#~ msgid "September"
-#~ msgstr "september"
-
-#~ msgid "October"
-#~ msgstr "oktober"
-
-#~ msgid "November"
-#~ msgstr "november"
-
-#~ msgid "December"
-#~ msgstr "december"
-
-#~ msgid "mar"
-#~ msgstr "mrt"
-
-#~ msgid "may"
-#~ msgstr "mei"
-
-#~ msgid "oct"
-#~ msgstr "okt"
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Jan."
-#~ msgstr "jan."
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Feb."
-#~ msgstr "feb."
-
-#~ msgctxt "abbrev. month"
-#~ msgid "March"
-#~ msgstr "maart"
-
-#~ msgctxt "abbrev. month"
-#~ msgid "April"
-#~ msgstr "april"
-
-#~ msgctxt "abbrev. month"
-#~ msgid "May"
-#~ msgstr "mei"
-
-#~ msgctxt "abbrev. month"
-#~ msgid "June"
-#~ msgstr "juni"
-
-#~ msgctxt "abbrev. month"
-#~ msgid "July"
-#~ msgstr "juli"
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Aug."
-#~ msgstr "aug."
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Sept."
-#~ msgstr "sep."
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Oct."
-#~ msgstr "okt."
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Nov."
-#~ msgstr "nov."
-
-#~ msgctxt "abbrev. month"
-#~ msgid "Dec."
-#~ msgstr "dec."
-
-#~ msgctxt "alt. month"
-#~ msgid "January"
-#~ msgstr "januari"
-
-#~ msgctxt "alt. month"
-#~ msgid "February"
-#~ msgstr "februari"
-
-#~ msgctxt "alt. month"
-#~ msgid "March"
-#~ msgstr "maart"
-
-#~ msgctxt "alt. month"
-#~ msgid "April"
-#~ msgstr "april"
-
-#~ msgctxt "alt. month"
-#~ msgid "May"
-#~ msgstr "mei"
-
-#~ msgctxt "alt. month"
-#~ msgid "June"
-#~ msgstr "juni"
-
-#~ msgctxt "alt. month"
-#~ msgid "July"
-#~ msgstr "juli"
-
-#~ msgctxt "alt. month"
-#~ msgid "August"
-#~ msgstr "augustus"
-
-#~ msgctxt "alt. month"
-#~ msgid "September"
-#~ msgstr "september"
-
-#~ msgctxt "alt. month"
-#~ msgid "October"
-#~ msgstr "oktober"
-
-#~ msgctxt "alt. month"
-#~ msgid "November"
-#~ msgstr "november"
-
-#~ msgctxt "alt. month"
-#~ msgid "December"
-#~ msgstr "december"
-
 #~ msgid "Neither Pillow nor PIL could be imported: %s"
 #~ msgstr "Zowel Pillow als PIL kon niet worden geïmporteerd: %s"
-
-#~ msgid "The '_imaging' module for the PIL could not be imported: %s"
-#~ msgstr "De '_imaging' module voor de PIL kon niet worden geïmporteerd: %s"
-
-#~ msgid "This is not a valid IPv6 address."
-#~ msgstr "Dit is geen geldig IPv6-adres."
-
-#~ msgid "or"
-#~ msgstr "of"
-
-#~ msgid ", "
-#~ msgstr ", "
-
-#~ msgid "%d year"
-#~ msgid_plural "%d years"
-#~ msgstr[0] "%d jaar"
-#~ msgstr[1] "%d jaar"
-
-#~ msgid "%d month"
-#~ msgid_plural "%d months"
-#~ msgstr[0] "%d maand"
-#~ msgstr[1] "%d maanden"
-
-#~ msgid "%d week"
-#~ msgid_plural "%d weeks"
-#~ msgstr[0] "%d week"
-#~ msgstr[1] "%d weken"
-
-#~ msgid "%d day"
-#~ msgid_plural "%d days"
-#~ msgstr[0] "%d dag"
-#~ msgstr[1] "%d dagen"
-
-#~ msgid "%d hour"
-#~ msgid_plural "%d hours"
-#~ msgstr[0] "%d uur"
-#~ msgstr[1] "%d uur"
-
-#~ msgid "%d minute"
-#~ msgid_plural "%d minutes"
-#~ msgstr[0] "%d minuut"
-#~ msgstr[1] "%d minuten"
-
-#~ msgid "0 minutes"
-#~ msgstr "0 minuten"
-
-#~ msgid "Directory indexes are not allowed here."
-#~ msgstr "Directory indexen zijn hier niet toegestaan."
-
-#~ msgid "\"%(path)s\" does not exist"
-#~ msgstr "\"%(path)s\" bestaat niet"
-
-#~ msgid "Index of %(directory)s"
-#~ msgstr "Index van %(directory)s"
-
-#~ msgid "No year specified"
-#~ msgstr "Geen jaar opgegeven"
-
-#~ msgid "No month specified"
-#~ msgstr "Geen maand opgegeven"
-
-#~ msgid "No day specified"
-#~ msgstr "Geen dag opgegeven"
-
-#~ msgid "No week specified"
-#~ msgstr "Geen week opgegeven"
-
-#~ msgid "No %(verbose_name_plural)s available"
-#~ msgstr "Geen %(verbose_name_plural)s beschikbaar"
-
-#~ msgid ""
-#~ "Future %(verbose_name_plural)s not available because %(class_name)s."
-#~ "allow_future is False."
-#~ msgstr ""
-#~ "Toekomstige %(verbose_name_plural)s is niet beschikbaar omdat "
-#~ "%(class_name)s allow_future False is."
-
-#~ msgid "Invalid date string '%(datestr)s' given format '%(format)s'"
-#~ msgstr ""
-#~ "Ongeldige datumstring '%(datestr)s' opgegeven, indeling '%(format)s'"
-
-#~ msgid "No %(verbose_name)s found matching the query"
-#~ msgstr "Geen %(verbose_name)s gevonden die de query matched"
-
-#~ msgid "Page is not 'last', nor can it be converted to an int."
-#~ msgstr "Pagina is niet 'last', kan ook niet worden omgezet in een int."
-
-#~ msgid "Invalid page (%(page_number)s): %(message)s"
-#~ msgstr "Ongeldige pagina (%(page_number)s): %(message)s"
-
-#~ msgid "Empty list and '%(class_name)s.allow_empty' is False."
-#~ msgstr "Lege lijst en '%(class_name)s.allow_empty' is False."
 
 #~ msgid "field_1"
 #~ msgstr "veld_1"
@@ -3499,9 +6327,6 @@ msgstr "Wachtwoord opnieuw ingesteld"
 
 #~ msgid "test"
 #~ msgstr "test"
-
-#~ msgid "Error."
-#~ msgstr "Fout."
 
 #~ msgid "Anything"
 #~ msgstr "Wat dan ook"
@@ -3574,9 +6399,6 @@ msgstr "Wachtwoord opnieuw ingesteld"
 
 #~ msgid "This literal should be included."
 #~ msgstr "Deze literal moet worde opgenomen."
-
-#~ msgid "name"
-#~ msgstr "naam"
 
 #~ msgid "once"
 #~ msgstr "eenmaal"
@@ -3697,9 +6519,6 @@ msgstr "Wachtwoord opnieuw ingesteld"
 
 #~ msgid "Email:"
 #~ msgstr "Gebruikersnaam"
-
-#~ msgid "view"
-#~ msgstr "toon"
 
 #~ msgid "Video"
 #~ msgstr "video"

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -539,8 +539,8 @@ class GlossListView(ListView):
 
         try:
             dataset_object = Dataset.objects.get(name=self.dataset_name)
-        except:
-            messages.add_message(self.request, messages.ERROR, _('No dataset with name '+self.dataset_name+' found.'))
+        except ObjectDoesNotExist:
+            messages.add_message(self.request, messages.ERROR, _('No dataset with that name found.'))
             return HttpResponseRedirect(URL + settings.PREFIX_URL + '/signs/search/')
 
         # make sure the user can write to this dataset
@@ -557,9 +557,9 @@ class GlossListView(ListView):
         ecv_file = write_ecv_file_for_dataset(self.dataset_name)
 
         if ecv_file:
-            messages.add_message(self.request, messages.INFO, ('ECV ' + self.dataset_name + ' successfully updated.'))
+            messages.add_message(self.request, messages.INFO, _('ECV successfully updated.'))
         else:
-            messages.add_message(self.request, messages.INFO, ('No ECV created for ' + self.dataset_name))
+            messages.add_message(self.request, messages.INFO, _('No ECV created for dataset.'))
         return HttpResponseRedirect(URL + settings.PREFIX_URL + '/signs/search/')
 
     # noinspection PyInterpreter,PyInterpreter
@@ -4277,9 +4277,9 @@ class DatasetListView(ListView):
             send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [owner.email])
 
         if not dataset_manager_found:
-            messages.add_message(self.request, messages.ERROR, ('No dataset manager has been found for '+dataset_object.name+'. Your request could not be submitted.'))
+            messages.add_message(self.request, messages.ERROR, _('No dataset manager was found. Your request could not be submitted.'))
         else:
-            messages.add_message(self.request, messages.INFO, ('Your request for view access to dataset '+dataset_object.name+' has been submitted.'))
+            messages.add_message(self.request, messages.INFO, _('Your request for view access to the dataset has been submitted.'))
         return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/available')
 
     def render_to_ecv_export_response(self, context):
@@ -4318,16 +4318,16 @@ class DatasetListView(ListView):
         # make sure the dataset is non-empty, don't create an empty ecv file
         dataset_count = dataset_object.count_glosses()
         if not dataset_count:
-            messages.add_message(self.request, messages.INFO, ('The dataset '+self.dataset_name+' is empty, export ECV is not available.'))
+            messages.add_message(self.request, messages.INFO, _('The dataset is empty, export ECV is not available.'))
             return HttpResponseRedirect(reverse('admin_dataset_view'))
 
         # if we get to here, the user is authenticated and has permission to export the dataset
         ecv_file = write_ecv_file_for_dataset(self.dataset_name)
 
         if ecv_file:
-            messages.add_message(self.request, messages.INFO, ('ECV ' + self.dataset_name + ' successfully updated.'))
+            messages.add_message(self.request, messages.INFO, _('ECV successfully updated.'))
         else:
-            messages.add_message(self.request, messages.INFO, ('No ECV created for ' + self.dataset_name))
+            messages.add_message(self.request, messages.INFO, _('No ECV created for the dataset.'))
         # return HttpResponse('ECV successfully updated.')
         return HttpResponseRedirect(reverse('admin_dataset_view'))
 
@@ -4501,7 +4501,7 @@ class DatasetManagerView(ListView):
             username = get['username']
         if username == '':
             messages.add_message(self.request, messages.ERROR,
-                                 ('Username must be non-empty. Please make a selection using the drop-down list.'))
+                                 _('Username must be non-empty. Please make a selection using the drop-down list.'))
             return None, HttpResponseRedirect(reverse('admin_dataset_manager'))
 
         try:
@@ -4565,18 +4565,16 @@ class DatasetManagerView(ListView):
             if dataset_object in get_objects_for_user(user_object, 'view_dataset', Dataset, accept_global_perms=False):
                 if user_object.is_staff or user_object.is_superuser:
                     messages.add_message(self.request, messages.INFO,
-                                     ('User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                      ') already has view permission for this dataset as staff or superuser.'))
+                                     _('User already has view permission for this dataset as staff or superuser.'))
                 else:
                     messages.add_message(self.request, messages.INFO,
-                                     ('User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                      ') already has view permission for this dataset.'))
+                                     _('User already has view permission for this dataset.'))
                 return HttpResponseRedirect(reverse('admin_dataset_manager')+'?'+manage_identifier)
 
             try:
                 assign_perm('view_dataset', user_object, dataset_object)
                 messages.add_message(self.request, messages.INFO,
-                                 ('View permission for user ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name + ') successfully granted.'))
+                                 _('View permission for user successfully granted.'))
 
                 if not user_object.is_active:
                     user_object.is_active = True
@@ -4605,7 +4603,7 @@ class DatasetManagerView(ListView):
                 send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [user_object.email])
 
             except:
-                messages.add_message(self.request, messages.ERROR, ('Error assigning view dataset permission to user '+username+'.'))
+                messages.add_message(self.request, messages.ERROR, _('Error assigning view dataset permission to user.'))
             return HttpResponseRedirect(reverse('admin_dataset_manager')+'?'+manage_identifier)
 
         if 'add_change_perm' in self.request.GET:
@@ -4613,20 +4611,15 @@ class DatasetManagerView(ListView):
             if dataset_object in get_objects_for_user(user_object, 'change_dataset', Dataset, accept_global_perms=False):
                 if user_object.is_staff or user_object.is_superuser:
                     messages.add_message(self.request, messages.INFO,
-                                         (
-                                         'User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                         ') already has change permission for this dataset as staff or superuser.'))
+                                         _('User already has change permission for this dataset as staff or superuser.'))
                 else:
                     messages.add_message(self.request, messages.INFO,
-                                 ('User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                  ') already has change permission for this dataset.'))
+                                 _('User already has change permission for this dataset.'))
                 return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
 
             if not dataset_object in get_objects_for_user(user_object, 'view_dataset', Dataset, accept_global_perms=False):
                 messages.add_message(self.request, messages.WARNING,
-                                     (
-                                     'User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                     ') does not have view permission for this dataset. Please grant view permission first.'))
+                                     _('User does not have view permission for this dataset. Please grant view permission first.'))
 
                 # open Manage View Dataset pane instead of Manage Change Dataset
                 manage_identifier = 'dataset_' + dataset_object.acronym.replace(' ', '')
@@ -4641,9 +4634,9 @@ class DatasetManagerView(ListView):
                     assign_perm('dictionary.add_gloss', user_object)
 
                 messages.add_message(self.request, messages.INFO,
-                                     ('Change permission for user ' + username + ' successfully granted.'))
+                                     _('Change permission for user successfully granted.'))
             except:
-                messages.add_message(self.request, messages.ERROR, ('Error assigning change dataset permission to user '+username+'.'))
+                messages.add_message(self.request, messages.ERROR, _('Error assigning change dataset permission to user.'))
             return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
 
         if 'delete_view_perm' in self.request.GET:
@@ -4652,9 +4645,7 @@ class DatasetManagerView(ListView):
             if dataset_object in get_objects_for_user(user_object, 'view_dataset', Dataset, accept_global_perms=False):
                 if user_object.is_staff or user_object.is_superuser:
                     messages.add_message(self.request, messages.ERROR,
-                                         (
-                                         'User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                         ') has view permission for this dataset as staff or superuser. This cannot be modified here.'))
+                                         _('User has view permission for this dataset as staff or superuser. This cannot be modified here.'))
                 else:
                     # can remove permission
                     try:
@@ -4663,14 +4654,14 @@ class DatasetManagerView(ListView):
                         remove_perm('view_dataset', user_object, dataset_object)
                         remove_perm('change_dataset', user_object, dataset_object)
                         messages.add_message(self.request, messages.INFO,
-                                             ('View (and change) permission for user ' + username + ' successfully revoked.'))
+                                             _('View (and change) permission for user successfully revoked.'))
                     except:
                         messages.add_message(self.request, messages.ERROR,
-                                             ('Error revoking view dataset permission for user ' + username + '.'))
+                                             _('Error revoking view dataset permission for user.'))
 
                 return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
             else:
-                messages.add_message(self.request, messages.ERROR, ('User '+username+' currently has no permission to view this dataset.'))
+                messages.add_message(self.request, messages.ERROR, _('User currently has no permission to view this dataset.'))
                 return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
 
         if 'delete_change_perm' in self.request.GET:
@@ -4681,9 +4672,7 @@ class DatasetManagerView(ListView):
             if dataset_object in datasets_user_can_change:
                 if user_object.is_staff or user_object.is_superuser:
                     messages.add_message(self.request, messages.ERROR,
-                                         (
-                                         'User ' + username + ' (' + user_object.first_name + ' ' + user_object.last_name +
-                                         ') has change permission for this dataset as staff or superuser. This cannot be modified here.'))
+                                         _('User has change permission for this dataset as staff or superuser. This cannot be modified here.'))
                 else:
                     # can remove permission
                     try:
@@ -4695,14 +4684,14 @@ class DatasetManagerView(ListView):
                             remove_perm('dictionary.change_gloss', user_object)
                             remove_perm('dictionary.add_gloss', user_object)
                         messages.add_message(self.request, messages.INFO,
-                                             ('Change permission for user ' + username + ' successfully revoked.'))
+                                             _('Change permission for user successfully revoked.'))
                     except:
                         messages.add_message(self.request, messages.ERROR,
-                                             ('Error revoking change dataset permission for user ' + username + '.'))
+                                             _('Error revoking change dataset permission for user.'))
 
                 return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
             else:
-                messages.add_message(self.request, messages.ERROR, ('User '+username+' currently has no permission to change this dataset.'))
+                messages.add_message(self.request, messages.ERROR, _('User currently has no permission to change this dataset.'))
                 return HttpResponseRedirect(reverse('admin_dataset_manager') + '?' + manage_identifier)
 
         # the code doesn't seem to get here. if somebody puts something else in the url (else case), there is no (hidden) csrf token.
@@ -4981,7 +4970,7 @@ class DatasetDetailView(DetailView):
         dataset_object.save()
 
         messages.add_message(self.request, messages.INFO,
-                     ('User ' + username + ' successfully made (co-)owner of this dataset.'))
+                     _('User successfully made (co-)owner of this dataset.'))
 
         return HttpResponseRedirect(URL + settings.PREFIX_URL + '/datasets/' + dataset_object.acronym)
 

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -1129,8 +1129,8 @@ class GlossDetailView(DetailView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested gloss does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,
@@ -1695,8 +1695,8 @@ class GlossRelationsDetailView(DetailView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested gloss does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,
@@ -2563,9 +2563,8 @@ class HandshapeDetailView(DetailView):
         try:
             # GET A HANDSHAPE OBJECT WITH THE REQUESTED MACHINE VALUE
             # see if Handshape object exists for this machine_value
-            self.object = self.get_object()
-
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             # SEE IF THERE IS A FIELDCHOICE FOR THIS HANDSHAPE MACHINE VALUE
             # check to see if this handshape has been created but not yet viewed
             # if that is the case, create a new handshape object and view that,
@@ -3512,8 +3511,8 @@ class GlossFrequencyView(DetailView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested gloss does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,
@@ -4853,8 +4852,8 @@ class DatasetDetailView(DetailView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested dataset does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,
@@ -5309,8 +5308,8 @@ class DatasetFrequencyView(DetailView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested dataset does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,
@@ -5703,8 +5702,8 @@ class MorphemeDetailView(DetailView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested morpheme does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,
@@ -7081,8 +7080,8 @@ class LemmaUpdateView(UpdateView):
             show_dataset_interface = False
 
         try:
-            self.object = self.get_object()
-        except ObjectDoesNotExist:
+            self.object = super().get_object()
+        except (Http404, ObjectDoesNotExist):
             translated_message = _('The requested lemma does not exist.')
             return render(request, 'dictionary/warning.html',
                           {'warning': translated_message,

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -4530,15 +4530,15 @@ class DatasetManagerView(ListView):
                 dataset_object.default_language = language
                 dataset_object.save()
                 messages.add_message(self.request, messages.INFO,
-                                     ('The default language of {} is set to {}.'
+                                     _('The default language of {} is set to {}.'
                                       .format(dataset_object.acronym, language.name)))
             else:
                 messages.add_message(self.request, messages.INFO,
-                                     ('{} is not in the set of languages of dataset {}.'
+                                     _('{} is not in the set of languages of dataset {}.'
                                       .format(language.name, dataset_object.acronym)))
-        except:
+        except (ObjectDoesNotExist, KeyError):
             messages.add_message(self.request, messages.ERROR,
-                                 ('Something went wrong setting the default language for '
+                                 _('Something went wrong setting the default language for '
                                   + dataset_object.acronym))
         return HttpResponseRedirect(reverse('admin_dataset_manager'))
 
@@ -6870,7 +6870,7 @@ def create_lemma_for_gloss(request, glossid):
                 lemmaidglosstranslation__text__exact=value.upper(),
                 dataset=dataset)
             if len(lemmas_for_this_language_and_annotation_idgloss) != 0:
-                messages.add_message(request, messages.ERROR, _('Lemma ID Gloss not unique for %(language)s.') % {'language': language.name})
+                messages.add_message(request, messages.ERROR, _('Lemma ID Gloss not unique for language.'))
                 return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
     if form.is_valid():

--- a/signbank/dictionary/templates/dictionary/add_gloss.html
+++ b/signbank/dictionary/templates/dictionary/add_gloss.html
@@ -5,7 +5,9 @@
 {% load bootstrap3 %}
 {% load tagging_tags %}
 {% load wrong_sign %}
-{% block bootstrap3_title %}Signbank: Add New Sign{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Add New Sign{% endblocktrans %}
+{% endblock %}
 
 {% load guardian_tags %}
 

--- a/signbank/dictionary/templates/dictionary/add_lemma.html
+++ b/signbank/dictionary/templates/dictionary/add_lemma.html
@@ -3,7 +3,9 @@
 {% load stylesheet %}
 {% load bootstrap3 %}
 {% load guardian_tags %}
-{% block bootstrap3_title %}Signbank: Create New Lemma{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Create New Lemma{% endblocktrans %}
+{% endblock %}
 
 {% block extrajs %}
 

--- a/signbank/dictionary/templates/dictionary/add_morpheme.html
+++ b/signbank/dictionary/templates/dictionary/add_morpheme.html
@@ -5,7 +5,9 @@
 {% load bootstrap3 %}
 {% load tagging_tags %}
 {% load wrong_sign %}
-{% block bootstrap3_title %}Signbank: Add New Morpheme{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Add New Morpheme{% endblocktrans %}
+{% endblock %}
 
 {% load guardian_tags %}
 

--- a/signbank/dictionary/templates/dictionary/admin_configure_handshapes.html
+++ b/signbank/dictionary/templates/dictionary/admin_configure_handshapes.html
@@ -5,7 +5,7 @@
 {% load bootstrap3 %}
 
 {% block bootstrap3_title %}
-{% blocktrans %}Configure Derivation History{% endblocktrans %}
+{% blocktrans %}Configure Handshapes{% endblocktrans %}
 {% endblock %}
 
 {% load guardian_tags %}
@@ -13,16 +13,16 @@
 {% block content %}
 
 <br/><br/>
-{% if not USE_DERIVATIONHISTORY %}
-<p>{% trans "Derivation History is not supported by your Signbank configuration." %}</p>
+{% if not USE_HANDSHAPE %}
+<p>{% trans "Handshapes are not supported by your Signbank configuration." %}</p>
 {% elif not user.is_superuser %}
-<p>{% trans "You do not have permission to configure Derivation Histories." %}</p>
+<p>{% trans "You do not have permission to configure Handshapes." %}</p>
 {% elif already_set_up %}
-<p>{% trans "Derivation History has already been configured." %}</p>
+<p>{% trans "Handshapes are already configured." %}</p>
 {% elif not revisions %}
-<p>{% trans "No choices found for Derivation History in FieldChoice." %}</p>
+<p>{% trans "No choices found for Handshape in FieldChoice." %}</p>
 {% else %}
-<p>{% trans "The following field choices have been set up for derivation histories. They can be modified in Admin." %}</p>
+<p>{% trans "The following field choices have been set up for handshapes. They can be modified in Admin." %}</p>
 <div id="definitionblock" style="z-index:0;padding-top: 100px;">
     <table class="table table-condensed">
         <thead>
@@ -34,12 +34,12 @@
             </tr>
         </thead>
 
-        {% for revision in revisions %}
+        {% for handshape in handshapes %}
             <tr>
-                <td>{{revision.machine_value}}</td>
-                <td>{{revision.english_name}}</td>
-                <td>{{revision.dutch_name}}</td>
-                <td>{{revision.chinese_name}}</td>
+                <td>{{handshape.machine_value}}</td>
+                <td>{{handshape.english_name}}</td>
+                <td>{{handshape.dutch_name}}</td>
+                <td>{{handshape.chinese_name}}</td>
             </tr>
         {% endfor %}
 

--- a/signbank/dictionary/templates/dictionary/admin_dataset_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_list.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Available Datasets{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Available Datasets{% endblocktrans %}
+{% endblock %}
 
 
 {% block content %}

--- a/signbank/dictionary/templates/dictionary/admin_dataset_manager.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_manager.html
@@ -48,7 +48,9 @@
 
 {% endblock %}
 
-{% block bootstrap3_title %}Signbank: Manage Datasets{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Manage Datasets{% endblocktrans %}
+{% endblock %}
 
 {% block content %}
 <h3>{% trans "Manage Datasets" %}</h3>

--- a/signbank/dictionary/templates/dictionary/admin_dataset_select_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_select_list.html
@@ -4,7 +4,9 @@
 {% load bootstrap3 %}
 {% load guardian_tags %}
 
-{% block bootstrap3_title %}Signbank: Dataset Selection{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Dataset Selection{% endblocktrans %}
+{% endblock %}
 
 {% block extrajs %}
 <script type="text/javascript" src="{{ STATIC_URL }}js/jquery.jeditable.mini.js"></script>

--- a/signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Available Derivation Histories{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Available Derivation Histories{% endblocktrans %}
+{% endblock %}
 
 
 {% block content %}

--- a/signbank/dictionary/templates/dictionary/admin_frequency_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_frequency_list.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load annotation_idgloss_translation %}
 {% load bootstrap3 %}
-{% block bootstrap3_title %}Signbank: Frequency List{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Frequency List{% endblocktrans %}
+{% endblock %}
 
 {% block extrahead %}
 {% endblock %}
@@ -225,7 +227,7 @@ table {
     <div id="visibility_buttons">
          <table class='table table-condensed'>
                 <tr id='phonology_selection'>
-                    <td style="width:200px;"><label>Phonology</label></td>
+                    <td style="width:200px;"><label>{% trans "Phonology" %}</label></td>
                     <td>
                         <select id='id_Phonology'>
                             {% for f_field, f_label in field_labels_list %}
@@ -235,7 +237,7 @@ table {
                     </td>
                 </tr>
                 <tr id='semantics_selection'>
-                    <td><label>Semantics</label></td>
+                    <td><label>{% trans "Semantics" %}</label></td>
                     <td>
                         <select id='id_Semantics'>
                             {% for s_field, s_label in field_labels_semantics_list %}

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -5,7 +5,9 @@
 {% load bootstrap3 %}
 {% load tagging_tags %}
 {% load wrong_sign %}
-{% block bootstrap3_title %}Signbank: Search Signs{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Search Signs{% endblocktrans %}
+{% endblock %}
 {% block extrahead %}
 {% endblock %}
 

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list_colors.html
@@ -5,7 +5,9 @@
 {% load bootstrap3 %}
 {% load tagging_tags %}
 {% load wrong_sign %}
-{% block bootstrap3_title %}Signbank: Search Signs (Preview Colors){% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Search Signs (Preview Colors){% endblocktrans %}
+{% endblock %}
 {% block extrahead %}
 {% endblock %}
 

--- a/signbank/dictionary/templates/dictionary/admin_handshape_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_handshape_list.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load annotation_idgloss_translation %}
 {% load bootstrap3 %}
-{% block bootstrap3_title %}Signbank: Search Handshapes{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Search Handshapes{% endblocktrans %}
+{% endblock %}
 {% block extrahead %}
 {% endblock %}
 

--- a/signbank/dictionary/templates/dictionary/admin_homonyms_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_homonyms_list.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load annotation_idgloss_translation %}
 {% load bootstrap3 %}
-{% block bootstrap3_title %}Signbank: Homonym List{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Homonym List{% endblocktrans %}
+{% endblock %}
 
 {% block extrahead %}
 {% endblock %}

--- a/signbank/dictionary/templates/dictionary/admin_lemma_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_lemma_list.html
@@ -140,7 +140,7 @@ var paginate_by = '{{paginate_by}}';
         <button id='delete_lemmas' type="button"
                 data-toggle="modal" data-target="#deleteNoGlossesModal"
                 data-keyboard="false" data-backdrop="static"
-                class='btn btn-danger pull-right'>{% trans "Delete Lemma's with No Glosses" %}</button>
+                class='btn btn-danger pull-right'>{% trans "Delete Lemmas with No Glosses" %}</button>
 
     {% endif %}
 </div>
@@ -274,8 +274,8 @@ var paginate_by = '{{paginate_by}}';
                 <h2 id='modalTitleDelete'>{% trans "Delete Lemmas with No Glosses" %}</h2>
             </div>
             <div class='modal-body'>
-                <p>{% trans "This action will delete all lemmas without glosses and all associated translations belonging to those lemma's. It cannot be undone." %}</p>
-                <p>{% trans "You have chosen to delete" %} {{num_gloss_zero_matches}} {% trans "lemma's." %}</p>
+                <p>{% trans "This action will delete all lemmas without glosses and all associated translations belonging to those lemmas. It cannot be undone." %}</p>
+                <p>{% trans "You have chosen to delete" %} {{num_gloss_zero_matches}} {% trans "lemmas." %}</p>
              </div>
           <div class="modal-footer">
           <form id="delete-no-glosses-form" action='' method="POST">

--- a/signbank/dictionary/templates/dictionary/admin_lemma_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_lemma_list.html
@@ -4,7 +4,9 @@
 {% load bootstrap3 %}
 {% load guardian_tags %}
 
-{% block bootstrap3_title %}Signbank: Lemmas{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Lemmas{% endblocktrans %}
+{% endblock %}
 
 {% load annotation_idgloss_translation %}
 

--- a/signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Minimal Pairs list{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Minimal Pairs list{% endblocktrans %}
+{% endblock %}
 
 {% block extrahead %}
 {% endblock %}

--- a/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
@@ -5,7 +5,9 @@
 {% load bootstrap3 %}
 {% load tagging_tags %}
 {% load wrong_sign %}
-{% block bootstrap3_title %}Signbank: Search Morphemes{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Search Morphemes{% endblocktrans %}
+{% endblock %}
 {% block extrahead %}
 {% endblock %}
 

--- a/signbank/dictionary/templates/dictionary/admin_semanticfield_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_semanticfield_list.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Available Semantic Fields{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Available Semantic Fields{% endblocktrans %}
+{% endblock %}
 
 
 {% block content %}

--- a/signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html
+++ b/signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html
@@ -213,7 +213,9 @@ input[type="color"] {
 </style>
 {% endblock %}
 
-{% block bootstrap3_title %}Signbank: Manage Field Choice Colors{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Manage Field Choice Colors{% endblocktrans %}
+{% endblock %}
 
 {% block content %}
 

--- a/signbank/dictionary/templates/dictionary/dataset_field_choices.html
+++ b/signbank/dictionary/templates/dictionary/dataset_field_choices.html
@@ -49,7 +49,9 @@ $(document).ready(function(){
 </script>
 {% endblock %}
 
-{% block bootstrap3_title %}Signbank: Manage Field Choices{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Manage Field Choices{% endblocktrans %}
+{% endblock %}
 
 {% block content %}
 

--- a/signbank/dictionary/templates/dictionary/dataset_frequency.html
+++ b/signbank/dictionary/templates/dictionary/dataset_frequency.html
@@ -94,7 +94,9 @@ dd {
 </style>
 {% endblock %}
 
-{% block bootstrap3_title %}Signbank: Corpus Overview{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Corpus Overview{% endblocktrans %}
+{% endblock %}
 
 {% block content %}
 

--- a/signbank/dictionary/templates/dictionary/dataset_frequency.html
+++ b/signbank/dictionary/templates/dictionary/dataset_frequency.html
@@ -127,9 +127,10 @@ dd {
                 {% else %}
                 <p>{% trans "There is no metadata CSV file for this dataset." %}</p>
 
-                <p>A metadata file can be uploaded by the Dataset Manager via the Manage Datasets page.</p>
+                <p>{% trans "A metadata file can be uploaded by the Dataset Manager via the Manage Datasets page." %}</p>
 
-                <p>The metadata CSV currently supports:<br>
+                <p>{% trans "The metadata CSV currently supports:" %}<br>
+                <!-- This is an example of the Header of a metafile, the column headers are in English as shown, do not translate. -->
                         <div class="container" >
                           <table class="justify-content:center">
                             <tr>
@@ -150,7 +151,7 @@ dd {
                           </table>
                         </div>
                 </p>
-                <p>The header row of the CSV file should be (using tab as separator):<br/>
+                <p>{% trans "The header row of the CSV file should be (using tab as separator):" %}<br/>
                 <pre>
 <code>
 Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
@@ -177,7 +178,7 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
               </div>
               {% else %}
               <p>{% trans "There are no EAF files for this dataset." %}</p>
-              <p>EAF files can be uploaded by the Dataset Manager via the Manage Datasets page.</p>
+              <p>{% trans "EAF files can be uploaded by the Dataset Manager via the Manage Datasets page." %}</p>
               {% endif %}
           </td>
         </tr>

--- a/signbank/dictionary/templates/dictionary/dataset_frequency.html
+++ b/signbank/dictionary/templates/dictionary/dataset_frequency.html
@@ -274,6 +274,9 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
 <!--        </tr>-->
         <tr>
             <td>
+            {% if request.user|has_group:"Dataset_Manager" %}
+            {% get_obj_perms request.user for dataset as "dataset_perms" %}
+            {% if "change_dataset" in dataset_perms %}
             <form name='process_speakers_form' id='process_speakers_form' method='get'>
                 <div class="hidden">
                     <input name='dataset_name' class='form-control' value='{{dataset.acronym}}' >
@@ -283,6 +286,8 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
                             value='{{dataset.acronym}}'>{% if speakers %}{% trans "Refresh Metadata" %}{% else %}{% trans "Process Metadata" %}{% endif %}</button>
                 </div>
             </form>
+            {% endif %}
+            {% endif %}
             </td>
         </tr>
         <tr>
@@ -305,15 +310,20 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
                       <dd class="col-sm-2" id='datum_{{identifier}}'>{{creation_time}}</dd>
                       <dd class="col-sm-3" id='numglosses_{{identifier}}'>{{number_of_glosses}}</dd>
                       <dd class="col-sm-2">
-                   {% csrf_token %}
-                   <input type='hidden' name='sourceid' value='{{gloss.pk}}'>
-                            <div class='btn-group' >
-                                <button id="update_document_{{identifier}}" class="btn btn-primary" method='post'
-                                        onclick='return update_document(this)'
-                                        style="padding-top: 0; padding-bottom: 0; margin-top: 0;"
-                                        name='update_document'
-                                        value='{{identifier}}'>{{identifier}}</button>
-                            </div>
+                           {% if request.user|has_group:"Dataset_Manager" %}
+                           {% get_obj_perms request.user for dataset as "dataset_perms" %}
+                           {% if "change_dataset" in dataset_perms %}
+                           {% csrf_token %}
+                           <input type='hidden' name='sourceid' value='{{gloss.pk}}'>
+                                    <div class='btn-group' >
+                                        <button id="update_document_{{identifier}}" class="btn btn-primary" method='post'
+                                                onclick='return update_document(this)'
+                                                style="padding-top: 0; padding-bottom: 0; margin-top: 0;"
+                                                name='update_document'
+                                                value='{{identifier}}'>{{identifier}}</button>
+                                    </div>
+                            {% endif %}
+                            {% endif %}
                       </dd>
                       <dd class="col-sm-2" id='toelichting_{{identifier}}'>{{toelichting}}
                       </dd>
@@ -357,7 +367,12 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
                       <li class="list-group-item active row" style="padding: 0;">
                           <dt class="col-sm-2">{% trans "Document" %}</dt>
                           <dt class="col-sm-6">{% trans "Path" %}</dt>
+                          {% if request.user|has_group:"Dataset_Manager" %}
+                          {% get_obj_perms request.user for dataset as "dataset_perms" %}
+                          {% if "change_dataset" in dataset_perms %}
                           <dt class="col-sm-2">{% trans "Delete" %}</dt>
+                          {% endif %}
+                          {% endif %}
                       </li>
 
                   <list name="document_path_tuples"
@@ -375,12 +390,16 @@ Participant&#9;Region&#9;Age&#9;Gender&#9;Handedness
                             {% endif %} >
                         <dd class="col-sm-2">{{document_identifier}}</dd>
                         <dd class="col-sm-6" >{{path}}</dd>
-
-                        <dd class="col-sm-2" id='{{dataset.acronym}}_{{document_identifier}}_{{path}}' value=''
-                            name="{{dataset.acronym}}_{{document_identifier}}_{{path}}">
-                                <input type="checkbox" name="select_document:{{path}}"
-                                       id="select_document_{{path}}" value="{{path}}" >
-                        </dd>
+                           {% if request.user|has_group:"Dataset_Manager" %}
+                           {% get_obj_perms request.user for dataset as "dataset_perms" %}
+                           {% if "change_dataset" in dataset_perms %}
+                            <dd class="col-sm-2" id='{{dataset.acronym}}_{{document_identifier}}_{{path}}' value=''
+                                name="{{dataset.acronym}}_{{document_identifier}}_{{path}}">
+                                    <input type="checkbox" name="select_document:{{path}}"
+                                        id="select_document_{{path}}" value="{{path}}" >
+                            </dd>
+                           {% endif %}
+                           {% endif %}
                       </li>
                       {% endfor %}
                       {% endwith %}

--- a/signbank/dictionary/templates/dictionary/derivationhistory_detail.html
+++ b/signbank/dictionary/templates/dictionary/derivationhistory_detail.html
@@ -3,6 +3,10 @@
 {% load stylesheet %}
 {% load bootstrap3 %}
 
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Derivation History Details{% endblocktrans %}
+{% endblock %}
+
 {% load guardian_tags %}
 
 {% block extrajs %}

--- a/signbank/dictionary/templates/dictionary/gloss_frequency.html
+++ b/signbank/dictionary/templates/dictionary/gloss_frequency.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load annotation_idgloss_translation %}
 {% load bootstrap3 %}
-{% block bootstrap3_title %}Signbank: Gloss Frequency{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Gloss Frequency{% endblocktrans %}
+{% endblock %}
 {% load stylesheet %}
 
 {% block extrahead %}

--- a/signbank/dictionary/templates/dictionary/handshape_detail.html
+++ b/signbank/dictionary/templates/dictionary/handshape_detail.html
@@ -3,6 +3,10 @@
 {% load stylesheet %}
 {% load bootstrap3 %}
 
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Handshape Details{% endblocktrans %}
+{% endblock %}
+
 {% load guardian_tags %}
 
 {% block extrajs %}

--- a/signbank/dictionary/templates/dictionary/import_csv_create.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_create.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Import CSV{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Import CSV{% endblocktrans %}
+{% endblock %}
 
 {% block extrajs %}
     <script type="text/javascript" src="{{PREFIX_URL}}/static/js/bootstrap-filestyle.min.js"> </script>

--- a/signbank/dictionary/templates/dictionary/import_csv_update.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_update.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Import CSV{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Import CSV Update{% endblocktrans %}
+{% endblock %}
 
 {% block extrajs %}
     <script type="text/javascript" src="{{PREFIX_URL}}/static/js/bootstrap-filestyle.min.js"> </script>

--- a/signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html
+++ b/signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Import CSV Update Lemmas{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Import CSV Update Lemmas{% endblocktrans %}
+{% endblock %}
 
 {% block extrajs %}
     <script type="text/javascript" src="{{PREFIX_URL}}/static/js/bootstrap-filestyle.min.js"> </script>

--- a/signbank/dictionary/templates/dictionary/import_media.html
+++ b/signbank/dictionary/templates/dictionary/import_media.html
@@ -54,7 +54,7 @@
 
 {% if errors %}
 <div>
-<h3>Errors</h3>
+<h3>{% trans "Errors" %}</h3>
 <ul>
     {% for error in errors %}
     <li>{{error}}</li>

--- a/signbank/dictionary/templates/dictionary/import_media.html
+++ b/signbank/dictionary/templates/dictionary/import_media.html
@@ -5,7 +5,9 @@
 {% load guardian_tags %}
 {% load annotation_idgloss_translation %}
 
-{% block bootstrap3_title %}Signbank: Import Media{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Import Media{% endblocktrans %}
+{% endblock %}
 
 {% block content %}
 

--- a/signbank/dictionary/templates/dictionary/lemma_frequency.html
+++ b/signbank/dictionary/templates/dictionary/lemma_frequency.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load annotation_idgloss_translation %}
 {% load bootstrap3 %}
-{% block bootstrap3_title %}Signbank: Lemma Frequency{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Lemma Frequency{% endblocktrans %}
+{% endblock %}
 {% load stylesheet %}
 
 {% block extrahead %}

--- a/signbank/dictionary/templates/dictionary/recently_added_glosses.html
+++ b/signbank/dictionary/templates/dictionary/recently_added_glosses.html
@@ -7,7 +7,7 @@
 {% load wrong_sign %}
 
 {% block bootstrap3_title %}
-{% blocktrans %}Recently Ddded Signs{% endblocktrans %}
+{% blocktrans %}Recently Added Signs{% endblocktrans %}
 {% endblock %}
 
 {% block content %}

--- a/signbank/dictionary/templates/dictionary/semanticfield_detail.html
+++ b/signbank/dictionary/templates/dictionary/semanticfield_detail.html
@@ -13,6 +13,10 @@
     </script>
 {% endblock %}
 
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Semantic Field Details{% endblocktrans %}
+{% endblock %}
+
 {% block content %}
 
 <h3>{% trans "Semantic Field Detail View" %}</h3>

--- a/signbank/dictionary/templates/dictionary/unassigned_glosses.html
+++ b/signbank/dictionary/templates/dictionary/unassigned_glosses.html
@@ -3,7 +3,9 @@
 {% load bootstrap3 %}
 {% load guardian_tags %}
 
-{% block bootstrap3_title %}Signbank: Unassigned Glosses{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Unassigned Glosses{% endblocktrans %}
+{% endblock %}
 
 
 {% block content %}

--- a/signbank/dictionary/templates/dictionary/unused_videos.html
+++ b/signbank/dictionary/templates/dictionary/unused_videos.html
@@ -1,19 +1,28 @@
 {% extends "baselayout.html" %}
+{% load i18n %}
+{% load stylesheet %}
+{% load annotation_idgloss_translation %}
+{% load bootstrap3 %}
 
 {% block script %}
 
 {% endblock %}
 
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Unused Video Files{% endblocktrans %}
+{% endblock %}
+
 {% block content %}
 
-<h1>Unused video files and other unlinked files</h1>
+<h3>{% trans "Unused video files and other unlinked files" %}</h3>
 
-<p><i>Number of unused video files: {{ file_not_in_glossvideo_object|length }}</i></p>
+<p><i>{% trans "Number of unused video files" %}: {{ file_not_in_glossvideo_object|length }}</i></p>
 
 {% if file_not_in_glossvideo_object %}
-    <table class="table">
+    <table class='table table-condensed'>
+        <tr><th>{% trans "Dataset" %}</th><th style="width:300px;">{% trans "Folder (Gloss Prefix)" %}</th><th>{% trans "Filename" %}</th></tr>
         {% for file in file_not_in_glossvideo_object %}
-            <tr><td>{{ file }}</td></tr>
+            <tr><td>{{file.0}}</td><td>{{file.1}}</td><td>{{file.2}}</td></tr>
         {% endfor %}
     </table>
 {% endif %}

--- a/signbank/dictionary/templates/dictionary/update_lemma.html
+++ b/signbank/dictionary/templates/dictionary/update_lemma.html
@@ -3,7 +3,9 @@
 {% load bootstrap3 %}
 {% load i18n %}
 {% load guardian_tags %}
-{% block bootstrap3_title %}Signbank: Update Lemma{% endblock %}
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Update Lemma{% endblocktrans %}
+{% endblock %}
 
 {% load annotation_idgloss_translation %}
 

--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -81,7 +81,6 @@ urlpatterns = [
 
     url(r'^import_images/$', permission_required('dictionary.change_gloss')(signbank.dictionary.views.import_media),{'video':False}),
     url(r'^import_videos/$', permission_required('dictionary.change_gloss')(signbank.dictionary.views.import_media),{'video':True}),
-    # url(r'^import_other_media/$', permission_required('dictionary.change_gloss')(signbank.dictionary.views.import_other_media)),
     url(r'update_corpus_document_counts/(?P<dataset_id>.*)/(?P<document_id>.*)/$',
         permission_required('dictionary.change_gloss')(signbank.frequency.update_document_counts)),
     url(r'update_corpora/$',
@@ -93,10 +92,6 @@ urlpatterns = [
         permission_required('dictionary.change_gloss')(signbank.dictionary.views.configure_handshapes)),
     url(r'configure_derivationhistory/$',
         permission_required('dictionary.change_gloss')(signbank.dictionary.views.configure_derivationhistory)),
-    url(r'configure_speakers/(?P<datasetid>\d+)$',
-        permission_required('dictionary.change_gloss')(signbank.dictionary.views.configure_speakers_dataset)),
-    url(r'configure_corpus_documents/(?P<datasetid>\d+)$',
-        permission_required('dictionary.change_gloss')(signbank.dictionary.views.configure_corpus_documents_dataset)),
 
     url(r'get_unused_videos/$',permission_required('dictionary.change_gloss')(signbank.dictionary.views.get_unused_videos)),
     url(r'all_field_choices.tsv/$',signbank.dictionary.views.list_all_fieldchoice_names),

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -2510,7 +2510,6 @@ def get_unused_videos(request):
                         gloss_video_path = os.path.join(settings.GLOSS_VIDEO_DIRECTORY, acronym, folder, filename)
                         gloss_videos = GlossVideo.objects.filter(videofile=gloss_video_path, version=0)
                         if not gloss_videos:
-                            feedback_path = os.path.join(acronym, folder, filename)
                             file_not_in_glossvideo_object.append((acronym, folder, filename))
 
     return render(request, "dictionary/unused_videos.html",

--- a/signbank/feedback/models.py
+++ b/signbank/feedback/models.py
@@ -1,6 +1,8 @@
 from django.db import models, OperationalError, ProgrammingError
 from django.contrib.auth import models as authmodels
 from django.conf import settings
+from signbank.settings.base import COMMENT_VIDEO_LOCATION, WRITABLE_FOLDER
+import os
 from signbank.video.fields import VideoUploadToFLVField
 
 from signbank.dictionary.models import *
@@ -57,6 +59,17 @@ class GeneralFeedback(models.Model):
            
     class Meta:
         ordering = ['-date']
+
+    def has_video(self):
+        """Return the video object for this Feedback or None if no video available"""
+        if self.video:
+            filepath = os.path.join(settings.COMMENT_VIDEO_LOCATION, os.sep, self.video.path)
+        else:
+            filepath = ''
+        if filepath and os.path.exists(filepath.encode('utf-8')):
+            return self.video
+        else:
+            return ''
 
 class GeneralFeedbackForm(forms.Form):
     """Form for general feedback"""
@@ -280,4 +293,14 @@ class MissingSignFeedback(models.Model):
 
     class Meta:
         ordering = ['-date']
-    
+
+    def has_video(self):
+        """Return the video object for this Feedback or None if no video available"""
+        if self.video:
+            filepath = os.path.join(settings.COMMENT_VIDEO_LOCATION, os.sep, self.video.path)
+        else:
+            filepath = ''
+        if filepath and os.path.exists(filepath.encode('utf-8')):
+            return self.video
+        else:
+            return ''

--- a/signbank/feedback/templates/feedback/generalfeedback.html
+++ b/signbank/feedback/templates/feedback/generalfeedback.html
@@ -15,30 +15,34 @@
 
 {% block content %}
     <div class="col-md-6 col-md-offset-3">
-     <h2>General Feedback</h2>
+     <h2>{% trans "General Feedback" %}</h2>
 
-   <p>Please enter any comments you may have about this site and click
-   "submit" to send your feedback to us. We value your contributions and comments.</p>
+   <p>{% blocktrans trimmed %}
+       Please enter any comments you may have about this site and click
+   "submit" to send your feedback to us. We value your contributions and comments.
+   {% endblocktrans %}</p>
    
   <form method="post" name="general" enctype="multipart/form-data">
     {% csrf_token %}
     <div id="{{form.comment.name}}Div" class="formcomponent">
-      <label for='comment'>General comments, suggestions, or anything you feel like telling us.</label>
+      <label for='comment'>{% trans "General comments, suggestions, or anything you feel like telling us." %}</label>
       {%if form.comment.errors %}{{form.comment.errors}}{% endif %}
       {% bootstrap_field form.comment show_label=False %}
     </div>
 
     <div id="{{form.video.name}}Div" class="formcomponent">
-      <label for='video'>Upload your feedback as a video.</label>
+      <label for='video'>{% trans " Upload your feedback as a video." %}</label>
       {%if form.video.errors %}{{form.video.errors}}{% endif %}
       {% bootstrap_field form.video show_label=False %}
-      <p>NOTE: Video files can be quite large, and may take a long time to send.
-           Please be patient when submitting this feedback.</p>
+      <p>{% blocktrans trimmed %}
+          NOTE: Video files can be quite large, and may take a long time to send.
+           Please be patient when submitting this feedback.
+      {% endblocktrans %}</p>
     </div>
 
     <hr>
     <div class="formbuttons">
-      <input class='btn btn-primary' type="submit" value="Submit" class="submit" />
+      <input class='btn btn-primary' type="submit" value='{% trans "Submit" %}' class="submit" />
     </div>
     <hr>
   </form>

--- a/signbank/feedback/templates/feedback/missingsign.html
+++ b/signbank/feedback/templates/feedback/missingsign.html
@@ -1,7 +1,8 @@
-
-
 {% extends "baselayout.html" %}
+{% load i18n %}
+{% load stylesheet %}
 {% load bootstrap3 %}
+{% block bootstrap3_title %}Signbank: Missing Sign Feedback{% endblock %}
 
 {% block extrajs %}
 <script type='text/javascript'>
@@ -47,61 +48,74 @@ $(document).ready(function(){
 {% block content %}
   <div class="col-md-6 col-md-offset-3">
       
-      <h2>Missing Sign Feedback</h2>
+      <h2>{% trans "Missing Sign Feedback" %}</h2>
       
   {% if posted %}
 <div id="feedbackmessage">
     <p class='alert alert-info'>
-        Thank you for your feedback. 
+        {% trans "Thank you for your feedback." %}
     </p>
 </div>    
   {% else %}
-      <p>Please submit a video comment showing the sign you think is missing.</p>
-      <p>Please produce the sign in isolation and then in an example sentence.</p>
-      <p>Please also type in the English translation equivalent below as well as
-          your contact information (name and email address) so we can contact you for a follow up if need be.</p>
-      <p>Thank you for taking the time to contact us and help SignBank grow.</p>
+      <p>{% trans "Please submit a video comment showing the sign you think is missing." %}</p>
+      <p>{% trans "Please produce the sign in isolation and then in an example sentence." %}</p>
+      <p>{% blocktrans trimmed %}
+          Please also type in the English translation equivalent below as well as
+          your contact information (name and email address) so we can contact you for a follow up if need be.
+      {% endblocktrans %}</p>
+      <p>{% trans "Thank you for taking the time to contact us and help SignBank grow." %}</p>
 
 <form method="post" enctype="multipart/form-data" name="missingsign">
    {% csrf_token %}
-    <p>You may either upload a video that shows the missing sign or
+    <p>{% blocktrans trimmed %}
+        You may either upload a video that shows the missing sign or
     fill in details below. In either case, you should
     enter a meaning and any comments you might have in the text 
-    boxes at the bottom of the form. </p>
+    boxes at the bottom of the form.
+    {% endblocktrans %}</p>
 
-    <button class='btn btn-default' id="togglevideobutton">Video Comment</button>
+    <button class='btn btn-default' id="togglevideobutton">{% trans "Video Comment" %}</button>
     
  <fieldset id="videoupload">
-  <legend>Video Upload</legend>
+  <legend>{% trans "Video Upload" %}</legend>
   <div id="{{form.video.name}}div">
     {% bootstrap_label form.video.label %}
-    <p>Upload a video of the sign.</p>
+    <p>{% trans "Upload a video of the sign." %}</p>
     {% if form.video.errors %}{{form.video.errors}}{% endif %}
     {% bootstrap_field form.video show_label=False %}
        
-    <p>NOTE: Video files can be quite large, and may take a long time to send. 
-    Please be patient when submitting this feedback.</p>
+    <p>{% blocktrans trimmed %}
+        NOTE: Video files can be quite large, and may take a long time to send.
+    Please be patient when submitting this feedback.
+    {% endblocktrans %}</p>
   </div>
 </fieldset>
 
 
 <fieldset id="meaninginput">
-  <legend>Details</legend>
+  <legend>{% trans "Details" %}</legend>
     <div id="{{form.meaning.name}}div">
-        <p>Please explain the meaning of the new or missing sign, or enter individual English words that have the same meaning as this sign (i.e. keywords).</p>
+        <p>{% blocktrans trimmed %}
+            Please explain the meaning of the new or missing sign, or enter individual
+            English words that have the same meaning as this sign (i.e. keywords).
+        {% endblocktrans %}</p>
         {% if form.meaning.errors %}{{form.meaning.errors}}{% endif %}
         {% bootstrap_field form.meaning show_label=False %}
     </div>
 
     <div id="{{form.comments.name}}div">
-        <p>Are there any other comments you would like to give about this sign? For example, do you think there are other or extra keyword/s that belong with this sign? If so, please include your comments below.</p>
+        <p>{% blocktrans trimmed %}
+            Are there any other comments you would like to give about this sign? For example,
+            do you think there are other or extra keyword/s that belong with this sign?
+            If so, please include your comments below.
+        {% endblocktrans %}</p>
         {% if form.comments.errors %}{{form.comments.errors}}{% endif %}
         {% bootstrap_field form.comments show_label=False %}
     </div>
 </fieldset>
  
 <div class="formbuttons">
-  <input class='btn btn-primary' type="submit" value="Submit Feedback" class="submit" />
+  <input class='btn btn-primary' type="submit" value='{% trans "Submit Feedback" %}' class="submit" />
 </div>
 </form>
 

--- a/signbank/feedback/templates/feedback/show.html
+++ b/signbank/feedback/templates/feedback/show.html
@@ -2,7 +2,6 @@
 {% load i18n %}
 {% load stylesheet %}
 {% load bootstrap3 %}
-
 {% block bootstrap3_title %}Signbank: Feedback Overview{% endblock %}
 
 {% block extrahead %}
@@ -30,11 +29,7 @@ $(window).ready(function(){
     $('.commenthead').click(togglecomment);
 	
 	$('.commentbody').hide();
- 
-	$('.delete').confirm({
-	    msg:'Delete this comment?',
-	    timeout:3000
-	});
+
 });
 </script>
 <script type='text/javascript'>
@@ -46,8 +41,8 @@ $(window).ready(function(){
 
 {% block content %}
 {% url 'dictionary:protected_media' '' as protected_media_url %}
+
   <h3>{% trans "General Feedback" %}</h3>
-  
   {% for fb in general %}
     <div class="panel-group" id="general{{fb.id}}">
       <div class="panel panel-default">
@@ -61,7 +56,7 @@ $(window).ready(function(){
         </div>
         <div id="gencollapse{{fb.id}}" class="panel-collapse collapse">
   
-        {% if fb.video %}  
+        {% if fb.has_video %}
         <div class="videocontainer">
             <video id='genfbvid{{fb.id}}' class='video-js vjs-default-skin' 
                poster='{{posterurl}}' controls  preload='false' data-setup='{"example_option":true}'>
@@ -70,8 +65,6 @@ $(window).ready(function(){
             <p><a href='{{protected_media_url}}{{ fb.video }}'>Download video</a><br>
                 (if video does not play here you may be able to play by downloading)</p>
         </div>
-
-        
         {% endif %}
       
 	    <p>{{fb.comment}}</p>
@@ -110,7 +103,6 @@ $(window).ready(function(){
   {% endfor %} 
   
   <h3>{% trans "Sign Feedback" %}</h3>
-  
   {% for fb in signfb %}
     <div class="panel-group" id="sign{{fb.pk}}">
       <div class="panel panel-default">
@@ -183,7 +175,7 @@ $(window).ready(function(){
         <div id="missingcollapse{{fb.id}}" class="panel-collapse collapse">
     
         <p>Email: <a href="mailto:{{fb.user.email}}">{{fb.user.email}}</a></p>
-        {% if fb.video %}  
+        {% if fb.has_video %}
         <div class="videocontainer">
             <video id='msfb{{fb.id}}' class='video-js vjs-default-skin' 
                poster='{{posterurl}}' controls preload='false' data-setup='{"example_option":true}'>


### PR DESCRIPTION
This issue adds translation to the Headings and User Forms in the Feedback section.

It also fixes a bug with a missing Feedback Video.
It tests that the (previously uploaded as part of a Feedback comment) video exists on the file system.

On my local server this was generating errors because I don't necessarily have copies of videos that are on Global as part of Feedback. These files are located here:
https://github.com/Signbank/Global-signbank/blob/cbfe53d2b452a88068a7649e6e436f70ed906228/signbank/settings/server_specific/default.py#L11
This will also catch Feedback video files that have not been ported to a new server.