### PR TITLE
Fix for ordering of sentences that already existed

### DIFF
--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -354,9 +354,7 @@ def sort_examplesentence(request, senseid, glossid, order, direction):
     gloss = Gloss.objects.get(id=glossid)
     sense_examplesentences_matching_order = SenseExamplesentence.objects.filter(sense=sense, order=order).count()
     if sense_examplesentences_matching_order != 1:
-        print('sort_examplesentence: multiple or no match for order: ', senseid, str(order))
-        messages.add_message(request, messages.ERROR, _('Could not sort this examplesentence.'))
-        return HttpResponseRedirect(reverse('dictionary:admin_gloss_view', kwargs={'pk': gloss.id}))
+        sense.reorder_examplesentences()
 
     senseexamplesentence = SenseExamplesentence.objects.get(sense=sense, order=order)
     swaporder = 0


### PR DESCRIPTION
Small fix: if sentences already existed before the last migration they have the default order 1 so this gave a problem when moving one up or down. Instead they first need to be given the right order number and then can be moved just fine. 