### PR TITLE
Fixed database test by changing gloss api test setup method

### DIFF
--- a/signbank/dictionary/tests.py
+++ b/signbank/dictionary/tests.py
@@ -3475,54 +3475,55 @@ def decode_messages(data):
 
 class GlossApiGetSignNameAndMediaInfoTests(TestCase):
 
-
     @classmethod
-    def setUpTestData(cls):
+    def setUpTestData(self):
 
-        cls.dataset = 0
-        cls.results = 50
-        cls.search_term = "test"
-        cls.gloss_name = 'test'
-        cls.gloss_id = 0
-        cls.video_url = 'test_video_url'
-        cls.file_path = path.join(settings.WRITABLE_FOLDER, cls.video_url)
+        self.dataset = 0
+        self.results = 50
+        self.search_term = "test_gloss_api"
+        self.gloss_name = 'test_gloss_api'
+        self.gloss_id = 0
+        self.video_url = 'test_video_url_in_gloss_api_tests'
+        self.file_path = path.join(settings.WRITABLE_FOLDER, self.video_url)
 
-        cls.factory = RequestFactory()
+        self.factory = RequestFactory()
 
-        # Create a language for the dataset and sign language models
-        language = Language.objects.create()
+        # Use a default dataset
+        dataset_name = settings.DEFAULT_DATASET
+        test_dataset = Dataset.objects.get(name=dataset_name)
+        self.dataset = test_dataset.id
 
-        # Create a sign language for the dataset
-        sign_language = SignLanguage.objects.create()
-
-        # Create a dataset and save the id for the filter
-        test_dataset = Dataset.objects.create(name=cls.gloss_name, signlanguage_id=sign_language.id,  default_language_id=language.id)
-        test_dataset.translation_languages.add(language)
-        cls.dataset = test_dataset.id
+        # Use default language
+        language = Language.objects.get(id=get_default_language_id())
 
         # Create a lemma and a translation so the api method can filter on the text
-        test_lemma = LemmaIdgloss.objects.create(dataset_id=test_dataset.id)
-        LemmaIdglossTranslation.objects.create(text=cls.gloss_name, lemma_id=test_lemma.id, language=language)
+        test_lemma = LemmaIdgloss(dataset=test_dataset)
+        test_lemma.save()
+
+        test_lemmaidglosstranslation = LemmaIdglossTranslation(text=self.gloss_name, lemma=test_lemma, language=language)
+        test_lemmaidglosstranslation.save()
 
         # Create a with a video that the api should return
-        gloss = Gloss.objects.create(lemma=test_lemma, inWeb=True)
-        GlossVideo.objects.create(gloss_id=gloss.id, videofile=cls.video_url)
-        cls.gloss_id = gloss.id
 
+        new_gloss = Gloss()
+        new_gloss.lemma = test_lemma
+        new_gloss.inWeb = True
+        new_gloss.save()
+        self.gloss_id = new_gloss.id
+
+        test_gloss_video = GlossVideo(gloss=new_gloss)
+        test_gloss_video.videofile = self.video_url
+        test_gloss_video.save()
+
+    def setUp(self):
         # Create the file for the video which the gloss will return when get_video_url is called
-        Path(cls.file_path).mkdir()
+        if not os.path.exists(self.file_path):
+            Path(self.file_path).mkdir()
 
-        # Create extra data which the api should not return because they are filtert out of the data
-        # Gloss without a video
-        Gloss.objects.create(lemma=test_lemma, inWeb=True)
-
-        # Gloss that is not in the public dictionary
-        Gloss.objects.create(lemma=test_lemma, inWeb=False)
-
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
         # Remove video path
-        Path(cls.file_path).rmdir()
+        if os.path.exists(self.file_path):
+            Path(self.file_path).rmdir()
 
     def test_other_request_methode_then_GET_or_POST(self):
         """


### PR DESCRIPTION
The test did not run because the gloss video folder was deleted when the test class was done running.
Now the folder is created before a single test and after that test it is also deleted and that seems to fix the problem.

I am not sure what the actual problem was, another test probably used the folder when it was removed.

There are still 4 failures and errors but i believe those have nothing to do with this problem (but again not sure)

Linked this branch to issue 882 Running tests in production container doesn't work