### PR TITLE
Don't show annotation language parentheses by default

### DIFF
--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -862,7 +862,8 @@ option:not(:checked) {
             {% for lang, annotation_idgloss_translation in annotation_idgloss.items %}
             <tr>
                 <th>
-                    {% trans "Annotation ID Gloss" %} ({{lang}})
+                    {% trans "Annotation ID Gloss" %}
+                    {% if SHOW_DATASET_INTERFACE_OPTIONS %} ({{ lang }}) {% endif %}
                 </th>
                 <td class='edit edit_text' id='annotation_idgloss_{{lang.language_code_2char}}' colspan="2">{{annotation_idgloss_translation}}</td>
                 <td>


### PR DESCRIPTION
This is a super small thing, but I'd like a thumbs up from at least one of you before I merge to master. 

The context:
* ASL signbank doesn't use our dataset functionality, as they have only 1
* As a consequence, they also have no 'translation language' for 'annotation ID gloss'
* This resulted in weird empty parentheses in the gloss detail view

![image](https://github.com/Signbank/Global-signbank/assets/1909317/0469e497-037b-4378-af31-931a11369704)
