### PR TITLE
Issue #876: Updated code for finding variants.

### DIFF
--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -1350,13 +1350,29 @@ class Gloss(models.Model):
         return tagged_homonym_objects
 
     def get_stems(self):
-
+        # the original list comprehension does not work for Japanese
+        # stems = [(x.language, x.text[:-2])
+        #          for x in annotations if x.text[-2] == '-' and x.language == this_sign_language ]
+        # the code has been expanded
         if not self.lemma or not self.lemma.dataset:
             return []
+        annotations = self.annotationidglosstranslation_set.all()
+        if not annotations:
+            return []
         this_sign_language = self.lemma.dataset.default_language
-        stems = [(x.language, x.text[:-2])
-                 for x in self.annotationidglosstranslation_set.all() if x.text[-2] == '-' and x.language == this_sign_language ]
-
+        stems = []
+        for annotation in annotations:
+            if not annotation.language == this_sign_language:
+                continue
+            this_text = annotation.text
+            if len(this_text) < 2:
+                # not long enough to include suffix
+                continue
+            suffix_text = this_text[-2]
+            if suffix_text == '-':
+                # this matches the pattern
+                stem_text = this_text[:-2]
+                stems.append((this_sign_language, stem_text))
         return stems
 
     def gloss_relations(self):

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -1350,10 +1350,6 @@ class Gloss(models.Model):
         return tagged_homonym_objects
 
     def get_stems(self):
-        # the original list comprehension does not work for Japanese
-        # stems = [(x.language, x.text[:-2])
-        #          for x in annotations if x.text[-2] == '-' and x.language == this_sign_language ]
-        # the code has been expanded
         if not self.lemma or not self.lemma.dataset:
             return []
         annotations = self.annotationidglosstranslation_set.all()

--- a/signbank/dictionary/templates/dictionary/find_and_save_variants.html
+++ b/signbank/dictionary/templates/dictionary/find_and_save_variants.html
@@ -1,0 +1,41 @@
+{% extends "baselayout.html" %}
+{% load stylesheet %}
+{% load bootstrap3 %}
+{% load i18n %}
+
+{% block bootstrap3_title %}
+{% blocktrans %}Find and Save Variants{% endblocktrans %}
+{% endblock %}
+
+{% load guardian_tags %}
+
+{% block content %}
+
+<h3>{% trans "Pattern Variants" %}</h3>
+
+{% if too_many_datasets %}
+<p>{% trans "Please choose a single dataset to use this functionality." %}</p>
+{% else %}
+<div id="variants_table" style="z-index:0;padding-top: 100px;">
+    <table class="table table-condensed">
+         <thead>
+             <tr>
+                 <th style="width:10em; text-align:left;">Focus Gloss ID</th>
+                 <th style="width:30em; text-align:left;">Focus Gloss Annotations</th>
+                 <th style="width:30em; text-align:left;">Variant Relations (Semantic)</th>
+                 <th style="width:30em; text-align:left;">Candidate Variants (Syntactic)</th>
+             </tr>
+         </thead>
+        <tbody>
+        {% for row, tuple in gloss_pattern_table.items %}
+            <tr>
+                {% for column in tuple %}
+                <td>{{column}}</td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
+{% endblock %}

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -2240,7 +2240,6 @@ def change_dataset_selection(request):
         if selected_dataset_acronyms:
             user_profile = UserProfile.objects.get(user=user)
             for dataset_name in selected_dataset_acronyms:
-                print(dataset_name, type(dataset_name))
                 try:
                     dataset = Dataset.objects.get(acronym=dataset_name)
                     user_profile.selected_datasets.add(dataset)

--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -85,7 +85,7 @@ urlpatterns = [
     url(r'update_corpora/$',
         permission_required('dictionary.change_gloss')(signbank.frequency.update_corpora)),
 
-    url(r'find_and_save_variants/$',permission_required('dictionary.change_gloss')(signbank.dictionary.views.find_and_save_variants)),
+    url(r'find_and_save_variants/$',login_required(signbank.dictionary.views.find_and_save_variants), name='find_and_save_variants'),
 
     url(r'get_unused_videos/$',permission_required('dictionary.change_gloss')(signbank.dictionary.views.get_unused_videos)),
     url(r'package/$', signbank.dictionary.views.package),


### PR DESCRIPTION
This issue revises the `find_and_save_variants` code in `views.py`.

- accommodates datasets and selected datasets
- non Latin languages (e.g., Japanese)
- makes use of a template (used to have hard-coded html)
- identifies focus glosses with annotations of pattern ending in -A, -B, ...
- displays a table showing other glosses that end in a different letter that are not related in some other way
- does not update anything, merely displays the patterns it finds (it used to save variants as new relations)

The code for `get_stems` (the pattern before the suffix) has been flattened out in order to work with non-Latin character sets.
The list comprehension did not work on Japanese.
See screenshots in the issue.
The code for actually saving the found variants has been commented. This can be added as a button after getting feedback on usage. Originally it was foreseen that this code would be run in a cron job.
