### PR TITLE
ClearForm Reset and Streamline Handshapes and Morphemes

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -1015,7 +1015,8 @@ class SenseListView(ListView):
         if 'sentenceContains' in get and get['sentenceContains'] not in ['', '0']:
             query_parameters['sentenceContains'] = get['sentenceContains']
             sentence_translations_with_this_text = ExampleSentenceTranslation.objects.filter(text__icontains=get['sentenceContains'])
-            qs = qs.filter(sense__exampleSentences__in=sentence_translations_with_this_text)
+            sentences_with_this_text = [est.examplesentence for est in sentence_translations_with_this_text]
+            qs = qs.filter(sense__exampleSentences__in=sentences_with_this_text).distinct()
 
         # save the query parameters to a session variable
         self.request.session['query_parameters'] = json.dumps(query_parameters)

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -238,7 +238,7 @@ class GlossListView(ListView):
         context = super(GlossListView, self).get_context_data(**kwargs)
 
         set_up_language_fields(Gloss, self, self.search_form)
-        set_up_signlanguage_dialects_fields(Gloss, self, self.search_form)
+        set_up_signlanguage_dialects_fields(self, self.search_form)
 
         context = get_context_data_for_list_view(self.request, self, self.kwargs, context)
         self.queryset_language_codes = context['queryset_language_codes']
@@ -809,7 +809,7 @@ class SenseListView(ListView):
         context = super(SenseListView, self).get_context_data(**kwargs)
 
         set_up_language_fields(GlossSense, self, self.search_form)
-        set_up_signlanguage_dialects_fields(GlossSense, self, self.search_form)
+        set_up_signlanguage_dialects_fields(self, self.search_form)
 
         context = get_context_data_for_list_view(self.request, self, self.kwargs, context)
 

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -965,7 +965,6 @@ class SenseListView(ListView):
             qs = qs.order_by('gloss__id', 'order')
             return qs
 
-        # No filters or 'show_all' specified? show nothing
         else:
             qs = GlossSense.objects.none()
 
@@ -974,18 +973,11 @@ class SenseListView(ListView):
         else:
             qs = qs.filter(gloss__inWeb__exact=True)
 
-        # If we wanted to get everything, we're done now
         if show_all:
             return qs
 
-        # this is a temporary query_parameters variable
-        # it is saved to self.query_parameters after the parameters are processed
-        query_parameters = dict()
-
-        # If not, we will go trhough a long list of filters
         if 'search' in get and get['search']:
             val = get['search']
-            query_parameters['search'] = val
             from signbank.tools import strip_control_characters
             val = strip_control_characters(val)
             query = Q(gloss__annotationidglosstranslation__text__iregex=val)
@@ -995,10 +987,14 @@ class SenseListView(ListView):
 
             qs = qs.filter(query)
 
+        qs = queryset_glosssense_from_get('GlossSense', GlossSearchForm, self.search_form, get, qs)
+        query_parameters = query_parameters_from_get('GlossSense', GlossSearchForm, self.search_form, get)
+
+        # this is a temporary query_parameters variable
+        # it is saved to self.query_parameters after the parameters are processed
+
         if self.search_type != 'sign':
             query_parameters['search_type'] = self.search_type
-
-        qs = queryset_glosssense_from_get('GlossSense', GlossSearchForm, self.search_form, get, qs)
 
         if 'sentenceType[]' in get:
             vals = get.getlist('sentenceType[]')

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -7036,7 +7036,7 @@ class LemmaListView(ListView):
             num_gloss_zero_matches = 0
         else:
             num_gloss_zero_matches = results.filter(num_gloss=0).count()
-        return (results,num_gloss_zero_matches)
+        return results,num_gloss_zero_matches
 
     def get_context_data(self, **kwargs):
         context = super(LemmaListView, self).get_context_data(**kwargs)
@@ -7057,6 +7057,10 @@ class LemmaListView(ListView):
         context['paginate_by'] = self.request.GET.get('paginate_by', self.paginate_by)
 
         (results, num_gloss_zero_matches) = self.get_annotated_queryset()
+
+        # this is set to avoid showing page numbers for non-existent pages after annotation filtering
+        context['is_paginated'] = results.count() > self.paginate_by
+
         context['search_results'] = results
         context['num_gloss_zero_matches'] = num_gloss_zero_matches
         context['lemma_count'] = LemmaIdgloss.objects.filter(dataset__in=selected_datasets).count()

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -62,7 +62,7 @@ from signbank.dictionary.update_senses_mapping import delete_empty_senses
 from signbank.dictionary.consistency_senses import consistent_senses, check_consistency_senses, \
     reorder_sensetranslations, reorder_senses
 from signbank.query_parameters import convert_query_parameters_to_filter, pretty_print_query_fields, pretty_print_query_values, \
-    query_parameters_this_gloss, apply_language_filters_to_results, search_fields_from_get, queryset_from_get
+    query_parameters_this_gloss, apply_language_filters_to_results, search_fields_from_get, queryset_from_get, set_up_model_translations
 from signbank.search_history import available_query_parameters_in_search_history, languages_in_query, display_parameters, \
     get_query_parameters, save_query_parameters, fieldnames_from_query_parameters
 from signbank.frequency import import_corpus_speakers, configure_corpus_documents_for_dataset, update_corpus_counts, \
@@ -2492,6 +2492,10 @@ class MorphemeListView(ListView):
         # Call the base implementation first to get a context
         context = super(MorphemeListView, self).get_context_data(**kwargs)
 
+        # this is needed because the MorphemeSearchForm is initialized without the request and
+        # the model translation language is unknown
+        set_up_model_translations(self.search_form)
+
         selected_datasets = get_selected_datasets_for_user(self.request.user)
         dataset_languages = get_dataset_languages(selected_datasets)
         context['dataset_languages'] = dataset_languages
@@ -2661,7 +2665,6 @@ class MorphemeListView(ListView):
             return qs
 
         qs = queryset_from_get(MorphemeSearchForm, self.search_form, get, qs)
-
         qs = qs.distinct()
 
         # Sort the queryset by the parameters given

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -64,7 +64,8 @@ from signbank.dictionary.consistency_senses import consistent_senses, check_cons
     reorder_sensetranslations, reorder_senses
 from signbank.query_parameters import convert_query_parameters_to_filter, pretty_print_query_fields, pretty_print_query_values, \
     query_parameters_this_gloss, apply_language_filters_to_results, search_fields_from_get, queryset_from_get, \
-    set_up_fieldchoice_translations, set_up_language_fields
+    set_up_fieldchoice_translations, set_up_language_fields, set_up_signlanguage_dialects_fields, \
+    queryset_glosssense_from_get, query_parameters_from_get
 from signbank.search_history import available_query_parameters_in_search_history, languages_in_query, display_parameters, \
     get_query_parameters, save_query_parameters, fieldnames_from_query_parameters
 from signbank.frequency import import_corpus_speakers, configure_corpus_documents_for_dataset, update_corpus_counts, \
@@ -222,18 +223,27 @@ class GlossListView(ListView):
     queryset_language_codes = []
     query_parameters = dict()
     search_form_data = QueryDict(mutable=True)
+    search_form = GlossSearchForm()
 
     def get_template_names(self):
         return ['dictionary/admin_gloss_list.html']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        fields_with_choices = fields_to_fieldcategory_dict(settings.GLOSS_CHOICE_FIELDS)
+        set_up_fieldchoice_translations(self.search_form, fields_with_choices)
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context
         context = super(GlossListView, self).get_context_data(**kwargs)
 
+        set_up_language_fields(Gloss, self, self.search_form)
+        set_up_signlanguage_dialects_fields(Gloss, self, self.search_form)
+
         context = get_context_data_for_list_view(self.request, self, self.kwargs, context)
         self.queryset_language_codes = context['queryset_language_codes']
 
-        context = get_context_data_for_gloss_search_form(self.request, self, self.kwargs, context)
+        context = get_context_data_for_gloss_search_form(self.request, self, self.search_form, self.kwargs, context)
 
         # it is necessary to sort the object list by lemma_id in order for all glosses with the same lemma to be grouped
         # correctly in the template
@@ -615,7 +625,6 @@ class GlossListView(ListView):
 
         return response
 
-
     def get_queryset(self):
         get = self.request.GET
 
@@ -751,257 +760,39 @@ class GlossListView(ListView):
         if self.search_type != 'sign':
             query_parameters['search_type'] = self.search_type
 
-        # Evaluate all gloss/language search fields
-        for get_key, get_value in get.items():
-            if get_key == 'csrfmiddlewaretoken':
-                continue
-            if get_key.startswith(GlossSearchForm.gloss_search_field_prefix) and get_value != '':
+        qs = queryset_glosssense_from_get(Gloss, GlossSearchForm, self.search_form, get, qs)
+        query_parameters = query_parameters_from_get(Gloss, GlossSearchForm, self.search_form, get)
 
-                query_parameters[get_key] = get_value
-                language_code_2char = get_key[len(GlossSearchForm.gloss_search_field_prefix):]
-                language = Language.objects.filter(language_code_2char=language_code_2char).first()
-                qs = qs.filter(annotationidglosstranslation__text__iregex=get_value,
-                               annotationidglosstranslation__language=language)
-            elif get_key.startswith(GlossSearchForm.lemma_search_field_prefix) and get_value != '':
-                query_parameters[get_key] = get_value
-                language_code_2char = get_key[len(GlossSearchForm.lemma_search_field_prefix):]
-                language = Language.objects.filter(language_code_2char=language_code_2char).first()
-                qs = qs.filter(lemma__lemmaidglosstranslation__text__iregex=get_value,
-                               lemma__lemmaidglosstranslation__language=language)
-            elif get_key.startswith(GlossSearchForm.keyword_search_field_prefix) and get_value != '':
-                query_parameters[get_key] = get_value
-                language_code_2char = get_key[len(GlossSearchForm.keyword_search_field_prefix):]
-                language = Language.objects.filter(language_code_2char=language_code_2char).first()
-                qs = qs.filter(translation__translation__text__iregex=get_value,
-                               translation__language=language)
-                
-        if 'translation' in get and get['translation'] != '':
-            val = get['translation']
-            query_parameters['translation'] = get['translation']
-            qs = qs.filter(senses__senseTranslations__translations__translation__text__iregex=val)
+        # # Evaluate all gloss/language search fields
+        # for get_key, get_value in get.items():
 
-        if 'inWeb' in get and get['inWeb'] != '0':
-            # Don't apply 'inWeb' filter, if it is unspecified ('0' according to the NULLBOOLEANCHOICES)
-            val = get['inWeb'] == '2'
-            query_parameters['inWeb'] = get['inWeb']
-            qs = qs.filter(inWeb__exact=val)
+        #     elif get_key.startswith(GlossSearchForm.keyword_search_field_prefix) and get_value != '':
+        #         query_parameters[get_key] = get_value
+        #         language_code_2char = get_key[len(GlossSearchForm.keyword_search_field_prefix):]
+        #         language = Language.objects.filter(language_code_2char=language_code_2char).first()
+        #         qs = qs.filter(translation__translation__text__iregex=get_value,
+        #                        translation__language=language)
+        #
+        # if 'translation' in get and get['translation'] != '':
+        #     val = get['translation']
+        #     query_parameters['translation'] = get['translation']
+        #     qs = qs.filter(senses__senseTranslations__translations__translation__text__iregex=val)
+        #
 
-        if 'excludeFromEcv' in get and get['excludeFromEcv'] != '0':
-            # Don't apply 'excludeFromEcv' filter, if it is unspecified ('0' according to the NULLBOOLEANCHOICES)
-            val = get['excludeFromEcv'] == '2'
-            query_parameters['excludeFromEcv'] = get['excludeFromEcv']
-            qs = qs.filter(excludeFromEcv__exact=val)
-
-        if 'hasvideo' in get and get['hasvideo'] not in ['unspecified', '0']:
-            val = get['hasvideo'] != '2'
-            query_parameters['hasvideo'] = get['hasvideo']
-            qs = qs.filter(glossvideo__isnull=val)
-
-        if 'hasothermedia' in get and get['hasothermedia'] not in ['unspecified', '0']:
-            query_parameters['hasothermedia'] = get['hasothermedia']
-
-            # Remember the pk of all glosses that have other media
-            pks_for_glosses_with_othermedia = [ om.parent_gloss.pk for om in OtherMedia.objects.all() ]
-
-            if get['hasothermedia'] == '2': #We only want glosses with other media
-                qs = qs.filter(pk__in=pks_for_glosses_with_othermedia)
-            elif get['hasothermedia'] == '3': #We only want glosses without other media
-                qs = qs.exclude(pk__in=pks_for_glosses_with_othermedia)
-
-        if 'defspublished' in get and get['defspublished'] not in ['0', 'unspecified']:
-            val = get['defspublished'] == 'yes'
-            query_parameters['defspublished'] = get['defspublished']
-            qs = qs.filter(definition__published=val)
-
-        if 'hasmultiplesenses' in get and get['hasmultiplesenses'] not in ['0', 'unspecified']:
-            val = get['hasmultiplesenses'] == 'yes'
-            query_parameters['hasmultiplesenses'] = get['hasmultiplesenses']
-            if val:
-                multiple_senses = [gsv['gloss'] for gsv in GlossSense.objects.values(
-                    'gloss').annotate(Count('id')).filter(id__count__gt=1)]
-            else:
-                multiple_senses = [gsv['gloss'] for gsv in GlossSense.objects.values(
-                    'gloss').annotate(Count('id')).filter(id__count=1)]
-            qs = qs.filter(id__in=multiple_senses)
-
-        fieldnames = FIELDS['main']+FIELDS['phonology']+FIELDS['semantics']+['inWeb', 'isNew']
-        if not settings.USE_DERIVATIONHISTORY and 'derivHist' in fieldnames:
-            fieldnames.remove('derivHist')
-
-        # SignLanguage and basic property filters
-        # allows for multiselect
-        vals = get.getlist('dialect[]')
-        if vals != []:
-            query_parameters['dialect[]'] = vals
-            qs = qs.filter(dialect__in=vals)
-
-        vals = get.getlist('tags[]')
-        if vals != []:
-            query_parameters['tags[]'] = vals
-            glosses_with_tag = list(
-                TaggedItem.objects.filter(tag__name__in=vals).values_list('object_id', flat=True))
-            qs = qs.filter(id__in=glosses_with_tag)
-
-        # allows for multiselect
-        vals = get.getlist('signlanguage[]')
-        if vals != []:
-            query_parameters['signlanguage[]'] = vals
-            qs = qs.filter(signlanguage__in=vals)
-
-        if 'useInstr' in get and get['useInstr'] != '':
-            query_parameters['useInstr'] = get['useInstr']
-            qs = qs.filter(useInstr__icontains=get['useInstr'])
-
-        fields_with_choices = fields_to_fieldcategory_dict()
-        for fieldnamemulti in fields_with_choices.keys():
-            fieldnamemultiVarname = fieldnamemulti + '[]'
-            fieldnameQuery = fieldnamemulti + '__machine_value__in'
-
-            vals = get.getlist(fieldnamemultiVarname)
-            if vals != []:
-                query_parameters[fieldnamemultiVarname] = vals
-                if fieldnamemulti == 'semField':
-                    qs = qs.filter(semField__in=vals)
-                elif fieldnamemulti == 'derivHist':
-                    qs = qs.filter(derivHist__in=vals)
-                else:
-                    qs = qs.filter(**{ fieldnameQuery: vals })
-
-        ## phonology and semantics field filters
-        fieldnames = [ f for f in fieldnames if f not in fields_with_choices.keys() ]
-        for fieldname in fieldnames:
-
-            if fieldname in get and get[fieldname] != '':
-                field_obj = Gloss.get_field(fieldname)
-
-                if type(field_obj) in [CharField,TextField] and not hasattr(field_obj, 'field_choice_category'):
-                    key = fieldname + '__icontains'
-                else:
-                    key = fieldname + '__exact'
-
-                val = get[fieldname]
-
-                if isinstance(field_obj,BooleanField):
-                    val = {'0':'','1': None, '2': True, '3': False}[val]
-
-                if val != '':
-                    query_parameters[fieldname] = get[fieldname]
-
-                    kwargs = {key:val}
-                    qs = qs.filter(**kwargs)
-
-        qs = qs.distinct()
-
-        if 'relationToForeignSign' in get and get['relationToForeignSign'] != '':
-            query_parameters['relationToForeignSign'] = get['relationToForeignSign']
-
-            relations = RelationToForeignSign.objects.filter(other_lang_gloss__icontains=get['relationToForeignSign'])
-            potential_pks = [relation.gloss.pk for relation in relations]
-            qs = qs.filter(pk__in=potential_pks)
-
-        if 'hasRelationToForeignSign' in get and get['hasRelationToForeignSign'] != '0':
-            query_parameters['hasRelationToForeignSign'] = get['hasRelationToForeignSign']
-
-            pks_for_glosses_with_relations = [relation.gloss.pk for relation in RelationToForeignSign.objects.all()]
-
-            if get['hasRelationToForeignSign'] == '1': #We only want glosses with a relation to a foreign sign
-                qs = qs.filter(pk__in=pks_for_glosses_with_relations)
-            elif get['hasRelationToForeignSign'] == '2': #We only want glosses without a relation to a foreign sign
-                qs = qs.exclude(pk__in=pks_for_glosses_with_relations)
-
-        if 'relation' in get and get['relation'] != '':
-            query_parameters['relation'] = get['relation']
-
-            potential_targets = Gloss.objects.filter(annotationidglosstranslation__text__iregex=get['relation'])
-            relations = Relation.objects.filter(target__in=potential_targets)
-            potential_pks = [relation.source.pk for relation in relations]
-            qs = qs.filter(pk__in=potential_pks)
-
-        if 'hasRelation' in get and get['hasRelation'] != '':
-            query_parameters['hasRelation'] = get['hasRelation']
-
-            #Find all relations with this role
-            if get['hasRelation'] == 'all':
-                relations_with_this_role = Relation.objects.all()
-            else:
-                relations_with_this_role = Relation.objects.filter(role__exact=get['hasRelation'])
-
-            #Remember the pk of all glosses that take part in the collected relations
-            pks_for_glosses_with_correct_relation = [relation.source.pk for relation in relations_with_this_role]
-            qs = qs.filter(pk__in=pks_for_glosses_with_correct_relation)
-
-        if 'morpheme' in get and get['morpheme'] != '':
-            query_parameters['morpheme'] = get['morpheme']
-
-            # morpheme is an integer
-            input_morpheme = get['morpheme']
-            # Filter all glosses that contain this morpheme in their simultaneous morphology
-            try:
-                selected_morpheme = Morpheme.objects.get(pk=get['morpheme'])
-                potential_pks = [appears.parent_gloss.pk for appears in SimultaneousMorphologyDefinition.objects.filter(morpheme=selected_morpheme)]
-                qs = qs.filter(pk__in=potential_pks)
-            except ObjectDoesNotExist:
-                # This error should not occur, the input search form requires the selection of a morpheme from a list
-                # If the user attempts to input a string, it is ignored by the gloss list search form
-                print("Morpheme not found: ", str(input_morpheme))
-
-        if 'hasComponentOfType[]' in get:
-            vals = get.getlist('hasComponentOfType[]')
-            if vals != []:
-                query_parameters['hasComponentOfType[]'] = vals
-
-                morphdefs_with_correct_role = MorphologyDefinition.objects.filter(role__machine_value__in=vals)
-                pks_for_glosses_with_morphdefs_with_correct_role = [morphdef.parent_gloss.pk for morphdef in morphdefs_with_correct_role]
-                qs = qs.filter(pk__in=pks_for_glosses_with_morphdefs_with_correct_role)
-
-        if 'hasMorphemeOfType' in get and get['hasMorphemeOfType'] not in ['', '0']:
-            query_parameters['hasMorphemeOfType'] = get['hasMorphemeOfType']
-
-            morpheme_type = get['hasMorphemeOfType']
-            # Get all Morphemes of the indicated mrpType
-            target_morphemes = [ m.id for m in Morpheme.objects.filter(mrpType__machine_value=morpheme_type) ]
-            qs = qs.filter(id__in=target_morphemes)
-
-        if 'definitionRole[]' in get:
-
-            vals = get.getlist('definitionRole[]')
-            if vals != []:
-                query_parameters['definitionRole[]'] = vals
-                #Find all definitions with this role
-                definitions_with_this_role = Definition.objects.filter(role__machine_value__in=vals)
-
-                #Remember the pk of all glosses that are referenced in the collection definitions
-                pks_for_glosses_with_these_definitions = [definition.gloss.pk for definition in definitions_with_this_role]
-                qs = qs.filter(pk__in=pks_for_glosses_with_these_definitions)
-
-        if 'definitionContains' in get and get['definitionContains'] not in ['', '0']:
-            query_parameters['definitionContains'] = get['definitionContains']
-
-            definitions_with_this_text = Definition.objects.filter(text__icontains=get['definitionContains'])
-
-            #Remember the pk of all glosses that are referenced in the collection definitions
-            pks_for_glosses_with_these_definitions = [definition.gloss.pk for definition in definitions_with_this_text]
-            qs = qs.filter(pk__in=pks_for_glosses_with_these_definitions)
-
-        if 'createdBefore' in get and get['createdBefore'] != '':
-            query_parameters['createdBefore'] = get['createdBefore']
-
-            created_before_date = DT.datetime.strptime(get['createdBefore'], settings.DATE_FORMAT).date()
-            qs = qs.filter(creationDate__range=(EARLIEST_GLOSS_CREATION_DATE,created_before_date))
-
-        if 'createdAfter' in get and get['createdAfter'] != '':
-            query_parameters['createdAfter'] = get['createdAfter']
-
-            created_after_date = DT.datetime.strptime(get['createdAfter'], settings.DATE_FORMAT).date()
-            qs = qs.filter(creationDate__range=(created_after_date,DT.datetime.now()))
-
-        if 'createdBy' in get and get['createdBy'] != '':
-            query_parameters['createdBy'] = get['createdBy']
-
-            created_by_search_string = ' '.join(get['createdBy'].strip().split()) # remove redundant spaces
-            qs = qs.annotate(
-                created_by=Concat('creator__first_name', V(' '), 'creator__last_name', output_field=CharField())) \
-                .filter(created_by__icontains=created_by_search_string)
+# if 'morpheme' in get and get['morpheme'] != '':
+#     query_parameters['morpheme'] = get['morpheme']
+#
+#     # morpheme is an integer
+#     input_morpheme = get['morpheme']
+#     # Filter all glosses that contain this morpheme in their simultaneous morphology
+#     try:
+#         selected_morpheme = Morpheme.objects.get(pk=get['morpheme'])
+# potential_pks = [appears.parent_gloss.pk for appears in SimultaneousMorphologyDefinition.objects.filter(morpheme=selected_morpheme)]
+#         qs = qs.filter(pk__in=potential_pks)
+#     except ObjectDoesNotExist:
+#         # This error should not occur, the input search form requires the selection of a morpheme from a list
+#         # If the user attempts to input a string, it is ignored by the gloss list search form
+#         print("Morpheme not found: ", str(input_morpheme))
 
         # save the query parameters to a session variable
         self.request.session['query_parameters'] = json.dumps(query_parameters)
@@ -1036,14 +827,23 @@ class SenseListView(ListView):
     query_parameters = dict()
     search_form_data = QueryDict(mutable=True)
     template_name = 'dictionary/admin_senses_list.html'
+    search_form = GlossSearchForm()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        fields_with_choices = fields_to_fieldcategory_dict(settings.GLOSSSENSE_CHOICE_FIELDS)
+        set_up_fieldchoice_translations(self.search_form, fields_with_choices)
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context
         context = super(SenseListView, self).get_context_data(**kwargs)
 
+        set_up_language_fields(GlossSense, self, self.search_form)
+        set_up_signlanguage_dialects_fields(GlossSense, self, self.search_form)
+
         context = get_context_data_for_list_view(self.request, self, self.kwargs, context)
 
-        context = get_context_data_for_gloss_search_form(self.request, self, self.kwargs, context)
+        context = get_context_data_for_gloss_search_form(self.request, self, self.search_form, self.kwargs, context)
 
         context['sensecount'] = Sense.objects.filter(glosssense__gloss__lemma__dataset__in=context['selected_datasets']).count()
 
@@ -1231,226 +1031,33 @@ class SenseListView(ListView):
         if self.search_type != 'sign':
             query_parameters['search_type'] = self.search_type
 
-        # Evaluate all gloss/language search fields
-        for get_key, get_value in get.items():
-            if get_key == 'csrfmiddlewaretoken':
-                continue
-            if get_key.startswith(GlossSearchForm.gloss_search_field_prefix) and get_value != '':
-
-                query_parameters[get_key] = get_value
-                language_code_2char = get_key[len(GlossSearchForm.gloss_search_field_prefix):]
-                language = Language.objects.filter(language_code_2char=language_code_2char).first()
-                qs = qs.filter(gloss__annotationidglosstranslation__text__iregex=get_value,
-                               gloss__annotationidglosstranslation__language=language)
-            elif get_key.startswith(GlossSearchForm.lemma_search_field_prefix) and get_value != '':
-                query_parameters[get_key] = get_value
-                language_code_2char = get_key[len(GlossSearchForm.lemma_search_field_prefix):]
-                language = Language.objects.filter(language_code_2char=language_code_2char).first()
-                qs = qs.filter(gloss__lemma__lemmaidglosstranslation__text__iregex=get_value,
-                               gloss__lemma__lemmaidglosstranslation__language=language)
-            elif get_key.startswith(GlossSearchForm.keyword_search_field_prefix) and get_value != '':
-                query_parameters[get_key] = get_value
-                language_code_2char = get_key[len(GlossSearchForm.keyword_search_field_prefix):]
-                language = Language.objects.filter(language_code_2char=language_code_2char)
-                qs = qs.filter(sense__senseTranslations__translations__translation__text__iregex=get_value)
-                qs = qs.filter(sense__senseTranslations__translations__language__in=language)
-
-        if 'inWeb' in get and get['inWeb'] != '0':
-            # Don't apply 'inWeb' filter, if it is unspecified ('0' according to the NULLBOOLEANCHOICES)
-            val = get['inWeb'] == '2'
-            query_parameters['inWeb'] = get['inWeb']
-            qs = qs.filter(gloss__inWeb__exact=val)
-
-        if 'excludeFromEcv' in get and get['excludeFromEcv'] != '0':
-            # Don't apply 'excludeFromEcv' filter, if it is unspecified ('0' according to the NULLBOOLEANCHOICES)
-            val = get['excludeFromEcv'] == '2'
-            query_parameters['excludeFromEcv'] = get['excludeFromEcv']
-            qs = qs.filter(gloss__excludeFromEcv__exact=val)
-
-        if 'hasvideo' in get and get['hasvideo'] not in ['unspecified', '0']:
-            val = get['hasvideo'] != '2'
-            query_parameters['hasvideo'] = get['hasvideo']
-            qs = qs.filter(gloss__glossvideo__isnull=val)
-
-        if 'hasothermedia' in get and get['hasothermedia'] not in ['unspecified', '0']:
-            query_parameters['hasothermedia'] = get['hasothermedia']
-
-            # Remember the pk of all glosses that have other media
-            pks_for_glosses_with_othermedia = [om.parent_gloss.pk for om in OtherMedia.objects.all()]
-
-            if get['hasothermedia'] == '2':  # We only want glosses with other media
-                qs = qs.filter(gloss__pk__in=pks_for_glosses_with_othermedia)
-            elif get['hasothermedia'] == '3':  # We only want glosses without other media
-                qs = qs.exclude(gloss__pk__in=pks_for_glosses_with_othermedia)
-
-        if 'defspublished' in get and get['defspublished'] not in ['0', 'unspecified']:
-            val = get['defspublished'] == 'yes'
-            query_parameters['defspublished'] = get['defspublished']
-            qs = qs.filter(gloss__definition__published=val)
-
-        if 'hasmultiplesenses' in get and get['hasmultiplesenses'] not in ['0', 'unspecified']:
-            val = get['hasmultiplesenses'] == 'yes'
-            query_parameters['hasmultiplesenses'] = get['hasmultiplesenses']
-            if val:
-                multiple_senses = [gsv['gloss'] for gsv in GlossSense.objects.values(
-                    'gloss').annotate(Count('id')).filter(id__count__gt=1)]
-            else:
-                multiple_senses = [gsv['gloss'] for gsv in GlossSense.objects.values(
-                    'gloss').annotate(Count('id')).filter(id__count=1)]
-            qs = qs.filter(gloss__id__in=multiple_senses)
-
-        fieldnames = FIELDS['main'] + FIELDS['phonology'] + FIELDS['semantics'] + ['inWeb', 'isNew']
-        if not settings.USE_DERIVATIONHISTORY and 'derivHist' in fieldnames:
-            fieldnames.remove('derivHist')
-
-        # SignLanguage and basic property filters
-        # allows for multiselect
-        vals = get.getlist('dialect[]')
-        if vals:
-            query_parameters['dialect[]'] = vals
-            qs = qs.filter(gloss__dialect__in=vals)
-
-        vals = get.getlist('tags[]')
-        if vals:
-            query_parameters['tags[]'] = vals
-            glosses_with_tag = list(
-                TaggedItem.objects.filter(tag__name__in=vals).values_list('object_id', flat=True))
-            qs = qs.filter(gloss__id__in=glosses_with_tag)
-
-        # allows for multiselect
-        vals = get.getlist('signlanguage[]')
-        if vals:
-            query_parameters['signlanguage[]'] = vals
-            qs = qs.filter(gloss__signlanguage__in=vals)
-
-        if 'useInstr' in get and get['useInstr']:
-            query_parameters['useInstr'] = get['useInstr']
-            qs = qs.filter(gloss__useInstr__icontains=get['useInstr'])
-
-        fields_with_choices = fields_to_fieldcategory_dict()
-        for fieldnamemulti in fields_with_choices.keys():
-            fieldnamemultiVarname = fieldnamemulti + '[]'
-            fieldnameQuery = 'gloss__' + fieldnamemulti + '__machine_value__in'
-
-            vals = get.getlist(fieldnamemultiVarname)
-            if vals:
-                query_parameters[fieldnamemultiVarname] = vals
-                if fieldnamemulti == 'semField':
-                    qs = qs.filter(gloss__semField__in=vals)
-                elif fieldnamemulti == 'derivHist':
-                    qs = qs.filter(gloss__derivHist__in=vals)
-                else:
-                    qs = qs.filter(**{fieldnameQuery: vals})
-
-        # phonology and semantics field filters
-        fieldnames = [f for f in fieldnames if f not in fields_with_choices.keys()]
-        for fieldname in fieldnames:
-
-            if fieldname in get and get[fieldname]:
-                field_obj = Gloss.get_field(fieldname)
-
-                if type(field_obj) in [CharField, TextField] and not hasattr(field_obj, 'field_choice_category'):
-                    key = 'gloss__' + fieldname + '__icontains'
-                else:
-                    key = 'gloss__' + fieldname + '__exact'
-
-                val = get[fieldname]
-
-                if isinstance(field_obj, BooleanField):
-                    val = {'0': '', '1': None, '2': True, '3': False}[val]
-
-                if val != '':
-                    query_parameters[fieldname] = get[fieldname]
-
-                    kwargs = {key: val}
-                    qs = qs.filter(**kwargs)
-
-        qs = qs.distinct()
-
-        if 'definitionRole[]' in get:
-
-            vals = get.getlist('definitionRole[]')
-            if vals:
-                query_parameters['definitionRole[]'] = vals
-                # Find all definitions with this role
-                definitions_with_this_role = Definition.objects.filter(role__machine_value__in=vals)
-
-                # Remember the pk of all glosses that are referenced in the collection definitions
-                pks_for_glosses_with_these_definitions = [definition.gloss.pk for definition in
-                                                          definitions_with_this_role]
-                qs = qs.filter(gloss__pk__in=pks_for_glosses_with_these_definitions)
-
-        if 'definitionContains' in get and get['definitionContains'] not in ['', '0']:
-            query_parameters['definitionContains'] = get['definitionContains']
-
-            definitions_with_this_text = Definition.objects.filter(text__icontains=get['definitionContains'])
-
-            # Remember the pk of all glosses that are referenced in the collection definitions
-            pks_for_glosses_with_these_definitions = [definition.gloss.pk for definition in definitions_with_this_text]
-            qs = qs.filter(gloss__pk__in=pks_for_glosses_with_these_definitions)
-
-        if 'createdBefore' in get and get['createdBefore']:
-            query_parameters['createdBefore'] = get['createdBefore']
-
-            created_before_date = DT.datetime.strptime(get['createdBefore'], settings.DATE_FORMAT).date()
-            qs = qs.filter(gloss__creationDate__range=(EARLIEST_GLOSS_CREATION_DATE, created_before_date))
-
-        if 'createdAfter' in get and get['createdAfter']:
-            query_parameters['createdAfter'] = get['createdAfter']
-
-            created_after_date = DT.datetime.strptime(get['createdAfter'], settings.DATE_FORMAT).date()
-            qs = qs.filter(gloss__creationDate__range=(created_after_date, DT.datetime.now()))
-
-        if 'createdBy' in get and get['createdBy']:
-            query_parameters['createdBy'] = get['createdBy']
-
-            created_by_search_string = ' '.join(get['createdBy'].strip().split())  # remove redundant spaces
-            qs = qs.annotate(
-                created_by=Concat('gloss__creator__first_name', V(' '), 'gloss__creator__last_name', output_field=CharField())) \
-                .filter(created_by__icontains=created_by_search_string)
+        qs = queryset_glosssense_from_get(GlossSense, GlossSearchForm, self.search_form, get, qs)
 
         if 'sentenceType[]' in get:
             vals = get.getlist('sentenceType[]')
             if vals:
-
                 query_parameters['sentenceType[]'] = vals
-
                 sentences_with_this_type = ExampleSentence.objects.filter(sentenceType__machine_value__in=vals)
+                qs = qs.filter(sense__exampleSentences__in=sentences_with_this_type)
 
-                # Remember the pk of all sentences that are referenced in the collection ExampleSentence
-                pks_for_sentences_with_this_type = [sentence.pk for sentence in sentences_with_this_type]
-                qs = qs.filter(sense__exampleSentences__pk__in=pks_for_sentences_with_this_type)
-
-        if 'negative' in get and get['negative'] not in ['unspecified', '0']:
+        if 'negative' in get and get['negative'] not in ['0']:
             query_parameters['negative'] = get['negative']
-            val = get['negative'] == 'yes'
-            # Remember the pk of all negative sentences
-            sentences_with_this_type = ExampleSentence.objects.filter(negative__exact=val)
-            pks_for_negative_sentences = [es.pk for es in sentences_with_this_type]
-
-            if get['negative'] == 'yes':  # We only want senses with negative sentences
-                qs = qs.filter(sense__exampleSentences__pk__in=pks_for_negative_sentences)
-            elif get['negative'] == 'no':  # We only want senses sentences that are not negative
-                qs = qs.filter(sense__exampleSentences__pk__in=pks_for_negative_sentences)
+            sentences_with_negative_type = ExampleSentence.objects.filter(negative__exact=True)
+            sentences_with_other_type = ExampleSentence.objects.filter(negative__exact=False)
+            if get['negative'] == 'yes':  # only senses with negative sentences
+                qs = qs.filter(sense__exampleSentences__in=sentences_with_negative_type)
+            else:  # only senses sentences that are not negative
+                qs = qs.filter(sense__exampleSentences__in=sentences_with_other_type)
 
         if 'sentenceContains' in get and get['sentenceContains'] not in ['', '0']:
             query_parameters['sentenceContains'] = get['sentenceContains']
-
             sentence_translations_with_this_text = ExampleSentenceTranslation.objects.filter(text__icontains=get['sentenceContains'])
-
-            # Remember the pk of all sentences that include this text
-            pks_for_sentences_with_this_text = [sentence_translation.examplesentence.pk
-                                                for sentence_translation in sentence_translations_with_this_text]
-            qs = qs.filter(sense__exampleSentences__pk__in=pks_for_sentences_with_this_text)
+            qs = qs.filter(sense__exampleSentences__in=sentence_translations_with_this_text)
 
         # save the query parameters to a session variable
         self.request.session['query_parameters'] = json.dumps(query_parameters)
         self.request.session.modified = True
         self.query_parameters = query_parameters
-        # qs = qs.select_related('lemma')
-        #
-        # Sort the queryset by the parameters given
-        # sorted_qs = order_queryset_by_sort_order(self.request.GET, qs, self.queryset_language_codes)
 
         self.request.session['search_type'] = self.search_type
         self.request.session['web_search'] = self.web_search
@@ -2488,10 +2095,7 @@ class MorphemeListView(ListView):
     template_name = 'dictionary/admin_morpheme_list.html'
     paginate_by = 25
     queryset_language_codes = []
-
-    @cached_property
-    def search_form(self):
-        return MorphemeSearchForm()
+    search_form = MorphemeSearchForm()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2504,11 +2108,11 @@ class MorphemeListView(ListView):
         # Call the base implementation first to get a context
         context = super(MorphemeListView, self).get_context_data(**kwargs)
 
+        set_up_language_fields(Morpheme, self, self.search_form)
+
         selected_datasets = get_selected_datasets_for_user(self.request.user)
         dataset_languages = get_dataset_languages(selected_datasets)
         context['dataset_languages'] = dataset_languages
-
-        set_up_language_fields(Morpheme, self, self.search_form)
 
         default_dataset_acronym = settings.DEFAULT_DATASET_ACRONYM
         default_dataset = Dataset.objects.get(acronym=default_dataset_acronym)
@@ -3568,7 +3172,7 @@ class QueryListView(ListView):
                 toggle_query_parameter = (query_field, _("Dialect"))
             elif query_field == 'hasComponentOfType':
                 toggle_query_parameter = (query_field, _("Sequential Morphology"))
-            elif query_field == 'hasMorphemeOfType':
+            elif query_field == 'mrpType':
                 toggle_query_parameter = (query_field, _("Morpheme Type"))
             elif query_field == 'morpheme':
                 toggle_query_parameter = (query_field, _("Simultaneous Morphology"))
@@ -6669,7 +6273,7 @@ def glosslist_ajax_complete(request, gloss_id):
         elif fieldname == 'hasComponentOfType':
             morphemes = " + ".join([x.__str__() for x in this_gloss.parent_glosses.all()])
             column_values.append((fieldname, morphemes))
-        elif fieldname == 'hasMorphemeOfType':
+        elif fieldname == 'mrpType':
             # the inheritance only works this way in this version of Django/Python
             # the morphemes are filtered on this glosses id, then the morpheme is used
             target_morphemes = Morpheme.objects.filter(id=this_gloss.id)
@@ -6759,7 +6363,7 @@ def glosslistheader_ajax(request):
                                   'hasothermedia': _("Other Media"),
                                   'hasComponentOfType': _("Sequential Morphology"),
                                   'morpheme': _("Simultaneous Morphology"),
-                                  'hasMorphemeOfType': _("Morpheme Type"),
+                                  'mrpType': _("Morpheme Type"),
                                   'relation': _("Gloss of Related Sign"),
                                   'hasRelationToForeignSign': _("Related to Foreign Sign"),
                                   'relationToForeignSign': _("Gloss of Foreign Sign")
@@ -6869,7 +6473,7 @@ def senselistheader_ajax(request):
                                   'hasothermedia': _("Other Media"),
                                   'hasComponentOfType': _("Sequential Morphology"),
                                   'morpheme': _("Simultaneous Morphology"),
-                                  'hasMorphemeOfType': _("Morpheme Type"),
+                                  'mrpType': _("Morpheme Type"),
                                   'relation': _("Gloss of Related Sign"),
                                   'hasRelationToForeignSign': _("Related to Foreign Sign"),
                                   'relationToForeignSign': _("Gloss of Foreign Sign")

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -213,7 +213,7 @@ class GlossListView(ListView):
 
     model = Gloss
     paginate_by = 100
-    only_export_ecv = False #Used to call the 'export ecv' functionality of this view without the need for an extra GET parameter
+    only_export_ecv = False
     search_type = 'sign'
     view_type = 'gloss_list'
     web_search = False
@@ -320,7 +320,6 @@ class GlossListView(ListView):
 
         return context
 
-
     def get_paginate_by(self, queryset):
         """
         Paginate by specified value in querystring, or use default class property value.
@@ -349,7 +348,6 @@ class GlossListView(ListView):
                 paginate_by = self.paginate_by
 
         return paginate_by
-
 
     def render_to_response(self, context):
         # Look for a 'format=json' GET argument
@@ -760,39 +758,8 @@ class GlossListView(ListView):
         if self.search_type != 'sign':
             query_parameters['search_type'] = self.search_type
 
-        qs = queryset_glosssense_from_get(Gloss, GlossSearchForm, self.search_form, get, qs)
-        query_parameters = query_parameters_from_get(Gloss, GlossSearchForm, self.search_form, get)
-
-        # # Evaluate all gloss/language search fields
-        # for get_key, get_value in get.items():
-
-        #     elif get_key.startswith(GlossSearchForm.keyword_search_field_prefix) and get_value != '':
-        #         query_parameters[get_key] = get_value
-        #         language_code_2char = get_key[len(GlossSearchForm.keyword_search_field_prefix):]
-        #         language = Language.objects.filter(language_code_2char=language_code_2char).first()
-        #         qs = qs.filter(translation__translation__text__iregex=get_value,
-        #                        translation__language=language)
-        #
-        # if 'translation' in get and get['translation'] != '':
-        #     val = get['translation']
-        #     query_parameters['translation'] = get['translation']
-        #     qs = qs.filter(senses__senseTranslations__translations__translation__text__iregex=val)
-        #
-
-# if 'morpheme' in get and get['morpheme'] != '':
-#     query_parameters['morpheme'] = get['morpheme']
-#
-#     # morpheme is an integer
-#     input_morpheme = get['morpheme']
-#     # Filter all glosses that contain this morpheme in their simultaneous morphology
-#     try:
-#         selected_morpheme = Morpheme.objects.get(pk=get['morpheme'])
-# potential_pks = [appears.parent_gloss.pk for appears in SimultaneousMorphologyDefinition.objects.filter(morpheme=selected_morpheme)]
-#         qs = qs.filter(pk__in=potential_pks)
-#     except ObjectDoesNotExist:
-#         # This error should not occur, the input search form requires the selection of a morpheme from a list
-#         # If the user attempts to input a string, it is ignored by the gloss list search form
-#         print("Morpheme not found: ", str(input_morpheme))
+        qs = queryset_glosssense_from_get('Gloss', GlossSearchForm, self.search_form, get, qs)
+        query_parameters = query_parameters_from_get('Gloss', GlossSearchForm, self.search_form, get)
 
         # save the query parameters to a session variable
         self.request.session['query_parameters'] = json.dumps(query_parameters)
@@ -1031,7 +998,7 @@ class SenseListView(ListView):
         if self.search_type != 'sign':
             query_parameters['search_type'] = self.search_type
 
-        qs = queryset_glosssense_from_get(GlossSense, GlossSearchForm, self.search_form, get, qs)
+        qs = queryset_glosssense_from_get('GlossSense', GlossSearchForm, self.search_form, get, qs)
 
         if 'sentenceType[]' in get:
             vals = get.getlist('sentenceType[]')

--- a/signbank/dictionary/context_data.py
+++ b/signbank/dictionary/context_data.py
@@ -133,7 +133,7 @@ def get_input_names_fields_and_labels(search_form):
     return input_names_fields_and_labels
 
 
-def get_context_data_for_gloss_search_form(request, listview, search_form, kwargs, context={}):
+def get_context_data_for_gloss_search_form(request, listview, search_form, kwargs, context={}, sentence_search_form=None):
     """
     Creates context data for gloss search form (e.g. in GlossListView, SenseListView)
     """
@@ -145,7 +145,8 @@ def get_context_data_for_gloss_search_form(request, listview, search_form, kwarg
     context['query_parameters_keys'] = json.dumps(list(query_parameters.keys()))
 
     context['searchform'] = search_form
-    context['sentenceform'] = SentenceForm(request.GET)
+    if sentence_search_form:
+        context['sentenceform'] = sentence_search_form
 
     other_parameter_keys, multiple_select_gloss_fields, fields_with_choices = get_other_parameter_keys()
     context['other_parameters_keys'] = json.dumps(other_parameter_keys)

--- a/signbank/dictionary/context_data.py
+++ b/signbank/dictionary/context_data.py
@@ -206,8 +206,8 @@ def get_morpheme_idgloss(query_parameters):
         return ''
 
     try:
-        return Morpheme.objects.get(pk=query_parameters['morpheme']).idgloss
-    except ObjectDoesNotExist:
+        return Morpheme.objects.get(pk=int(query_parameters['morpheme'])).idgloss
+    except (ObjectDoesNotExist, ValueError):
         return ''
 
 

--- a/signbank/dictionary/context_data.py
+++ b/signbank/dictionary/context_data.py
@@ -4,7 +4,7 @@ from signbank.tools import get_selected_datasets_for_user, get_dataset_languages
 from django.http import QueryDict
 from django.utils.html import escape
 from signbank.dictionary.field_choices import fields_to_fieldcategory_dict
-from signbank.dictionary.translate_choice_list import choicelist_queryset_to_field_colors
+from signbank.dictionary.translate_choice_list import choicelist_queryset_to_field_colors, choicelist_choicelist_to_field_colors
 
 
 def get_web_search(request):
@@ -101,9 +101,16 @@ def get_gloss_fields_to_populate(request):
 def get_choices_colors(fields_with_choices):
     fields_with_choices['definitionRole'] = 'NoteType'
     fields_with_choices['hasComponentOfType'] = 'MorphologyType'
+    fields_with_choices['mrpType'] = 'MorphemeType'
+    fields_with_choices['hasRelation'] = 'Relation'
     choices_colors = {}
     for (fieldname, field_category) in fields_with_choices.items():
-        if field_category in CATEGORY_MODELS_MAPPING.keys():
+        if fieldname == 'hasRelation':
+            relations = ['homonym', 'synonym', 'variant', 'antonym', 'hyponym',
+                         'hypernym', 'seealso', 'paradigm']
+            choices_colors[fieldname] = json.dumps(choicelist_choicelist_to_field_colors(relations))
+            continue
+        elif field_category in CATEGORY_MODELS_MAPPING.keys():
             field_choices = CATEGORY_MODELS_MAPPING[field_category].objects.all()
         else:
             field_choices = FieldChoice.objects.filter(field__iexact=field_category)
@@ -126,7 +133,7 @@ def get_input_names_fields_and_labels(search_form):
     return input_names_fields_and_labels
 
 
-def get_context_data_for_gloss_search_form(request, listview, kwargs, context={}):
+def get_context_data_for_gloss_search_form(request, listview, search_form, kwargs, context={}):
     """
     Creates context data for gloss search form (e.g. in GlossListView, SenseListView)
     """
@@ -137,14 +144,12 @@ def get_context_data_for_gloss_search_form(request, listview, kwargs, context={}
     context['query_parameters'] = json.dumps(query_parameters)
     context['query_parameters_keys'] = json.dumps(list(query_parameters.keys()))
 
-    search_form = GlossSearchForm(request.GET, languages=context['dataset_languages'],
-                                  sign_languages=context['sign_languages'], dialects=context['dialects'])
     context['searchform'] = search_form
     context['sentenceform'] = SentenceForm(request.GET)
 
     other_parameter_keys, multiple_select_gloss_fields, fields_with_choices = get_other_parameter_keys()
     context['other_parameters_keys'] = json.dumps(other_parameter_keys)
-    multiple_select_gloss_fields.extend(['definitionRole', 'hasComponentOfType'])
+    multiple_select_gloss_fields.extend(['definitionRole', 'hasComponentOfType', 'mrpType', 'hasRelation'])
     context['MULTIPLE_SELECT_GLOSS_FIELDS'] = multiple_select_gloss_fields
     context['field_colors'] = get_choices_colors(fields_with_choices)
 
@@ -207,4 +212,4 @@ def get_morpheme_idgloss(query_parameters):
 
 
 def get_input_names_field_labels(fields, search_form):
-   return [(field, search_form[field], search_form[field].label) for field in fields]
+    return [(field, search_form[field], search_form[field].label) for field in fields]

--- a/signbank/dictionary/field_choices.py
+++ b/signbank/dictionary/field_choices.py
@@ -62,6 +62,16 @@ def fields_to_fieldcategory_dict(fieldnames=[]):
             # this is a search form field for Definition role
             choice_categories[field] = 'NoteType'
             continue
+        elif field in ['mrpType']:
+            # this is a search form field for Definition role
+            choice_categories[field] = 'MorphemeType'
+            continue
+        elif field in ['hasComponentOfType']:
+            choice_categories[field] = 'MorphologyType'
+            continue
+        elif field in ['hasRelation']:
+            choice_categories[field] = 'Relation'
+            continue
         if field in settings.HANDSHAPE_ETYMOLOGY_FIELDS + settings.HANDEDNESS_ARTICULATION_FIELDS:
             continue
         if field in Gloss.get_field_names():

--- a/signbank/dictionary/field_choices.py
+++ b/signbank/dictionary/field_choices.py
@@ -58,7 +58,10 @@ def fields_to_fieldcategory_dict(fieldnames=[]):
         elif field in ['derivHist']:
             choice_categories[field] = 'derivHist'
             continue
-
+        elif field in ['definitionRole']:
+            # this is a search form field for Definition role
+            choice_categories[field] = 'NoteType'
+            continue
         if field in settings.HANDSHAPE_ETYMOLOGY_FIELDS + settings.HANDEDNESS_ARTICULATION_FIELDS:
             continue
         if field in Gloss.get_field_names():

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -41,19 +41,6 @@ def tag_choices():
     return tag_choices_list
 
 
-class UserSignSearchForm(forms.Form):
-
-    glossQuery = forms.CharField(label=_(u'Glosses Containing'), max_length=100, required=False, widget=forms.TextInput(attrs={'class': 'form-control'}))
-    query = forms.CharField(label=_(u'Senses Containing'), max_length=100, required=False, widget=forms.TextInput(attrs={'class': 'form-control'}))
-    category = forms.ChoiceField(label=_(u'Search'), choices=CATEGORY_CHOICES, required=False, widget=forms.Select(attrs={'class': 'form-control'}))
-        
-
-class GlossModelForm(forms.ModelForm):
-    class Meta:
-        model = Gloss
-        # fields are defined in settings.py
-        fields = settings.QUICK_UPDATE_GLOSS_FIELDS
-
 class GlossCreateForm(forms.ModelForm):
     """Form for creating a new gloss from scratch"""
 
@@ -110,22 +97,6 @@ class GlossCreateForm(forms.ModelForm):
         gloss.save()
 
         return gloss
-
-
-class UserMorphemeSearchForm(forms.Form):
-    """Facilitate searching for morphemes"""
-
-    morphQuery = forms.CharField(label=_(u'Morphemes Containing'), max_length=100, required=False,
-                                 widget=forms.TextInput(attrs={'class': 'form-control'}))
-    query = forms.CharField(label=_(u'Translations Containing'), max_length=100, required=False,
-                            widget=forms.TextInput(attrs={'class': 'form-control'}))
-
-
-class MorphemeModelForm(forms.ModelForm):
-    class Meta:
-        model = Morpheme
-        # fields are defined in settings.py
-        fields = settings.QUICK_UPDATE_GLOSS_FIELDS
 
 
 class MorphemeCreateForm(forms.ModelForm):
@@ -251,8 +222,10 @@ class GlossSearchForm(forms.ModelForm):
     translation = forms.CharField(label=_('Search Senses'))
     hasvideo = forms.ChoiceField(label=_('Has Video'), choices=NULLBOOLEANCHOICES)
     hasothermedia = forms.ChoiceField(label=_('Has Other Media'), choices=NULLBOOLEANCHOICES)
-    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES)
-    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES)
+    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES,
+                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES,
+                                          widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
     relation = forms.CharField(label=_(u'Gloss of Related Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     relationToForeignSign = forms.CharField(label=_(u'Gloss of Foreign Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
@@ -473,8 +446,10 @@ class MorphemeSearchForm(forms.ModelForm):
                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     definitionRole.field_choice_category = 'NoteType'
     definitionContains = forms.CharField(label=_(u'Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
-    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES)
-    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES)
+    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES,
+                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES,
+                                          widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
     createdBefore = forms.DateField(label=_(u'Created Before'),
                                     input_formats=[settings.DATE_FORMAT],
@@ -506,7 +481,7 @@ class MorphemeSearchForm(forms.ModelForm):
 
         for language in languages:
             morphemesearch_field_name = self.gloss_search_field_prefix + language.language_code_2char
-            setattr(self, morphemesearch_field_name, forms.CharField(label=_("Gloss") + (" (%s)" % language.name)))
+            setattr(self, morphemesearch_field_name, forms.CharField(label=_("Annotation") + (" (%s)" % language.name)))
             if morphemesearch_field_name in queryDict:
                 getattr(self, morphemesearch_field_name).value = queryDict[morphemesearch_field_name]
 
@@ -578,6 +553,7 @@ class DefinitionForm(forms.ModelForm):
                                                 ),
                                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
+
 class RelationForm(forms.ModelForm):
     
     sourceid = forms.CharField(label=_(u'Source Gloss'))
@@ -590,6 +566,7 @@ class RelationForm(forms.ModelForm):
                    'role': forms.Select(attrs={'class': 'form-control'}),
                    }
 
+
 class VariantsForm(forms.Form):
     sourceid = forms.CharField(label=_(u'Source Gloss'))
     targetid = forms.CharField(label=_(u'Target Gloss'))
@@ -597,6 +574,7 @@ class VariantsForm(forms.Form):
     class Meta:
         model = Relation
         
+
 class RelationToForeignSignForm(forms.ModelForm):
 
     sourceid = forms.CharField(label=_(u'Source Gloss'))
@@ -627,12 +605,14 @@ class GlossMorphologyForm(forms.Form):
         self.fields['role'].choices = list(FieldChoice.objects.filter(field='MorphologyType').order_by('machine_value')
                                            .values_list('pk', 'name'))
 
+
 class GlossMorphemeForm(forms.Form):
     """Specify simultaneous morphology components belonging to a Gloss"""
 
     host_gloss_id = forms.CharField(label=_(u'Host Gloss'))
     description = forms.CharField(label=_(u'Meaning'), required=False)
     morph_id = forms.CharField(label=_(u'Morpheme'))
+
 
 class GlossBlendForm(forms.Form):
     """Specify simultaneous morphology components belonging to a Gloss"""
@@ -646,11 +626,12 @@ def get_other_media_type_choices():
     choices = [('','---------')]
     return choices
 
+
 class OtherMediaForm(forms.ModelForm):
 
     gloss = forms.CharField()
-    file = forms.FileField(widget=forms.FileInput(attrs={'accept':'video/*, image/*, application/pdf'}), required=True)
-    # type = forms.ChoiceField(choices=get_other_media_type_choices,widget=forms.Select(attrs=ATTRS_FOR_FORMS), required=True)
+    file = forms.FileField(widget=forms.FileInput(attrs={'accept':'video/*, image/*, application/pdf'}),
+                           required=True)
     alternative_gloss = forms.TextInput()
 
     class Meta:

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -723,49 +723,16 @@ class DatasetUpdateForm(forms.ModelForm):
         super(DatasetUpdateForm, self).__init__(*args, **kwargs)
         self.fields['default_language'] = forms.ChoiceField(widget=forms.Select(attrs={'class': 'form-control'}), choices=languages)
 
-def get_finger_selection_choices():
-    choices = [('','---------')]
-    return choices
-
-def get_quantity_choices():
-    choices = [('','---------')]
-    return choices
-
-def get_joint_configuration_choices():
-    choices = [('','---------')]
-    return choices
-
-def get_spreading_choices():
-    choices = [('','---------')]
-    return choices
-
-def get_aperture_choices():
-    choices = [('','---------')]
-    return choices
 
 attrs_default = {'class': 'form-control'}
-FINGER_SELECTION = ((True, 'True'), (False, 'False'), (None, 'Either'))
+FINGER_SELECTION = ((True, 'True'), (False, 'False'))
+
 
 class HandshapeSearchForm(forms.ModelForm):
     use_required_attribute = False  # otherwise the html required attribute will show up on every form
 
     sortOrder = forms.CharField(label=_("Sort Order"),
                                 initial="machine_value")  # Used in Handshapelistview to store user-selection
-
-    # this is used to pass the label to the handshapes list view, the choices aren't displayed, there are radio buttons
-    unselectedFingers = forms.ChoiceField(label=_(u'Unselected Fingers Extended'), choices=get_finger_selection_choices,
-                                          widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-
-    hsFingConf = forms.ChoiceField(label=_(u'Finger configuration'), choices=get_joint_configuration_choices,
-                                   widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hsFingConf2 = forms.ChoiceField(label=_(u'Finger configuration 2'), choices=get_joint_configuration_choices,
-                                    widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hsNumSel = forms.ChoiceField(label=_(u'Quantity'), choices=get_quantity_choices,
-                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hsSpread = forms.ChoiceField(label=_(u'Spreading'), choices=get_spreading_choices,
-                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hsAperture = forms.ChoiceField(label=_(u'Aperture'), choices=get_aperture_choices,
-                                   widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
     fsT = forms.NullBooleanSelect()
     fsI = forms.NullBooleanSelect()
@@ -823,45 +790,49 @@ class HandshapeSearchForm(forms.ModelForm):
                                                     ),
                                                     widget=forms.Select(attrs=ATTRS_FOR_FORMS))
         self.fields['hsNumSel'] = forms.ChoiceField(label=_(u'Quantity'),
-                                                          choices=choicelist_queryset_to_translated_dict(
-                                                              list(
-                                                                  FieldChoice.objects.filter(field='Quantity').order_by(
-                                                                      'machine_value')),
-                                                              ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+                                                    choices=choicelist_queryset_to_translated_dict(
+                                                          list(
+                                                              FieldChoice.objects.filter(field='Quantity').order_by(
+                                                                  'machine_value')),
+                                                          ordered=False, id_prefix='', shortlist=False
+                                                    ),
+                                                    widget=forms.Select(attrs=ATTRS_FOR_FORMS))
         self.fields['hsFingConf'] = forms.ChoiceField(label=_(u'Finger configuration'),
-                                                          choices=choicelist_queryset_to_translated_dict(
+                                                      choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='JointConfiguration').order_by(
                                                                       'machine_value')),
                                                               ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+                                                      ),
+                                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
         self.fields['hsFingConf2'] = forms.ChoiceField(label=_(u'Finger configuration 2'),
-                                                          choices=choicelist_queryset_to_translated_dict(
-                                                              list(
-                                                                  FieldChoice.objects.filter(field='JointConfiguration').order_by(
-                                                                      'machine_value')),
-                                                              ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+                                                       choices=choicelist_queryset_to_translated_dict(
+                                                          list(
+                                                              FieldChoice.objects.filter(field='JointConfiguration').order_by(
+                                                                  'machine_value')),
+                                                          ordered=False, id_prefix='', shortlist=False
+                                                       ),
+                                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
         self.fields['hsSpread'] = forms.ChoiceField(label=_(u'Spreading'),
-                                                          choices=choicelist_queryset_to_translated_dict(
+                                                    choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='Spreading').order_by(
                                                                       'machine_value')),
                                                               ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+                                                    ),
+                                                    widget=forms.Select(attrs=ATTRS_FOR_FORMS))
         self.fields['hsAperture'] = forms.ChoiceField(label=_(u'Aperture'),
-                                                          choices=choicelist_queryset_to_translated_dict(
+                                                      choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='Aperture').order_by(
                                                                       'machine_value')),
                                                               ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+                                                      ),
+                                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+        for finger in ['fsT', 'fsI', 'fsM', 'fsR', 'fsP',
+                       'fs2T', 'fs2I', 'fs2M', 'fs2R', 'fs2P',
+                       'ufT', 'ufI', 'ufM', 'ufR', 'ufP']:
+            self.fields[finger].inital = False
 
 
 def check_multilingual_fields(ClassModel, queryDict, languages):

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -473,12 +473,11 @@ class MorphemeSearchForm(forms.ModelForm):
         # language fields will be set up elsewhere
         # field choice choices will be set up elsewhere
         # these are the multiselect field choice fields for morphemes
-        fieldnames = ['handedness', 'handCh', 'relatArtic', 'locprim', 'relOriMov',
-                      'relOriLoc', 'oriCh', 'contType', 'movSh', 'movDir', 'mrpType', 'wordClass',
-                      'semField', 'derivHist', 'namEnt', 'valence']
-        for fieldname in fieldnames:
-            # morphemes do not have Handshape fields, these are hidden, see issue #638
-            if fieldname.startswith('mrpType'):
+        for fieldname in settings.MORPHEME_CHOICE_FIELDS:
+            if fieldname in ['definitionRole']:
+                # this is a search form field name
+                continue
+            elif fieldname.startswith('mrpType'):
                 field_label = Morpheme.get_field(fieldname).verbose_name
             else:
                 field_label = Gloss.get_field(fieldname).verbose_name

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -299,21 +299,34 @@ class GlossSearchForm(forms.ModelForm):
         dialects = kwargs.pop('dialects')
         super(GlossSearchForm, self).__init__(queryDict, *args, **kwargs)
 
+        count_languages = len(languages)
         for language in languages:
             glosssearch_field_name = self.gloss_search_field_prefix + language.language_code_2char
-            setattr(self, glosssearch_field_name, forms.CharField(label=_("Gloss")+(" (%s)" % language.name)))
+            if count_languages > 1:
+                annotation_label = _("Gloss")+(" (%s)" % language.name)
+            else:
+                annotation_label = _("Gloss")
+            setattr(self, glosssearch_field_name, forms.CharField(label=annotation_label))
             if glosssearch_field_name in queryDict:
                 getattr(self, glosssearch_field_name).value = queryDict[glosssearch_field_name]
 
             # do the same for Translations
             keyword_field_name = self.keyword_search_field_prefix + language.language_code_2char
-            setattr(self, keyword_field_name, forms.CharField(label=_("Senses")+(" (%s)" % language.name)))
+            if count_languages > 1:
+                keyword_label = _("Senses")+(" (%s)" % language.name)
+            else:
+                keyword_label = _("Senses")
+            setattr(self, keyword_field_name, forms.CharField(label=keyword_label))
             if keyword_field_name in queryDict:
                 getattr(self, keyword_field_name).value = queryDict[keyword_field_name]
 
             # and for LemmaIdgloss
             lemma_field_name = self.lemma_search_field_prefix + language.language_code_2char
-            setattr(self, lemma_field_name, forms.CharField(label=_("Lemma")+(" (%s)" % language.name)))
+            if count_languages > 1:
+                lemma_label = _("Lemma")+(" (%s)" % language.name)
+            else:
+                lemma_label = _("Lemma")
+            setattr(self, lemma_field_name, forms.CharField(label=lemma_label))
             if lemma_field_name in queryDict:
                 getattr(self, lemma_field_name).value = queryDict[lemma_field_name]
 
@@ -868,12 +881,19 @@ class LemmaSearchForm(forms.ModelForm):
         languages = kwargs.pop('languages')
         super(LemmaSearchForm, self).__init__(queryDict, *args, **kwargs)
 
+        count_languages = len(languages)
         for language in languages:
             # and for LemmaIdgloss
             lemma_field_name = self.lemma_search_field_prefix + language.language_code_2char
-            setattr(self, lemma_field_name, forms.CharField(label=_("Lemma")+(" (%s)" % language.name)))
+            if count_languages > 1:
+                lemma_label = _("Lemma")+(" (%s)" % language.name)
+            else:
+                lemma_label = _("Lemma")
+            setattr(self, lemma_field_name, forms.CharField(label=lemma_label))
             if lemma_field_name in queryDict:
                 getattr(self, lemma_field_name).value = queryDict[lemma_field_name]
+        for boolean_field in ['no_glosses', 'has_glosses']:
+            self.fields[boolean_field].choices = [(0, _('No')), (1, _('Yes'))]
 
 
 class LemmaCreateForm(forms.ModelForm):

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -799,6 +799,7 @@ class HandshapeSearchForm(forms.ModelForm):
                        'fs2T', 'fs2I', 'fs2M', 'fs2R', 'fs2P',
                        'ufT', 'ufI', 'ufM', 'ufR', 'ufP']:
             self.fields[finger].inital = False
+            self.fields[finger].widget.choices = [(True, _('Yes')), (False, _('No'))]
 
 
 def check_multilingual_fields(ClassModel, queryDict, languages):

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -193,21 +193,6 @@ RELATION_ROLE_CHOICES = (('', '---------'),
                          )
 
 
-def get_definition_role_choices():
-    choices = [('','---------'),('all','All')]
-    return choices
-
-
-def get_component_role_choice():
-    choices = [('','---------')]
-    return choices
-
-
-def get_morpheme_role_choices():
-    choices = [('','---------')]
-    return choices
-
-
 ATTRS_FOR_FORMS = {'class': 'form-control'}
 ATTRS_FOR_BOOLEAN_FORMS = {'class': 'form-control', 'style': 'width:80px'}
 
@@ -242,11 +227,11 @@ class GlossSearchForm(forms.ModelForm):
     # these field's choices are set dynamically in the __init__ method below
     # that they appear here is used statically by the query parameters method which looks at the gloss search form fields
     hasComponentOfType = forms.ChoiceField(label=_('Has Compound Component Type'),
-                                           choices=get_component_role_choice,
+                                           choices=[(0, '-')],
                                            widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     hasComponentOfType.field_choice_category = 'MorphologyType'
     hasMorphemeOfType = forms.ChoiceField(label=_('Has Morpheme Type'),
-                                          choices=get_morpheme_role_choices,
+                                          choices=[(0, '-')],
                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     hasMorphemeOfType.field_choice_category = 'MorphemeType'
 
@@ -269,7 +254,7 @@ class GlossSearchForm(forms.ModelForm):
     # this field's choices are set dynamically in the __init__ method below
     # It's presence here is used statically by the query parameters method which looks at the gloss search form fields
     definitionRole = forms.ChoiceField(label=_('Note Type'),
-                                       choices=get_definition_role_choices,
+                                       choices=[(0, '-')],
                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     definitionRole.field_choice_category = 'NoteType'
     definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
@@ -455,9 +440,8 @@ class MorphemeSearchForm(forms.ModelForm):
     inWeb = forms.ChoiceField(label=_('Is in Web Dictionary'), choices=[(0, '-')],
                               widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    definitionRole = forms.ChoiceField(label=_('Note Type'), choices=get_definition_role_choices,
+    definitionRole = forms.ChoiceField(label=_('Note Type'), choices=[(0, '-')],
                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    definitionRole.field_choice_category = 'NoteType'
     definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=[(0, '-')],
                                       widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
@@ -486,22 +470,9 @@ class MorphemeSearchForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(MorphemeSearchForm, self).__init__(*args, **kwargs)
 
-        for language in Language.objects.all():
-            morphemesearch_field_name = self.gloss_search_field_prefix + language.language_code_2char
-            morphemesearch_field_label = _("Annotation") + (" (%s)" % language.name)
-            self.fields[morphemesearch_field_name] = forms.CharField(label=morphemesearch_field_label)
+        # language fields will be set up elsewhere
 
-            # Morphemes have translations not senses
-            keyword_field_name = self.keyword_search_field_prefix + language.language_code_2char
-            keyword_field_label = _("Translations")+(" (%s)" % language.name)
-            self.fields[keyword_field_name] = forms.CharField(label=keyword_field_label)
-            self.fields[keyword_field_name].widget.label = keyword_field_label
-
-            lemma_field_name = self.lemma_search_field_prefix + language.language_code_2char
-            lemma_field_label = _("Lemma")+(" (%s)" % language.name)
-            self.fields[lemma_field_name] = forms.CharField(label=lemma_field_label)
-
-        fieldnames = FIELDS['main']+settings.MORPHEME_DISPLAY_FIELDS+FIELDS['semantics']+['inWeb', 'isNew', 'mrpType']
+        fieldnames = FIELDS['main']+settings.MORPHEME_DISPLAY_FIELDS+FIELDS['semantics']+['mrpType']
         fields_with_choices = fields_to_fieldcategory_dict(fieldnames)
         fields_with_choices['definitionRole'] = 'NoteType'
 

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -176,7 +176,6 @@ class TagUpdateForm(forms.Form):
 
 YESNOCHOICES = (('unspecified', "---------"), ('yes', 'Yes'), ('no', 'No'))
 NULLBOOLEANCHOICES = [(0, '---------'), (2, 'True'), (3, 'False')]
-NONEBOOLEANCHOICES = [(0, '---------'), (1, 'None'), (2, 'True'), (3, 'False')]
 UNKNOWNBOOLEANCHOICES = [(0, '---------'), (2, 'True'), (3, 'False')]
 NEUTRALBOOLEANCHOICES = [(1, 'Neutral'), (2, 'Yes'), (3, 'No')]
 NEUTRALQUERYCHOICES = [(0, '---------'), (1, 'Neutral'), (2, 'True'), (3, 'False')]
@@ -426,7 +425,6 @@ class MorphemeSearchForm(forms.ModelForm):
     tags = forms.ChoiceField(label=_('Tags'), choices=tag_choices)
     translation = forms.CharField(label=_('Search Senses'))
     hasvideo = forms.ChoiceField(label=_('Has Video'), choices=NULLBOOLEANCHOICES)
-    hasothermedia = forms.ChoiceField(label=_('Has Other Media'), choices=NULLBOOLEANCHOICES)
     useInstr = forms.CharField(label=_("Annotation instructions"))
 
     phonOth = forms.CharField(label=_(u'Phonology Other'), widget=forms.TextInput())
@@ -448,8 +446,6 @@ class MorphemeSearchForm(forms.ModelForm):
     definitionContains = forms.CharField(label=_(u'Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES,
                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES,
-                                          widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
     createdBefore = forms.DateField(label=_(u'Created Before'),
                                     input_formats=[settings.DATE_FORMAT],

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -174,25 +174,6 @@ class TagUpdateForm(forms.Form):
                                                widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
 
-YESNOCHOICES = (('unspecified', "---------"), ('yes', 'Yes'), ('no', 'No'))
-NULLBOOLEANCHOICES = [(0, '---------'), (2, 'True'), (3, 'False')]
-UNKNOWNBOOLEANCHOICES = [(0, '---------'), (2, 'True'), (3, 'False')]
-NEUTRALBOOLEANCHOICES = [(1, 'Neutral'), (2, 'Yes'), (3, 'No')]
-NEUTRALQUERYCHOICES = [(0, '---------'), (1, 'Neutral'), (2, 'True'), (3, 'False')]
-
-RELATION_ROLE_CHOICES = (('', '---------'),
-                         ('all', 'All'),
-                         ('homonym', 'Homonym'),
-                         ('synonym', 'Synonym'),
-                         ('variant', 'Variant'),
-                         ('antonym', 'Antonym'),
-                         ('hyponym', 'Hyponym'),
-                         ('hypernym', 'Hypernym'),
-                         ('seealso', 'See Also'),
-                         ('paradigm', 'Handshape Paradigm')
-                         )
-
-
 ATTRS_FOR_FORMS = {'class': 'form-control'}
 ATTRS_FOR_BOOLEAN_FORMS = {'class': 'form-control', 'style': 'width:80px'}
 
@@ -202,62 +183,71 @@ class GlossSearchForm(forms.ModelForm):
     use_required_attribute = False  # otherwise the html required attribute will show up on every form
 
     search = forms.CharField(label=_('Search Gloss'))
-    sortOrder = forms.CharField(label=_('Sort Order'))       # Used in glosslistview to store user-selection
-    tags = forms.ChoiceField(label=_('Tags'), choices=tag_choices)
+    sortOrder = forms.CharField(label=_('Sort Order'))
+    tags = forms.ChoiceField(label=_('Tags'), choices=[(0, '-')])
     translation = forms.CharField(label=_('Search Senses'))
-    hasvideo = forms.ChoiceField(label=_('Has Video'), choices=NULLBOOLEANCHOICES)
-    hasothermedia = forms.ChoiceField(label=_('Has Other Media'), choices=NULLBOOLEANCHOICES)
-    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES,
+    hasvideo = forms.ChoiceField(label=_('Has Video'), choices=[(0, '-')])
+    hasothermedia = forms.ChoiceField(label=_('Has Other Media'), choices=[(0, '-')])
+    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=[(0, '-')],
                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES,
+    hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=[(0, '-')],
                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
-    relation = forms.CharField(label=_('Gloss of Related Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
-    relationToForeignSign = forms.CharField(label=_('Gloss of Foreign Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    relation = forms.CharField(label=_('Gloss of Related Sign'),
+                               widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    relationToForeignSign = forms.CharField(label=_('Gloss of Foreign Sign'),
+                                            widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     morpheme = forms.CharField(label=_('Search for gloss with this as morpheme'))
 
-    oriChAbd = forms.ChoiceField(label=_('Abduction Change'),choices=NULLBOOLEANCHOICES)
-    oriChFlex = forms.ChoiceField(label=_('Flexion Change'),choices=NULLBOOLEANCHOICES)
+    phonOth = forms.CharField(label=_('Phonology Other'), widget=forms.TextInput())
 
-    phonOth = forms.CharField(label=_('Phonology Other'),widget=forms.TextInput())
+    hasRelationToForeignSign = forms.ChoiceField(label=_('Related to Foreign Sign'),
+                                                 choices=[(0, '-')],
+                                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    hasRelation = forms.ChoiceField(label=_('Type of Relation'),
+                                    choices=[(0, '-')],
+                                    widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
-    hasRelationToForeignSign = forms.ChoiceField(label=_('Related to Foreign Sign'),choices=[(0,'---------'),(1,'Yes'),(2,'No')],widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hasRelation = forms.ChoiceField(label=_('Type of Relation'),choices=RELATION_ROLE_CHOICES,widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-
-    # these field's choices are set dynamically in the __init__ method below
-    # that they appear here is used statically by the query parameters method which looks at the gloss search form fields
     hasComponentOfType = forms.ChoiceField(label=_('Has Compound Component Type'),
                                            choices=[(0, '-')],
                                            widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hasComponentOfType.field_choice_category = 'MorphologyType'
-    hasMorphemeOfType = forms.ChoiceField(label=_('Has Morpheme Type'),
-                                          choices=[(0, '-')],
-                                          widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hasMorphemeOfType.field_choice_category = 'MorphemeType'
 
-    repeat = forms.ChoiceField(label=_('Repeating Movement'),choices=NULLBOOLEANCHOICES)
-    altern = forms.ChoiceField(label=_('Alternating Movement'),choices=NULLBOOLEANCHOICES)
+    repeat = forms.ChoiceField(label=_('Repeating Movement'), choices=[(0, '-')],
+                               widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    altern = forms.ChoiceField(label=_('Alternating Movement'), choices=[(0, '-')],
+                               widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    weakprop = forms.ChoiceField(label=_('Weak Prop'),choices=NEUTRALQUERYCHOICES)
-    weakdrop = forms.ChoiceField(label=_('Weak Drop'),choices=NEUTRALQUERYCHOICES)
+    weakprop = forms.ChoiceField(label=_('Weak Prop'), choices=[(0, '-')],
+                                 widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    weakdrop = forms.ChoiceField(label=_('Weak Drop'), choices=[(0, '-')],
+                                 widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    domhndsh_letter = forms.ChoiceField(label=_('letter'),choices=UNKNOWNBOOLEANCHOICES)
-    domhndsh_number = forms.ChoiceField(label=_('number'),choices=UNKNOWNBOOLEANCHOICES)
+    domhndsh_letter = forms.ChoiceField(label=_('letter'), choices=[(0, '-')],
+                                        widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    domhndsh_number = forms.ChoiceField(label=_('number'), choices=[(0, '-')],
+                                        widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    subhndsh_letter = forms.ChoiceField(label=_('letter'),choices=UNKNOWNBOOLEANCHOICES)
-    subhndsh_number = forms.ChoiceField(label=_('number'),choices=UNKNOWNBOOLEANCHOICES)
+    subhndsh_letter = forms.ChoiceField(label=_('letter'), choices=[(0, '-')],
+                                        widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    subhndsh_number = forms.ChoiceField(label=_('number'), choices=[(0, '-')],
+                                        widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    isNew = forms.ChoiceField(label=_('Is a proposed new sign'),choices=NULLBOOLEANCHOICES)
-    inWeb = forms.ChoiceField(label=_('Is in Web Dictionary'),choices=NULLBOOLEANCHOICES)
-    excludeFromEcv = forms.ChoiceField(label=_('Exclude from ECV'),choices=NULLBOOLEANCHOICES)
+    isNew = forms.ChoiceField(label=_('Is a proposed new sign'), choices=[(0, '-')],
+                              widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    inWeb = forms.ChoiceField(label=_('Is in Web Dictionary'), choices=[(0, '-')],
+                              widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    excludeFromEcv = forms.ChoiceField(label=_('Exclude from ECV'), choices=[(0, '-')],
+                                       widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    # this field's choices are set dynamically in the __init__ method below
-    # It's presence here is used statically by the query parameters method which looks at the gloss search form fields
     definitionRole = forms.ChoiceField(label=_('Note Type'),
                                        choices=[(0, '-')],
                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    definitionRole.field_choice_category = 'NoteType'
-    definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    definitionContains = forms.CharField(label=_('Note Contains'),
+                                         widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+
+    mrpType = forms.ChoiceField(label=_('Has Morpheme Type'),
+                                choices=[(0, '-')],
+                                widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
     createdBy = forms.CharField(label=_('Created By'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     createdAfter = forms.DateField(label=_('Created After'),
@@ -276,92 +266,37 @@ class GlossSearchForm(forms.ModelForm):
     class Meta:
 
         model = Gloss
-        fields = settings.FIELDS['phonology'] + settings.FIELDS['semantics'] + settings.FIELDS['main'] + ['inWeb', 'isNew', 'excludeFromEcv']
+        fields = settings.FIELDS['phonology'] + settings.FIELDS['semantics'] + settings.FIELDS['main'] + \
+                 ['inWeb', 'isNew', 'excludeFromEcv']
 
-    def __init__(self, queryDict, *args, **kwargs):
-        languages = kwargs.pop('languages')
-        sign_languages = kwargs.pop('sign_languages')
-        dialects = kwargs.pop('dialects')
-        super(GlossSearchForm, self).__init__(queryDict, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
 
-        count_languages = len(languages)
-        for language in languages:
-            glosssearch_field_name = self.gloss_search_field_prefix + language.language_code_2char
-            if count_languages > 1:
-                annotation_label = _("Gloss")+(" (%s)" % language.name)
-            else:
-                annotation_label = _("Gloss")
-            setattr(self, glosssearch_field_name, forms.CharField(label=annotation_label))
-            if glosssearch_field_name in queryDict:
-                getattr(self, glosssearch_field_name).value = queryDict[glosssearch_field_name]
+        super(GlossSearchForm, self).__init__(*args, **kwargs)
 
-            # do the same for Translations
-            keyword_field_name = self.keyword_search_field_prefix + language.language_code_2char
-            if count_languages > 1:
-                keyword_label = _("Senses")+(" (%s)" % language.name)
-            else:
-                keyword_label = _("Senses")
-            setattr(self, keyword_field_name, forms.CharField(label=keyword_label))
-            if keyword_field_name in queryDict:
-                getattr(self, keyword_field_name).value = queryDict[keyword_field_name]
-
-            # and for LemmaIdgloss
-            lemma_field_name = self.lemma_search_field_prefix + language.language_code_2char
-            if count_languages > 1:
-                lemma_label = _("Lemma")+(" (%s)" % language.name)
-            else:
-                lemma_label = _("Lemma")
-            setattr(self, lemma_field_name, forms.CharField(label=lemma_label))
-            if lemma_field_name in queryDict:
-                getattr(self, lemma_field_name).value = queryDict[lemma_field_name]
-
-        field_label_signlanguage = gettext("Sign Language")
-        field_label_dialects = gettext("Dialect")
-        self.fields['signLanguage'] = forms.ModelMultipleChoiceField(label=field_label_signlanguage, widget=Select2,
-                    queryset=SignLanguage.objects.filter(id__in=[signlanguage[0] for signlanguage in sign_languages]))
-
-        self.fields['dialects'] = forms.ModelMultipleChoiceField(label=field_label_dialects, widget=Select2,
-                    queryset=Dialect.objects.filter(id__in=[dia[0] for dia in dialects]))
-
-        fields_with_choices = fields_to_fieldcategory_dict()
-        fields_with_choices['definitionRole'] = 'NoteType'
-        for (fieldname, field_category) in fields_with_choices.items():
-            if fieldname == 'definitionRole':
-                field_label = _('Note Type')
+        # language fields will be set up elsewhere
+        # field choice choices will be set up elsewhere
+        # these are the multiselect field choice fields for morphemes
+        for fieldname in settings.GLOSS_CHOICE_FIELDS:
+            if fieldname in ['definitionRole', 'hasComponentOfType', 'mrpType', 'hasRelation']:
+                # this is a search form field name
+                continue
             else:
                 field_label = Gloss.get_field(fieldname).verbose_name
-            if fieldname.startswith('semField'):
-                field_choices = SemanticField.objects.all()
-            elif fieldname.startswith('derivHist'):
-                field_choices = DerivationHistory.objects.all()
-            elif fieldname in ['domhndsh', 'subhndsh', 'final_domhndsh', 'final_subhndsh']:
-                field_choices = Handshape.objects.all()
-            else:
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category)
-            translated_choices = choicelist_queryset_to_translated_dict(field_choices,ordered=False,id_prefix='',shortlist=True)
-            self.fields[fieldname] = forms.TypedMultipleChoiceField(label=field_label,
-                                                        choices=translated_choices,
-                                                        required=False, widget=Select2)
-        self.fields['hasComponentOfType'] = forms.ChoiceField(label=_('Has Compound Component Type'),
-                                                          choices=choicelist_queryset_to_translated_dict(
-                                                              list(
-                                                                  FieldChoice.objects.filter(field='MorphologyType').order_by(
-                                                                      'machine_value')),
-                                                              ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hasMorphemeOfType'] = forms.ChoiceField(label=_('Has Morpheme Type'),
-                                                             choices=choicelist_queryset_to_translated_dict(
-                                                              list(
-                                                                  FieldChoice.objects.filter(field='MorphemeType').order_by(
-                                                                      'machine_value')),
-                                                              ordered=False, id_prefix='', shortlist=False
-                                                          ),
-                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+            self.fields[fieldname] = forms.ChoiceField(label=field_label,
+                                                       choices=[(0, '-')],
+                                                       required=False, widget=Select2)
         self.fields['tags'] = forms.ChoiceField(label=_('Tags'),
                                                 choices=[(tag.name, tag.name.replace('_', ' '))
                                                          for tag in Tag.objects.all()],
                                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+        for boolean_field in ['hasvideo', 'repeat', 'altern', 'isNew', 'inWeb', 'defspublished',
+                              'excludeFromEcv', 'hasRelationToForeignSign', 'hasmultiplesenses',
+                              'hasothermedia']:
+            self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]
+        for boolean_field in ['weakdrop', 'weakprop']:
+            self.fields[boolean_field].choices = [(0, '-'), (1, _('Neutral')), (2, _('True')), (3, _('False'))]
+        for boolean_field in ['domhndsh_letter', 'domhndsh_number', 'subhndsh_letter', 'subhndsh_number']:
+            self.fields[boolean_field].choices = [(0, '-'), (2, _('True')), (3, _('False'))]
 
 
 def check_language_fields(SearchForm, queryDict, languages):
@@ -442,7 +377,8 @@ class MorphemeSearchForm(forms.ModelForm):
 
     definitionRole = forms.ChoiceField(label=_('Note Type'), choices=[(0, '-')],
                                        required=False, widget=Select2)
-    definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    definitionContains = forms.CharField(label=_('Note Contains'),
+                                         widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=[(0, '-')],
                                       widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
@@ -541,11 +477,6 @@ class RelationToForeignSignForm(forms.ModelForm):
         widgets = {}
 
 
-def get_morphology_type_choices():
-    choices = [('','---------')]
-    return choices
-
-
 class GlossMorphologyForm(forms.Form):
     """Morphology specification of a Gloss"""
 
@@ -574,11 +505,6 @@ class GlossBlendForm(forms.Form):
     host_gloss_id = forms.CharField(label=_('Host Gloss'))
     role = forms.CharField(label=_('Role'))
     blend_id = forms.CharField(label=_('Blend'))
-
-
-def get_other_media_type_choices():
-    choices = [('','---------')]
-    return choices
 
 
 class OtherMediaForm(forms.ModelForm):
@@ -813,16 +739,16 @@ class ImageUploadForHandshapeForm(forms.Form):
     redirect = forms.CharField(widget=forms.HiddenInput, required=False)
 
 
-NO_GLOSS_SELECTION = [(0,'False'),(1,'True')]
-
 class LemmaSearchForm(forms.ModelForm):
     use_required_attribute = False  # otherwise the html required attribute will show up on every form
 
     search = forms.CharField(label=_("Lemma"))
     sortOrder = forms.CharField(label=_("Sort Order"))
     lemma_search_field_prefix = "lemma_"
-    no_glosses = forms.ChoiceField(label=_('Only show results without glosses'),choices=NO_GLOSS_SELECTION)
-    has_glosses = forms.ChoiceField(label=_('Only show results with glosses'),choices=NO_GLOSS_SELECTION)
+    no_glosses = forms.ChoiceField(label=_('Only show results without glosses'), choices=[],
+                                   widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    has_glosses = forms.ChoiceField(label=_('Only show results with glosses'), choices=[],
+                                    widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
     menu_bar_search = "Menu Bar Search Gloss"
     menu_bar_translation = "Menu Bar Search Translation"
 
@@ -1002,17 +928,14 @@ class KeyMappingSearchForm(forms.ModelForm):
 
 class FocusGlossSearchForm(forms.ModelForm):
 
-    use_required_attribute = False #otherwise the html required attribute will show up on every form
+    use_required_attribute = False  # otherwise the html required attribute will show up on every form
 
     search = forms.CharField(label=_("Search Gloss"))
     sortOrder = forms.CharField(label=_("Sort Order"))       # Used in glosslistview to store user-selection
     translation = forms.CharField(label=_('Search Senses'))
 
-    oriChAbd = forms.ChoiceField(label=_('Abduction Change'), choices=NULLBOOLEANCHOICES)
-    oriChFlex = forms.ChoiceField(label=_('Flexion Change'), choices=NULLBOOLEANCHOICES)
-
-    repeat = forms.ChoiceField(label=_('Repeating Movement'), choices=NULLBOOLEANCHOICES)
-    altern = forms.ChoiceField(label=_('Alternating Movement'), choices=NULLBOOLEANCHOICES)
+    repeat = forms.ChoiceField(label=_('Repeating Movement'), choices=[('0', '-')])
+    altern = forms.ChoiceField(label=_('Alternating Movement'), choices=[('0', '-')])
 
     gloss_search_field_prefix = "glosssearch_"
     keyword_search_field_prefix = "keyword_"
@@ -1066,6 +989,8 @@ class FocusGlossSearchForm(forms.ModelForm):
             self.fields[fieldname] = forms.TypedMultipleChoiceField(label=field_label,
                                                                     choices=translated_choices,
                                                                     required=False, widget=Select2)
+        for boolean_field in ['repeat', 'altern']:
+            self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]
 
 
 class FieldChoiceColorForm(forms.Form):
@@ -1428,8 +1353,9 @@ class SearchHistoryForm(forms.ModelForm):
 
 class SentenceForm(forms.ModelForm):
 
-    sentenceType = forms.ChoiceField(label=_("Type"), choices=[])
-    negative = forms.ChoiceField(label=_('Negative'), choices=YESNOCHOICES)
+    sentenceType = forms.ChoiceField(label=_("Type"), choices=[('0', '-')])
+    negative = forms.ChoiceField(label=_('Negative'), choices=[('0', '-')],
+                                 widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
     sentenceContains = forms.CharField(label=_('Sentence Contains'),
                                        widget=forms.TextInput(attrs=ATTRS_FOR_FORMS), required=False)
 
@@ -1446,9 +1372,10 @@ class SentenceForm(forms.ModelForm):
 
         field_choices = FieldChoice.objects.filter(field__iexact='sentenceType')
 
-        translated_choices = choicelist_queryset_to_translated_dict(field_choices, ordered=False, id_prefix='',
+        translated_choices = choicelist_queryset_to_translated_dict(field_choices,
+                                                                    ordered=False, id_prefix='',
                                                                     shortlist=True)
         self.fields['sentenceType'] = forms.TypedMultipleChoiceField(label=_('Type'),
                                                                      choices=translated_choices,
                                                                      required=False, widget=Select2)
-
+        self.fields['negative'].choices = [('0', '-'), ('yes', _('Yes')), ('no', _('No'))]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -767,10 +767,7 @@ class LemmaSearchForm(forms.ModelForm):
         for language in languages:
             # and for LemmaIdgloss
             lemma_field_name = self.lemma_search_field_prefix + language.language_code_2char
-            if count_languages > 1:
-                lemma_label = _("Lemma")+(" (%s)" % language.name)
-            else:
-                lemma_label = _("Lemma")
+            lemma_label = _("Lemma")+(" (%s)" % language.name) if count_languages > 1 else _("Lemma")
             setattr(self, lemma_field_name, forms.CharField(label=lemma_label))
             if lemma_field_name in queryDict:
                 getattr(self, lemma_field_name).value = queryDict[lemma_field_name]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -209,6 +209,7 @@ def get_morpheme_role_choices():
 
 
 ATTRS_FOR_FORMS = {'class': 'form-control'}
+ATTRS_FOR_BOOLEAN_FORMS = {'class': 'form-control', 'style': 'width:80px'}
 
 
 class GlossSearchForm(forms.ModelForm):
@@ -226,58 +227,58 @@ class GlossSearchForm(forms.ModelForm):
     hasmultiplesenses = forms.ChoiceField(label=_("Has Multiple Senses"), choices=YESNOCHOICES,
                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
-    relation = forms.CharField(label=_(u'Gloss of Related Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
-    relationToForeignSign = forms.CharField(label=_(u'Gloss of Foreign Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
-    morpheme = forms.CharField(label=_(u'Search for gloss with this as morpheme'))
+    relation = forms.CharField(label=_('Gloss of Related Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    relationToForeignSign = forms.CharField(label=_('Gloss of Foreign Sign'),widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    morpheme = forms.CharField(label=_('Search for gloss with this as morpheme'))
 
-    oriChAbd = forms.ChoiceField(label=_(u'Abduction Change'),choices=NULLBOOLEANCHOICES)
-    oriChFlex = forms.ChoiceField(label=_(u'Flexion Change'),choices=NULLBOOLEANCHOICES)
+    oriChAbd = forms.ChoiceField(label=_('Abduction Change'),choices=NULLBOOLEANCHOICES)
+    oriChFlex = forms.ChoiceField(label=_('Flexion Change'),choices=NULLBOOLEANCHOICES)
 
-    phonOth = forms.CharField(label=_(u'Phonology Other'),widget=forms.TextInput())
+    phonOth = forms.CharField(label=_('Phonology Other'),widget=forms.TextInput())
 
-    hasRelationToForeignSign = forms.ChoiceField(label=_(u'Related to Foreign Sign'),choices=[(0,'---------'),(1,'Yes'),(2,'No')],widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    hasRelation = forms.ChoiceField(label=_(u'Type of Relation'),choices=RELATION_ROLE_CHOICES,widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    hasRelationToForeignSign = forms.ChoiceField(label=_('Related to Foreign Sign'),choices=[(0,'---------'),(1,'Yes'),(2,'No')],widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    hasRelation = forms.ChoiceField(label=_('Type of Relation'),choices=RELATION_ROLE_CHOICES,widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
     # these field's choices are set dynamically in the __init__ method below
     # that they appear here is used statically by the query parameters method which looks at the gloss search form fields
-    hasComponentOfType = forms.ChoiceField(label=_(u'Has Compound Component Type'),
+    hasComponentOfType = forms.ChoiceField(label=_('Has Compound Component Type'),
                                            choices=get_component_role_choice,
                                            widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     hasComponentOfType.field_choice_category = 'MorphologyType'
-    hasMorphemeOfType = forms.ChoiceField(label=_(u'Has Morpheme Type'),
+    hasMorphemeOfType = forms.ChoiceField(label=_('Has Morpheme Type'),
                                           choices=get_morpheme_role_choices,
                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     hasMorphemeOfType.field_choice_category = 'MorphemeType'
 
-    repeat = forms.ChoiceField(label=_(u'Repeating Movement'),choices=NULLBOOLEANCHOICES)
-    altern = forms.ChoiceField(label=_(u'Alternating Movement'),choices=NULLBOOLEANCHOICES)
+    repeat = forms.ChoiceField(label=_('Repeating Movement'),choices=NULLBOOLEANCHOICES)
+    altern = forms.ChoiceField(label=_('Alternating Movement'),choices=NULLBOOLEANCHOICES)
 
-    weakprop = forms.ChoiceField(label=_(u'Weak Prop'),choices=NEUTRALQUERYCHOICES)
-    weakdrop = forms.ChoiceField(label=_(u'Weak Drop'),choices=NEUTRALQUERYCHOICES)
+    weakprop = forms.ChoiceField(label=_('Weak Prop'),choices=NEUTRALQUERYCHOICES)
+    weakdrop = forms.ChoiceField(label=_('Weak Drop'),choices=NEUTRALQUERYCHOICES)
 
-    domhndsh_letter = forms.ChoiceField(label=_(u'letter'),choices=UNKNOWNBOOLEANCHOICES)
-    domhndsh_number = forms.ChoiceField(label=_(u'number'),choices=UNKNOWNBOOLEANCHOICES)
+    domhndsh_letter = forms.ChoiceField(label=_('letter'),choices=UNKNOWNBOOLEANCHOICES)
+    domhndsh_number = forms.ChoiceField(label=_('number'),choices=UNKNOWNBOOLEANCHOICES)
 
-    subhndsh_letter = forms.ChoiceField(label=_(u'letter'),choices=UNKNOWNBOOLEANCHOICES)
-    subhndsh_number = forms.ChoiceField(label=_(u'number'),choices=UNKNOWNBOOLEANCHOICES)
+    subhndsh_letter = forms.ChoiceField(label=_('letter'),choices=UNKNOWNBOOLEANCHOICES)
+    subhndsh_number = forms.ChoiceField(label=_('number'),choices=UNKNOWNBOOLEANCHOICES)
 
-    isNew = forms.ChoiceField(label=_(u'Is a proposed new sign'),choices=NULLBOOLEANCHOICES)
-    inWeb = forms.ChoiceField(label=_(u'Is in Web Dictionary'),choices=NULLBOOLEANCHOICES)
-    excludeFromEcv = forms.ChoiceField(label=_(u'Exclude from ECV'),choices=NULLBOOLEANCHOICES)
+    isNew = forms.ChoiceField(label=_('Is a proposed new sign'),choices=NULLBOOLEANCHOICES)
+    inWeb = forms.ChoiceField(label=_('Is in Web Dictionary'),choices=NULLBOOLEANCHOICES)
+    excludeFromEcv = forms.ChoiceField(label=_('Exclude from ECV'),choices=NULLBOOLEANCHOICES)
 
     # this field's choices are set dynamically in the __init__ method below
     # It's presence here is used statically by the query parameters method which looks at the gloss search form fields
-    definitionRole = forms.ChoiceField(label=_(u'Note Type'),
+    definitionRole = forms.ChoiceField(label=_('Note Type'),
                                        choices=get_definition_role_choices,
                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     definitionRole.field_choice_category = 'NoteType'
-    definitionContains = forms.CharField(label=_(u'Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
 
-    createdBy = forms.CharField(label=_(u'Created By'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
-    createdAfter = forms.DateField(label=_(u'Created After'),
+    createdBy = forms.CharField(label=_('Created By'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    createdAfter = forms.DateField(label=_('Created After'),
                                    input_formats=[settings.DATE_FORMAT], required=False,
                                    widget=forms.TextInput(attrs={'type': 'date'}))
-    createdBefore = forms.DateField(label=_(u'Created Before'),
+    createdBefore = forms.DateField(label=_('Created Before'),
                                     input_formats=[settings.DATE_FORMAT], required=False,
                                     widget=forms.TextInput(attrs={'type': 'date'}))
 
@@ -288,8 +289,6 @@ class GlossSearchForm(forms.ModelForm):
     menu_bar_translation = "Menu Bar Search Senses"
 
     class Meta:
-
-        ATTRS_FOR_FORMS = {'class':'form-control'}
 
         model = Gloss
         fields = settings.FIELDS['phonology'] + settings.FIELDS['semantics'] + settings.FIELDS['main'] + ['inWeb', 'isNew', 'excludeFromEcv']
@@ -330,7 +329,7 @@ class GlossSearchForm(forms.ModelForm):
         fields_with_choices['definitionRole'] = 'NoteType'
         for (fieldname, field_category) in fields_with_choices.items():
             if fieldname == 'definitionRole':
-                field_label = _(u'Note Type')
+                field_label = _('Note Type')
             else:
                 field_label = Gloss.get_field(fieldname).verbose_name
             if fieldname.startswith('semField'):
@@ -345,7 +344,7 @@ class GlossSearchForm(forms.ModelForm):
             self.fields[fieldname] = forms.TypedMultipleChoiceField(label=field_label,
                                                         choices=translated_choices,
                                                         required=False, widget=Select2)
-        self.fields['hasComponentOfType'] = forms.ChoiceField(label=_(u'Has Compound Component Type'),
+        self.fields['hasComponentOfType'] = forms.ChoiceField(label=_('Has Compound Component Type'),
                                                           choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='MorphologyType').order_by(
@@ -353,7 +352,7 @@ class GlossSearchForm(forms.ModelForm):
                                                               ordered=False, id_prefix='', shortlist=False
                                                           ),
                                            widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hasMorphemeOfType'] = forms.ChoiceField(label=_(u'Has Morpheme Type'),
+        self.fields['hasMorphemeOfType'] = forms.ChoiceField(label=_('Has Morpheme Type'),
                                                              choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='MorphemeType').order_by(
@@ -422,38 +421,42 @@ class MorphemeSearchForm(forms.ModelForm):
 
     search = forms.CharField(label=_("Search Gloss"))
     sortOrder = forms.CharField(label=_("Sort Order"))
-    tags = forms.ChoiceField(label=_('Tags'), choices=tag_choices)
+    tags = forms.ChoiceField(label=_('Tags'), choices=[(0, '-')],
+                             widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     translation = forms.CharField(label=_('Search Senses'))
-    hasvideo = forms.ChoiceField(label=_('Has Video'), choices=NULLBOOLEANCHOICES)
+    hasvideo = forms.ChoiceField(label=_('Has Video'), choices=[(0, '-')],
+                                 widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
     useInstr = forms.CharField(label=_("Annotation instructions"))
 
-    phonOth = forms.CharField(label=_(u'Phonology Other'), widget=forms.TextInput())
+    phonOth = forms.CharField(label=_('Phonology Other'), widget=forms.TextInput())
 
-    repeat = forms.ChoiceField(label=_(u'Repeating Movement'),
-                               choices=NULLBOOLEANCHOICES)
-    altern = forms.ChoiceField(label=_(u'Alternating Movement'),
-                               choices=NULLBOOLEANCHOICES)
+    repeat = forms.ChoiceField(label=_('Repeating Movement'),
+                               choices=[(0, '-')],
+                               widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    altern = forms.ChoiceField(label=_('Alternating Movement'),
+                               choices=[(0, '-')],
+                               widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    isNew = forms.ChoiceField(label=_(u'Is a proposed new sign'), choices=NULLBOOLEANCHOICES,
-                              widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    inWeb = forms.ChoiceField(label=_(u'Is in Web Dictionary'), choices=NULLBOOLEANCHOICES,
-                              widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    isNew = forms.ChoiceField(label=_('Is a proposed new sign'), choices=[(0, '-')],
+                              widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
+    inWeb = forms.ChoiceField(label=_('Is in Web Dictionary'), choices=[(0, '-')],
+                              widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    definitionRole = forms.ChoiceField(label=_(u'Note Type'), choices=get_definition_role_choices,
+    definitionRole = forms.ChoiceField(label=_('Note Type'), choices=get_definition_role_choices,
                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     definitionRole.field_choice_category = 'NoteType'
-    definitionContains = forms.CharField(label=_(u'Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
-    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=YESNOCHOICES,
-                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=[(0, '-')],
+                                      widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
-    createdBefore = forms.DateField(label=_(u'Created Before'),
+    createdBefore = forms.DateField(label=_('Created Before'),
                                     input_formats=[settings.DATE_FORMAT],
                                     widget=forms.TextInput(attrs={'class': 'form-control', 'type': 'date'}))
-    createdAfter = forms.DateField(label=_(u'Created After'),
+    createdAfter = forms.DateField(label=_('Created After'),
                                    input_formats=[settings.DATE_FORMAT],
                                    widget=forms.TextInput(attrs={'class': 'form-control', 'type': 'date'}))
 
-    createdBy = forms.CharField(label=_(u'Created By'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
+    createdBy = forms.CharField(label=_('Created By'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
 
     gloss_search_field_prefix = "morphemesearch_"
     keyword_search_field_prefix = "keyword_"
@@ -462,11 +465,10 @@ class MorphemeSearchForm(forms.ModelForm):
     menu_bar_translation = "Menu Bar Search Senses"
 
     class Meta:
-        ATTRS_FOR_FORMS = {'class': 'form-control'}
 
         model = Morpheme
 
-        fields = settings.MORPHEME_DISPLAY_FIELDS + settings.FIELDS['semantics'] + settings.FIELDS['main'] + ['inWeb', 'isNew']
+        fields = settings.MORPHEME_DISPLAY_FIELDS + settings.FIELDS['semantics'] + settings.FIELDS['main'] + ['inWeb', 'isNew', 'mrpType']
 
     def __init__(self, *args, **kwargs):
         super(MorphemeSearchForm, self).__init__(*args, **kwargs)
@@ -476,14 +478,12 @@ class MorphemeSearchForm(forms.ModelForm):
             morphemesearch_field_label = _("Annotation") + (" (%s)" % language.name)
             self.fields[morphemesearch_field_name] = forms.CharField(label=morphemesearch_field_label)
 
-            # do the same for Translations
             # Morphemes have translations not senses
             keyword_field_name = self.keyword_search_field_prefix + language.language_code_2char
             keyword_field_label = _("Translations")+(" (%s)" % language.name)
             self.fields[keyword_field_name] = forms.CharField(label=keyword_field_label)
             self.fields[keyword_field_name].widget.label = keyword_field_label
 
-            # and for LemmaIdgloss
             lemma_field_name = self.lemma_search_field_prefix + language.language_code_2char
             lemma_field_label = _("Lemma")+(" (%s)" % language.name)
             self.fields[lemma_field_name] = forms.CharField(label=lemma_field_label)
@@ -495,29 +495,32 @@ class MorphemeSearchForm(forms.ModelForm):
         for (fieldname, field_category) in fields_with_choices.items():
             # morphemes do not have Handshape fields, these are hidden, see issue #638
             if fieldname == 'definitionRole':
-                field_label = _(u'Note Type')
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category)
+                field_label = _('Note Type')
+                field_choices = FieldChoice.objects.filter(field__iexact=field_category).order_by('name')
             elif fieldname.startswith('mrpType'):
                 field_label = Morpheme.get_field(fieldname).verbose_name
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category)
+                field_choices = FieldChoice.objects.filter(field__iexact=field_category).order_by('name')
             elif fieldname.startswith('semField'):
                 field_label = Gloss.get_field(fieldname).verbose_name
-                field_choices = SemanticField.objects.all()
+                field_choices = SemanticField.objects.all().order_by('name')
             elif fieldname.startswith('derivHist'):
                 field_label = Gloss.get_field(fieldname).verbose_name
-                field_choices = DerivationHistory.objects.all()
+                field_choices = DerivationHistory.objects.all().order_by('name')
             else:
                 field_label = Gloss.get_field(fieldname).verbose_name
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category)
-            translated_choices = choicelist_queryset_to_translated_dict(field_choices,ordered=False, id_prefix='',
+                field_choices = FieldChoice.objects.filter(field__iexact=field_category).order_by('name')
+            translated_choices = choicelist_queryset_to_translated_dict(field_choices, ordered=False, id_prefix='',
                                                                         shortlist=True)
-            self.fields[fieldname] = forms.TypedMultipleChoiceField(label=field_label,
+            self.fields[fieldname] = forms.ChoiceField(label=field_label,
                                                                     choices=translated_choices,
                                                                     required=False, widget=Select2)
         self.fields['tags'] = forms.ChoiceField(label=_('Tags'),
                                                 choices=[(tag.name, tag.name.replace('_', ' '))
                                                          for tag in Tag.objects.all()],
                                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+        for boolean_field in ['hasvideo', 'repeat', 'altern', 'isNew', 'inWeb', 'defspublished']:
+            boolean_choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]
+            self.fields[boolean_field].choices = boolean_choices
 
 
 class DefinitionForm(forms.ModelForm):
@@ -527,7 +530,7 @@ class DefinitionForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields['note'] = forms.ChoiceField(label=_(u'Type'),
+        self.fields['note'] = forms.ChoiceField(label=_('Type'),
                                                 choices=choicelist_queryset_to_translated_dict(
                                                      list(FieldChoice.objects.filter(field='NoteType').order_by(
                                                          'machine_value')),
@@ -538,8 +541,8 @@ class DefinitionForm(forms.ModelForm):
 
 class RelationForm(forms.ModelForm):
     
-    sourceid = forms.CharField(label=_(u'Source Gloss'))
-    targetid = forms.CharField(label=_(u'Target Gloss'))
+    sourceid = forms.CharField(label=_('Source Gloss'))
+    targetid = forms.CharField(label=_('Target Gloss'))
     
     class Meta:
         model = Relation
@@ -550,8 +553,8 @@ class RelationForm(forms.ModelForm):
 
 
 class VariantsForm(forms.Form):
-    sourceid = forms.CharField(label=_(u'Source Gloss'))
-    targetid = forms.CharField(label=_(u'Target Gloss'))
+    sourceid = forms.CharField(label=_('Source Gloss'))
+    targetid = forms.CharField(label=_('Target Gloss'))
 
     class Meta:
         model = Relation
@@ -559,9 +562,9 @@ class VariantsForm(forms.Form):
 
 class RelationToForeignSignForm(forms.ModelForm):
 
-    sourceid = forms.CharField(label=_(u'Source Gloss'))
-    other_lang = forms.CharField(label=_(u'Related Language'))
-    other_lang_gloss = forms.CharField(label=_(u'Gloss in Related Language'), required=False)
+    sourceid = forms.CharField(label=_('Source Gloss'))
+    other_lang = forms.CharField(label=_('Related Language'))
+    other_lang_gloss = forms.CharField(label=_('Gloss in Related Language'), required=False)
     
     class Meta:
         model = RelationToForeignSign
@@ -577,10 +580,10 @@ def get_morphology_type_choices():
 class GlossMorphologyForm(forms.Form):
     """Morphology specification of a Gloss"""
 
-    parent_gloss_id = forms.CharField(label=_(u'Parent Gloss'))
-    role = forms.ChoiceField(label=_(u'Type'),choices=[],
+    parent_gloss_id = forms.CharField(label=_('Parent Gloss'))
+    role = forms.ChoiceField(label=_('Type'),choices=[],
                              widget=forms.Select(attrs=ATTRS_FOR_FORMS), required=True)
-    morpheme_id = forms.CharField(label=_(u'Morpheme'))
+    morpheme_id = forms.CharField(label=_('Morpheme'))
 
     def __init__(self, *args, **kwargs):
         super(GlossMorphologyForm, self).__init__(*args, **kwargs)
@@ -591,17 +594,17 @@ class GlossMorphologyForm(forms.Form):
 class GlossMorphemeForm(forms.Form):
     """Specify simultaneous morphology components belonging to a Gloss"""
 
-    host_gloss_id = forms.CharField(label=_(u'Host Gloss'))
-    description = forms.CharField(label=_(u'Meaning'), required=False)
-    morph_id = forms.CharField(label=_(u'Morpheme'))
+    host_gloss_id = forms.CharField(label=_('Host Gloss'))
+    description = forms.CharField(label=_('Meaning'), required=False)
+    morph_id = forms.CharField(label=_('Morpheme'))
 
 
 class GlossBlendForm(forms.Form):
     """Specify simultaneous morphology components belonging to a Gloss"""
 
-    host_gloss_id = forms.CharField(label=_(u'Host Gloss'))
-    role = forms.CharField(label=_(u'Role'))
-    blend_id = forms.CharField(label=_(u'Blend'))
+    host_gloss_id = forms.CharField(label=_('Host Gloss'))
+    role = forms.CharField(label=_('Role'))
+    blend_id = forms.CharField(label=_('Blend'))
 
 
 def get_other_media_type_choices():
@@ -622,7 +625,7 @@ class OtherMediaForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super(OtherMediaForm, self).__init__(*args, **kwargs)
-        self.fields['type'] = forms.ChoiceField(label=_(u'Type'),
+        self.fields['type'] = forms.ChoiceField(label=_('Type'),
                                                 choices= choicelist_queryset_to_translated_dict(
                                                     list(FieldChoice.objects.filter(field='OtherMediaType').order_by(
                                                         'machine_value')),
@@ -744,7 +747,7 @@ class HandshapeSearchForm(forms.ModelForm):
     def __init__(self, queryDict=None, *args, **kwargs):
         super(HandshapeSearchForm, self).__init__(queryDict, *args, **kwargs)
 
-        self.fields['unselectedFingers'] = forms.ChoiceField(label=_(u'Unselected Fingers Extended'),
+        self.fields['unselectedFingers'] = forms.ChoiceField(label=_('Unselected Fingers Extended'),
                                                     choices=choicelist_queryset_to_translated_dict(
                                                         list(
                                                             FieldChoice.objects.filter(field='FingerSelection').order_by(
@@ -752,7 +755,7 @@ class HandshapeSearchForm(forms.ModelForm):
                                                         ordered=False, id_prefix='', shortlist=False
                                                     ),
                                                     widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hsNumSel'] = forms.ChoiceField(label=_(u'Quantity'),
+        self.fields['hsNumSel'] = forms.ChoiceField(label=_('Quantity'),
                                                     choices=choicelist_queryset_to_translated_dict(
                                                           list(
                                                               FieldChoice.objects.filter(field='Quantity').order_by(
@@ -760,7 +763,7 @@ class HandshapeSearchForm(forms.ModelForm):
                                                           ordered=False, id_prefix='', shortlist=False
                                                     ),
                                                     widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hsFingConf'] = forms.ChoiceField(label=_(u'Finger configuration'),
+        self.fields['hsFingConf'] = forms.ChoiceField(label=_('Finger configuration'),
                                                       choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='JointConfiguration').order_by(
@@ -768,7 +771,7 @@ class HandshapeSearchForm(forms.ModelForm):
                                                               ordered=False, id_prefix='', shortlist=False
                                                       ),
                                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hsFingConf2'] = forms.ChoiceField(label=_(u'Finger configuration 2'),
+        self.fields['hsFingConf2'] = forms.ChoiceField(label=_('Finger configuration 2'),
                                                        choices=choicelist_queryset_to_translated_dict(
                                                           list(
                                                               FieldChoice.objects.filter(field='JointConfiguration').order_by(
@@ -776,7 +779,7 @@ class HandshapeSearchForm(forms.ModelForm):
                                                           ordered=False, id_prefix='', shortlist=False
                                                        ),
                                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hsSpread'] = forms.ChoiceField(label=_(u'Spreading'),
+        self.fields['hsSpread'] = forms.ChoiceField(label=_('Spreading'),
                                                     choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='Spreading').order_by(
@@ -784,7 +787,7 @@ class HandshapeSearchForm(forms.ModelForm):
                                                               ordered=False, id_prefix='', shortlist=False
                                                     ),
                                                     widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        self.fields['hsAperture'] = forms.ChoiceField(label=_(u'Aperture'),
+        self.fields['hsAperture'] = forms.ChoiceField(label=_('Aperture'),
                                                       choices=choicelist_queryset_to_translated_dict(
                                                               list(
                                                                   FieldChoice.objects.filter(field='Aperture').order_by(
@@ -848,8 +851,8 @@ class LemmaSearchForm(forms.ModelForm):
     search = forms.CharField(label=_("Lemma"))
     sortOrder = forms.CharField(label=_("Sort Order"))
     lemma_search_field_prefix = "lemma_"
-    no_glosses = forms.ChoiceField(label=_(u'Only show results without glosses'),choices=NO_GLOSS_SELECTION)
-    has_glosses = forms.ChoiceField(label=_(u'Only show results with glosses'),choices=NO_GLOSS_SELECTION)
+    no_glosses = forms.ChoiceField(label=_('Only show results without glosses'),choices=NO_GLOSS_SELECTION)
+    has_glosses = forms.ChoiceField(label=_('Only show results with glosses'),choices=NO_GLOSS_SELECTION)
     menu_bar_search = "Menu Bar Search Gloss"
     menu_bar_translation = "Menu Bar Search Translation"
 
@@ -1028,11 +1031,11 @@ class FocusGlossSearchForm(forms.ModelForm):
     sortOrder = forms.CharField(label=_("Sort Order"))       # Used in glosslistview to store user-selection
     translation = forms.CharField(label=_('Search Senses'))
 
-    oriChAbd = forms.ChoiceField(label=_(u'Abduction Change'),choices=NULLBOOLEANCHOICES)
-    oriChFlex = forms.ChoiceField(label=_(u'Flexion Change'),choices=NULLBOOLEANCHOICES)
+    oriChAbd = forms.ChoiceField(label=_('Abduction Change'), choices=NULLBOOLEANCHOICES)
+    oriChFlex = forms.ChoiceField(label=_('Flexion Change'), choices=NULLBOOLEANCHOICES)
 
-    repeat = forms.ChoiceField(label=_(u'Repeating Movement'),choices=NULLBOOLEANCHOICES)
-    altern = forms.ChoiceField(label=_(u'Alternating Movement'),choices=NULLBOOLEANCHOICES)
+    repeat = forms.ChoiceField(label=_('Repeating Movement'), choices=NULLBOOLEANCHOICES)
+    altern = forms.ChoiceField(label=_('Alternating Movement'), choices=NULLBOOLEANCHOICES)
 
     gloss_search_field_prefix = "glosssearch_"
     keyword_search_field_prefix = "keyword_"
@@ -1449,8 +1452,8 @@ class SearchHistoryForm(forms.ModelForm):
 class SentenceForm(forms.ModelForm):
 
     sentenceType = forms.ChoiceField(label=_("Type"), choices=[])
-    negative = forms.ChoiceField(label=_(u'Negative'), choices=YESNOCHOICES)
-    sentenceContains = forms.CharField(label=_(u'Sentence Contains'),
+    negative = forms.ChoiceField(label=_('Negative'), choices=YESNOCHOICES)
+    sentenceContains = forms.CharField(label=_('Sentence Contains'),
                                        widget=forms.TextInput(attrs=ATTRS_FOR_FORMS), required=False)
 
     class Meta:

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -1353,7 +1353,8 @@ class SearchHistoryForm(forms.ModelForm):
 
 class SentenceForm(forms.ModelForm):
 
-    sentenceType = forms.ChoiceField(label=_("Type"), choices=[('0', '-')])
+    use_required_attribute = False  # otherwise the html required attribute will show up on every form
+
     negative = forms.ChoiceField(label=_('Negative'), choices=[('0', '-')],
                                  widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
     sentenceContains = forms.CharField(label=_('Sentence Contains'),
@@ -1370,12 +1371,7 @@ class SentenceForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(SentenceForm, self).__init__(*args, **kwargs)
 
-        field_choices = FieldChoice.objects.filter(field__iexact='sentenceType')
-
-        translated_choices = choicelist_queryset_to_translated_dict(field_choices,
-                                                                    ordered=False, id_prefix='',
-                                                                    shortlist=True)
-        self.fields['sentenceType'] = forms.TypedMultipleChoiceField(label=_('Type'),
-                                                                     choices=translated_choices,
-                                                                     required=False, widget=Select2)
+        self.fields['sentenceType'] = forms.ChoiceField(label=_('Type'),
+                                                        choices=[(0, '-')],
+                                                        required=False, widget=Select2)
         self.fields['negative'].choices = [('0', '-'), ('yes', _('Yes')), ('no', _('No'))]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -441,7 +441,7 @@ class MorphemeSearchForm(forms.ModelForm):
                               widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
 
     definitionRole = forms.ChoiceField(label=_('Note Type'), choices=[(0, '-')],
-                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+                                       required=False, widget=Select2)
     definitionContains = forms.CharField(label=_('Note Contains'), widget=forms.TextInput(attrs=ATTRS_FOR_FORMS))
     defspublished = forms.ChoiceField(label=_("All Definitions Published"), choices=[(0, '-')],
                                       widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
@@ -471,40 +471,26 @@ class MorphemeSearchForm(forms.ModelForm):
         super(MorphemeSearchForm, self).__init__(*args, **kwargs)
 
         # language fields will be set up elsewhere
-
-        fieldnames = FIELDS['main']+settings.MORPHEME_DISPLAY_FIELDS+FIELDS['semantics']+['mrpType']
-        fields_with_choices = fields_to_fieldcategory_dict(fieldnames)
-        fields_with_choices['definitionRole'] = 'NoteType'
-
-        for (fieldname, field_category) in fields_with_choices.items():
+        # field choice choices will be set up elsewhere
+        # these are the multiselect field choice fields for morphemes
+        fieldnames = ['handedness', 'handCh', 'relatArtic', 'locprim', 'relOriMov',
+                      'relOriLoc', 'oriCh', 'contType', 'movSh', 'movDir', 'mrpType', 'wordClass',
+                      'semField', 'derivHist', 'namEnt', 'valence']
+        for fieldname in fieldnames:
             # morphemes do not have Handshape fields, these are hidden, see issue #638
-            if fieldname == 'definitionRole':
-                field_label = _('Note Type')
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category).order_by('name')
-            elif fieldname.startswith('mrpType'):
+            if fieldname.startswith('mrpType'):
                 field_label = Morpheme.get_field(fieldname).verbose_name
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category).order_by('name')
-            elif fieldname.startswith('semField'):
-                field_label = Gloss.get_field(fieldname).verbose_name
-                field_choices = SemanticField.objects.all().order_by('name')
-            elif fieldname.startswith('derivHist'):
-                field_label = Gloss.get_field(fieldname).verbose_name
-                field_choices = DerivationHistory.objects.all().order_by('name')
             else:
                 field_label = Gloss.get_field(fieldname).verbose_name
-                field_choices = FieldChoice.objects.filter(field__iexact=field_category).order_by('name')
-            translated_choices = choicelist_queryset_to_translated_dict(field_choices, ordered=False, id_prefix='',
-                                                                        shortlist=True)
             self.fields[fieldname] = forms.ChoiceField(label=field_label,
-                                                                    choices=translated_choices,
-                                                                    required=False, widget=Select2)
+                                                       choices=[(0, '-')],
+                                                       required=False, widget=Select2)
         self.fields['tags'] = forms.ChoiceField(label=_('Tags'),
                                                 choices=[(tag.name, tag.name.replace('_', ' '))
                                                          for tag in Tag.objects.all()],
                                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
         for boolean_field in ['hasvideo', 'repeat', 'altern', 'isNew', 'inWeb', 'defspublished']:
-            boolean_choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]
-            self.fields[boolean_field].choices = boolean_choices
+            self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]
 
 
 class DefinitionForm(forms.ModelForm):

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2243,12 +2243,6 @@ class Gloss(models.Model):
 
         return self.options_to_json(RELATION_ROLE_CHOICES)
 
-    def handedness_weak_choices_json(self):
-        """Return JSON for the etymology choice list"""
-        from signbank.dictionary.forms import NEUTRALBOOLEANCHOICES
-
-        return self.options_to_json(NEUTRALBOOLEANCHOICES)
-
     def handedness_weak_drop_prop_json(self):
         """Return JSON for the etymology choice list"""
 

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -638,37 +638,38 @@ function do_toggle_language(el) {
                         {% for dataset_lang in dataset_languages %}
 
                         <tr>
-                            {% with searchform|get_search_field_for_language:dataset_lang as search_field %}
+                            {% with searchform|get_annotation_search_field_for_language:dataset_lang as search_field %}
                             <td>
                                 <div class='input-group'>
-                                <label class='input-group-addon' for='id_annotation_idgloss_{{ dataset_lang.language_code_2char }}'>
+                                <label class='input-group-addon' for='id_annotation_idgloss_{{dataset_lang.language_code_2char}}'>
                                     {{search_field.label}}
                                 </label>
-                                <input id='glosssearch_{{ dataset_lang.language_code_2char }}'
+                                <input id='glosssearch_{{dataset_lang.language_code_2char}}'
                                        type='text'
-                                       name='glosssearch_{{ dataset_lang.language_code_2char }}' class='form-control' {% if search_field.value %}value='{{search_field.value}}'{% endif %}>
+                                       name='glosssearch_{{dataset_lang.language_code_2char}}' class='form-control'>
                                 </div>
                             </td>
                             {% endwith %}
 
-                            {% with searchform|get_lemma_field_for_language:dataset_lang as lemma_field %}
+                            {% with searchform|get_lemma_form_field_for_language:dataset_lang as lemma_field %}
                             <td><div class='input-group'>
 
-                                <label class='input-group-addon' for='id_lemma_{{ dataset_lang.language_code_2char }}'>
+                                <label class='input-group-addon' for='id_lemma_{{dataset_lang.language_code_2char}}'>
                                     {{lemma_field.label}}
                                 </label>
-                                <input name='lemma_{{ dataset_lang.language_code_2char }}'
+                                <input name='lemma_{{dataset_lang.language_code_2char}}'
                                        type='text'
-                                       class='form-control' {% if lemma_field.value %}value='{{lemma_field.value}}'{% endif %}></div>
+                                       class='form-control'></div>
                             </td>
                             {% endwith %}
 
-                            {% with searchform|get_keyword_field_for_language:dataset_lang as keyword_field %}
+                            {% with searchform|get_senses_form_field_for_language:dataset_lang as keyword_field %}
                             <td><div class='input-group'>
-                                <label class='input-group-addon' for='id_keyword_{{ dataset_lang.language_code_2char }}'>{{keyword_field.label}}</label>
-                                <input name='keyword_{{ dataset_lang.language_code_2char }}'
+                                <label class='input-group-addon' for='id_keyword_{{dataset_lang.language_code_2char}}'>
+                                    {{keyword_field.label}}</label>
+                                <input name='keyword_{{dataset_lang.language_code_2char}}'
                                        type='text'
-                                       class='form-control' {% if keyword_field.value %}value='{{keyword_field.value}}'{% endif %}></div>
+                                       class='form-control'></div>
                             </td>
                             {% endwith %}
                         </tr>
@@ -722,8 +723,8 @@ function do_toggle_language(el) {
                                 </tr>
                                 <tr><td style="padding-left:30px;"><label for='id_hasComponentOfType'>{{searchform.hasComponentOfType.label}}</label></td>
                                     <td style="width:600px;">{{searchform.hasComponentOfType}}</td></tr>
-                                <tr><td style="padding-left:30px;"><label for='id_hasMorphemeOfType'>{{searchform.hasMorphemeOfType.label}}</label></td>
-                                    <td style="width:600px;">{{searchform.hasMorphemeOfType}}</td></tr>
+                                <tr><td style="padding-left:30px;"><label for='id_mrpType'>{{searchform.mrpType.label}}</label></td>
+                                    <td style="width:600px;">{{searchform.mrpType}}</td></tr>
                             </table>
 
                           </td>

--- a/signbank/dictionary/templates/dictionary/admin_gloss_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_gloss_list.html
@@ -210,21 +210,24 @@ $(document).ready(function() {
         };
      }
 
+     if (query_parameters_keys.includes('morpheme')) {
+        var query_initial = query_parameters_dict['morpheme'];
+        console.log('morpheme '+query_initial+' '+morpheme_idgloss);
+        // special case for morpheme, the query parameter is its ID, stored in a hidden field
+        var morpheme_id = '#morpheme_id';
+        $(morpheme_id).attr('value', query_initial);
+        // the context variable morpheme_idgloss is shown to the user
+        var this_id = '#morphemeidgloss';
+        $(this_id).val(morpheme_idgloss);
+     }
+
      // initialize non-multiple select, not language-based query fields
      for (var i = 0; i < other_parameters_keys.length; i++) {
         var this_var = other_parameters_keys[i];
         if (query_parameters_keys.includes(this_var)) {
             var this_id = '#id_' + other_parameters_keys[i];
             var query_initial = query_parameters_dict[this_var];
-            if (this_var == 'morpheme') {
-                // special case for morpheme, the query parameter is its ID, stored in a hidden field
-                var $hiddeninput = $("input[name='morpheme']");
-                $hiddeninput.val(query_initial);
-                // the context variable morpheme_idgloss is shown to the user
-                $(this_id).attr('value', morpheme_idgloss);
-            } else {
-                $(this_id).val(query_initial);
-            };
+            $(this_id).val(query_initial);
         };
     }
 
@@ -354,6 +357,7 @@ function clearForm() {
       $('input').each(function() {
         var this_field = $(this).attr('name');
         if (this_field == undefined) { return; };
+        if (this_field == 'morpheme') { $(this).attr('value', ""); return; };
         var this_type = $(this).attr('type');
         if (this_type == 'hidden' || this_type == 'submit' || this_type == 'radio') { return; };
         if (this_type == 'date') {
@@ -362,7 +366,7 @@ function clearForm() {
             $(this).val('');
         };
       });
-
+      $('#morphemeidgloss').val('');
       $('select').each(function() {
         var this_field = $(this).attr('name');
         if (this_field == undefined) { return; };
@@ -717,8 +721,11 @@ function do_toggle_language(el) {
                                 <tr>
                                     <td style="padding-left:30px;"><label for='id_morpheme'>{{searchform.morpheme.label}}</label></td>
                                     <td style="width:600px;">
-                                        <input class='form-control morphtypeahead' id="id_morpheme" placeholder='{% trans "Morpheme Gloss" %}' value="{{searchform.morpheme.value|default:''}}"/>
-                                        <input type="hidden" name='morpheme' value=""/>
+                                        <input class='form-control morphtypeahead'
+                                               id="morphemeidgloss"
+                                               placeholder='{% trans "Morpheme Gloss" %}'
+                                               value=""/>
+                                        <input type="hidden" name='morpheme' id='morpheme_id' value=""/>
                                     </td>
                                 </tr>
                                 <tr><td style="padding-left:30px;"><label for='id_hasComponentOfType'>{{searchform.hasComponentOfType.label}}</label></td>

--- a/signbank/dictionary/templates/dictionary/admin_handshape_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_handshape_list.html
@@ -25,52 +25,35 @@
     <script type='text/javascript'>
 
 
-// http://www.javascript-coder.com/javascript-form/javascript-reset-form.phtml
-function clearForm(myFormElement) {
+function clearForm() {
 
-  var elements = myFormElement.elements;
+      $('input').each(function() {
+        var this_field = $(this).attr('name');
+        if (this_field == undefined) { return; };
+        var this_type = $(this).attr('type');
+        if (this_type == 'hidden' || this_type == 'submit') { return; };
+        if (this_type == 'radio') {
+            $(this).prop('checked', false);
+        } else {
+            $(this).val('');
+        };
+      });
 
-  myFormElement.reset();
-
-  for(i=0; i<elements.length; i++) {
-
-      field_type = elements[i].type.toLowerCase();
-      field_name = elements[i].name;
-
-      if (field_name == 'search_type') {
-        elements[i].value = "handshape";
-      }
-      else if (field_name == 'sortOrder') {
-        elements[i].value = "machine_value";
-      }
-      else {
-          switch(field_type) {
-
-            case "text":
-            case "textarea":
-
-              elements[i].value = "";
-              break;
-
-            case "radio":
-            case "checkbox":
-              if (elements[i].checked) {
-                  elements[i].checked = false;
-              }
-              break;
-
-            case "select-one":
-            case "select-multiple":
-              elements[i].selectedIndex = -1;
-              break;
-
-            default:
-              break;
-          }
-      }
-  }
-  return(false);
-  <!--document.getElementById('adminsearch').submit();-->
+      $('select').each(function() {
+        var this_field = $(this).attr('name');
+        if (this_field == undefined) { return; };
+        var this_type = $(this).attr('type');
+        if (this_type == 'hidden') { return; };
+        if (this_field.endsWith('[]')) {
+            return;
+        } else {
+            $(this).find('option').each(function () {
+                $(this).removeAttr("selected");
+            });;
+        };
+      });
+     $("input[name='translation']").val('');
+     $("input[name='search']").val('');
 }
 
 /**
@@ -98,27 +81,23 @@ function do_sort_column(field_name, action, frmName) {
   $("#" + frmName).submit();
 }
 
-
-/**
- * @returns {void}
- */
 function do_adminsearch(el) {
  var sSearchType = $(el).attr('value');
  $(el).selected = true;
   $("#adminsearch input[name='search_type']").val(sSearchType);
   switch(sSearchType) {
     case "sign_handshape":
-        $("#adminsearch").attr('action', '{{PREFIX_URL}}/dictionary/handshapes/');
+        $("#adminsearch").attr('action', '{{PREFIX_URL}}/signs/search_handshape/');
         break;
     case "handshape":
-        $("#adminsearch").attr('action', '{{PREFIX_URL}}/dictionary/handshapes/');
+        $("#adminsearch").attr('action', '{{PREFIX_URL}}/signs/search_handshape/');
         break;
   }
   document.getElementById('adminsearch').submit();
 }
    </script>
 
-    <script type='text/javascript' src="{{ STATIC_URL }}js/handshape_search.js"></script>
+    <script type='text/javascript' src="{{STATIC_URL}}js/handshape_search.js"></script>
 
     <!-- Expand and collapse all panels -->
     <script type='text/javascript'>
@@ -140,7 +119,7 @@ function do_adminsearch(el) {
 {% url 'dictionary:protected_media' '' as protected_media_url %}
 </div>
 <div id='searchformwell' class='well'>
-<form name='adminsearch' id='adminsearch'>
+<form name='adminsearch' id='adminsearch' method='get' action='{{PREFIX_URL}}/signs/search_handshape/'>
 <div class="panel panel-default">
 {% if not user.is_anonymous %}
 <div class="panel-heading" data-toggle="collapse" data-target="#queryarea">{% trans "Form Your Query" %}</div>
@@ -154,7 +133,9 @@ function do_adminsearch(el) {
                     <table class='table'>
                         <tr id='handshape_name_field'>
                             <td><label for='id_name'>{% trans "Handshape Name" %}</label></td>
-                            <td><input class='form-control handshapetypeahead' placeholder='{% trans "Handshape Name" %}' name='name' type='text'
+                            <td><input class='form-control handshapetypeahead'
+                                       placeholder='{% trans "Handshape Name" %}'
+                                       name='name' type='text'
                                        value="{{searchform.name.value|default:'' }}"/></td>
                         </tr>
                     </table>
@@ -349,7 +330,8 @@ function do_adminsearch(el) {
     <input class='btn btn-default' type='submit' name='format' value='CSV'>
     {% endif %}
 
-    <input class='btn btn-default' type='submit' onclick="clearForm(document.adminsearch);" value='{% trans "Reset" %}'>
+    <input class='btn btn-default' type='submit' name='reset'
+           onclick="clearForm();" value='{% trans "Reset" %}'>
 </div>
 {% endif %}
 </div>

--- a/signbank/dictionary/templates/dictionary/admin_handshape_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_handshape_list.html
@@ -483,7 +483,7 @@ function do_adminsearch(el) {
     {% for handshape in object_list %}
     <tr>
 
-      <td>{%if handshape.get_image_path != None %}
+      <td>{% if handshape.get_image_path %}
           <div class="thumbnail_container">
               <img class="thumbnail_handshape" src="{{protected_media_url}}{{handshape.get_image_path}}">
           </div>
@@ -534,7 +534,7 @@ function do_adminsearch(el) {
     {% for gloss in object_list %}
 
     <tr>
-      <td>{%if gloss.get_image_path != None %}
+      <td>{% if gloss.get_image_path %}
           <div class="thumbnail_container">
           <a href="{{PREFIX_URL}}/dictionary/gloss/{{gloss.pk}}/"><img class="thumbnail" src="{{protected_media_url}}{{gloss.get_image_path}}"></a>
           </div>

--- a/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
@@ -172,6 +172,15 @@ $(document).ready(function(){
         };
      }
 
+     // tags are multi-select but not included in multiple_select_fields because
+     // they don't have colours and are created differently
+     if (populate_fields_keys.includes('tags[]')) {
+         var query_initial = populate_fields['tags[]'];
+         var this_id = '#id_tags';
+         $(this_id).val(query_initial);
+         $(this_id).trigger('change');
+     };
+
      // initialize non-multiple select, not language-based query fields
      for (var i = 0; i < populate_fields_keys.length; i++) {
         var this_var = populate_fields_keys[i];

--- a/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
@@ -119,38 +119,6 @@ $(document).ready(function(){
 
      $('.js-example-basic-multiple').val(null).trigger('change');
 
-     <!--Alert: The sign language and dialect multiple select code differs from the other fields.-->
-     <!--The code must appear after the class initialisation for for js-example-basic-multiple to avoid applying it to these fields prematurely-->
-
-     <!--Alert: the id for sign language is SIGNLANG, not the same as the model field!-->
-     <!--Django was messing up the template generation otherwise -->
-     <!--The value field is signlanguage[] matches the model)-->
-
-     makeMultipleSelect('id_SIGNLANG', 'signlanguage[]');
-     $('#id_SIGNLANG').select2({
-        allowClear: true,
-        dropdownAutoWidth: true,
-        width: 'resolve',
-        placeholder: ''
-     });
-     $('#id_SIGNLANG').val(null).trigger('change');
-
-     $('#id_SIGNLANG').change(function() {
-        set_signlanguages_dialects();
-     });
-
-     <!--Alert: the id for the dialect field is dialects (plural), not the same as the model field!-->
-     <!--Django was messing up the template generation otherwise (without the s at the end)-->
-
-     makeMultipleSelect('id_dialects', 'dialect[]');
-     $('#id_dialects').select2({
-        allowClear: true,
-        dropdownAutoWidth: true,
-        width: 'resolve',
-        placeholder: ''
-     });
-     $('#id_dialects').val(null).trigger('change');
-
      makeMultipleSelect('id_tags', 'tags[]');
      $('#id_tags').select2({
         allowClear: true,
@@ -262,55 +230,6 @@ function do_sort_column(field_name, action, frmName) {
   $("#" + frmName).submit();
 }
 
-function set_signlanguages_dialects() {
-    this_selection_elt = $('#signlanguage_selection');
-    var signlanguage_str = '';
-    this_selection_elt.find(".select2-selection__choice").each(function(){
-        if (signlanguage_str) {
-            signlanguage_str+=','+$(this).attr('title');
-        }
-        else {
-            signlanguage_str = $(this).attr('title');
-        }
-    });
-
-    optionValues = [];
-
-    if (signlanguage_str) {
-        var signlanguages = signlanguage_str.split(",");
-        this_selection_choices = $('#signlanguage_selection');
-
-        for(i = 0; i < signlanguages.length; i++) {
-            $('#id_SIGNLANG option').each(function(){
-                if ($(this).html() == signlanguages[i]) {
-                    optionValues.push($(this).html());
-                };
-            });
-        };
-    }
-
-    $('#id_dialects').val(null).trigger('change');
-
-    this_selection_dialect_elt = $('#dialect_selection');
-    $('#id_dialects option').each(function(){
-        $(this).attr('disabled','disabled');
-    });
-    $('#id_dialects option').each(function(){
-        var this_node_str = $(this).html();
-        for(k = 0; k < optionValues.length; k++) {
-            if (this_node_str.startsWith(optionValues[k])) {
-                $(this).removeAttr('disabled');
-            }
-        };
-    });
-    $('#id_dialects').select2({
-        allowClear: true,
-        dropdownAutoWidth: true,
-        width: 'resolve'
-     });
-    $('#id_dialects').val(null).trigger('change');
-}
-
 /**
  * set the lemma language for the chosen dataset
  */
@@ -388,12 +307,12 @@ function do_set_lemma_language(el) {
                         <input id='morphemesearch_{{dataset_lang.language_code_2char}}'
                                name='morphemesearch_{{dataset_lang.language_code_2char}}'
                                type='text'
-                               class='form-control' {% if search_field.value %}value='{{search_field.value}}'{% endif %}>
+                               class='form-control'>
                         </div>
                     </td>
                     {% endwith %}
 
-                    {% with searchform|get_lemma_field_for_language:dataset_lang as lemma_field %}
+                    {% with searchform|get_lemma_form_field_for_language:dataset_lang as lemma_field %}
                     <td><div class='input-group'>
 
                         <label class='input-group-addon' for='id_lemma_{{dataset_lang.language_code_2char}}'>
@@ -401,16 +320,18 @@ function do_set_lemma_language(el) {
                         </label>
                         <input name='lemma_{{dataset_lang.language_code_2char}}'
                                type='text'
-                               class='form-control' {% if lemma_field.value %}value='{{lemma_field.value}}'{% endif %}></div>
+                               class='form-control'></div>
                     </td>
                     {% endwith %}
 
-                    {% with searchform|get_keyword_field_for_language:dataset_lang as keyword_field %}
+                    {% with searchform|get_keyword_form_field_for_language:dataset_lang as keyword_field %}
                     <td><div class='input-group'>
-                        <label class='input-group-addon' for='id_keyword_{{dataset_lang.language_code_2char}}'>{{keyword_field.label}}</label>
+                        <label class='input-group-addon' for='id_keyword_{{dataset_lang.language_code_2char}}'>
+                            {{keyword_field.label}}
+                        </label>
                         <input name='keyword_{{dataset_lang.language_code_2char}}'
                                type='text'
-                               class='form-control' {% if keyword_field.value %}value='{{keyword_field.value}}'{% endif %}></div>
+                               class='form-control'></div>
                     </td>
                     {% endwith %}
                 </tr>
@@ -419,23 +340,9 @@ function do_set_lemma_language(el) {
         </div>
 
             <div class="panel panel-default">
-                <div class="panel-heading" data-toggle="collapse" data-target="#searchpanels">{% trans "Search by Language and Basic Properties" %}</div>
+                <div class="panel-heading" data-toggle="collapse" data-target="#searchpanels">{% trans "Search by Basic Properties" %}</div>
 
                 <div id='searchpanels' class='collapse'>
-                <table class='table'>
-                    {% csrf_token %}
-                    <tr id='signlanguage_selection'>
-                        <td><label>{{searchform.SIGNLANG.label}}</label>
-                                {{searchform.SIGNLANG}}
-                        </td>
-                      </tr>
-                    <tr id='dialect_selection'>
-                        <td><label>{{searchform.dialects.label}}</label>
-                                {{searchform.dialects}}
-                        </td>
-                    </tr>
-
-                </table>
 
                 <table class='table'>
                     {% for fieldname,field,label in input_names_fields_and_labels.main %}
@@ -554,7 +461,7 @@ function do_set_lemma_language(el) {
     <option {% if paginate_by == 10 %}selected{% endif %}>10</option>
 </select>
 {% csrf_token %}
-<input type="submit" value = '{% trans "Refresh" %}' />
+<input type="submit" value='{% trans "Refresh" %}' />
 </div>
 </form>
 

--- a/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
@@ -15,10 +15,10 @@
 
 {% block extrajs %}
 <script type="text/javascript">
-    var url = '{{ PREFIX_URL }}';
-    var language_code = '{{ LANGUAGE_CODE }}';
-    var lemma_create_field_prefix = "{{ lemma_create_field_prefix }}";
-    var user_can_add_gloss = {{ perms.dictionary.add_gloss|yesno:"true,false" }};
+    var url = '{{PREFIX_URL}}';
+    var language_code = '{{LANGUAGE_CODE}}';
+    var lemma_create_field_prefix = "{{lemma_create_field_prefix}}";
+    var user_can_add_gloss = {{perms.dictionary.add_gloss|yesno:"true,false" }};
     var lookahead_initial_language = "{{default_dataset_lang}}";
 </script>
 
@@ -29,17 +29,19 @@
 }
 </style>
 
-<script type="text/javascript" src="{{ STATIC_URL }}js/jquery.jeditable.mini.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/jquery.jeditable.checkbox.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/typeahead.bundle.min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}js/gloss_add.js"></script>
+<script type="text/javascript" src="{{STATIC_URL}}js/jquery.jeditable.mini.js"></script>
+<script type="text/javascript" src="{{STATIC_URL}}js/jquery.jeditable.checkbox.js"></script>
+<script type="text/javascript" src="{{STATIC_URL}}js/typeahead.bundle.min.js"></script>
+<script type="text/javascript" src="{{STATIC_URL}}js/gloss_add.js"></script>
 <link href="//cdnjs.cloudflare.com/ajax/libs/select2/4.0.0/css/select2.css" rel="stylesheet"/>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.5/js/select2.full.js"></script>
 <script type='text/javascript'>
-var show_dataset_interface_options = {{ SHOW_DATASET_INTERFACE_OPTIONS|yesno:"true,false" }};
-var user_can_add_morpheme = {{ perms.dictionary.add_morpheme|yesno:"true,false" }};
+var show_dataset_interface_options = {{SHOW_DATASET_INTERFACE_OPTIONS|yesno:"true,false"}};
+var user_can_add_morpheme = {{perms.dictionary.add_morpheme|yesno:"true,false"}};
 var multiple_select_fields = {{MULTIPLE_SELECT_MORPHEME_FIELDS|safe}};
 var field_colors = {{field_colors|safe}};
+var populate_fields_keys = {{populate_fields_keys|safe}};
+var populate_fields = {{populate_fields|safe}};
 
 var csrf_token = '{{csrf_token}}';
 
@@ -157,52 +159,74 @@ $(document).ready(function(){
         placeholder: ''
      });
      $('#id_tags').val(null).trigger('change');
+
+
+     // initialise multiple select fields from the GET parameters
+     for (var i = 0; i < multiple_select_fields.length; i++) {
+        var this_id = '#id_' + multiple_select_fields[i];
+        var this_var = multiple_select_fields[i] + '[]';
+        if (populate_fields_keys.includes(this_var)) {
+            var query_initial = populate_fields[this_var];
+            $(this_id).val(query_initial);
+            $(this_id).trigger('change');
+        };
+     }
+
+     // initialize non-multiple select, not language-based query fields
+     for (var i = 0; i < populate_fields_keys.length; i++) {
+        var this_var = populate_fields_keys[i];
+        if (this_var.endsWith('[]')) { continue; }
+        var this_id = '#id_' + populate_fields_keys[i];
+        var $language_search = $("input[name='"+this_var+"']");
+        var query_initial = populate_fields[this_var];
+        if ($language_search) {
+            $language_search.val(query_initial);
+        } else {
+            $(this_id).val(query_initial);
+        }
+     }
 });
 
 </script>
 
-<script type='text/javascript' src="{{ STATIC_URL }}js/lemma_typeahead.js"></script>
+<script type='text/javascript' src="{{STATIC_URL}}js/lemma_typeahead.js"></script>
 
 <script>
+function clearForm() {
+      $('input').each(function() {
+        var this_field = $(this).attr('name');
+        if (this_field == undefined) { return; };
+        var this_type = $(this).attr('type');
+        if (this_type == 'hidden' || this_type == 'submit' || this_type == 'radio') { return; };
+        if (this_type == 'date' || this_type == 'text') {
+            $(this).attr('value', "");
+        } else {
+            $(this).val('');
+        };
+      });
 
-// http://www.javascript-coder.com/javascript-form/javascript-reset-form.phtml
-function clearForm(myFormElement) {
+      $('select').each(function() {
+        var this_field = $(this).attr('name');
+        if (this_field == undefined) { return; };
+        var this_type = $(this).attr('type');
+        if (this_type == 'hidden') { return; };
+        if (this_field.endsWith('[]')) {
+            return;
+        } else {
+            $(this).find('option').each(function () {
+                $(this).removeAttr("selected");
+            });;
+        };
+      });
 
-  var elements = myFormElement.elements;
+     $('.js-example-basic-multiple').val(null).trigger('change');
+     $("input[name='translation']").val('');
+     $("input[name='search']").val('');
+}
 
-  myFormElement.reset();
-
-  for(i=0; i<elements.length; i++) {
-
-      field_type = elements[i].type.toLowerCase();
-    
-      switch(field_type) {
-    
-        case "text":
-        case "password":
-        case "textarea":
-        case "hidden":
-    
-          elements[i].value = "";
-          break;
-    
-        case "radio":
-        case "checkbox":
-            if (elements[i].checked) {
-              elements[i].checked = false;
-          }
-          break;
-    
-        case "select-one":
-        case "select-multiple":
-                    elements[i].selectedIndex = -1;
-          break;
-    
-        default:
-          break;
-      }
-    }
-    return(false);
+function do_adminsearch(el) {
+    $("#adminsearch").attr('action', '{{PREFIX_URL}}/morphemes/search');
+    document.getElementById('adminsearch').submit();
 }
 
 /**
@@ -228,28 +252,6 @@ function do_sort_column(field_name, action, frmName) {
   // Submit the form with the indicated name
   $("#" + frmName).submit();
 }
-
-
-/**
- * @returns {void}
- */
-function do_adminsearch(el) {
- var sSearchType = $(el).attr('value');
-  $("#adminsearch input[name='search_type']").val(sSearchType);
-  switch(sSearchType) {
-    case "morpheme":
-        $("#adminsearch").attr('action', '{{PREFIX_URL}}/morphemes/search/');
-        break;
-    case "sign":
-        $("#adminsearch").attr('action', '{{PREFIX_URL}}/signs/search/');
-        break;
-    case "sign_or_morpheme":
-        $("#adminsearch").attr('action', '{{PREFIX_URL}}/signs/search/');
-        break;
-  }
-  document.getElementById('adminsearch').submit();
-}
-
 
 function set_signlanguages_dialects() {
     this_selection_elt = $('#signlanguage_selection');
@@ -361,8 +363,8 @@ function do_set_lemma_language(el) {
         <!-- EK: A sort-order specification is in a hidden form field, which is filled by JS:do_sort_column() -->
             <!-- this is empty as an initial value because the view python code sets it -->
         <div class="hidden">
-            <input name='sortOrder' class='form-control' value='' >
-            <input name='search_type' class='form-control' value='morpheme'>
+            <input name='sortOrder' class='form-control' value='' type='hidden'>
+            <input name='search_type' class='form-control' value='morpheme' type='hidden'>
         </div>
         <div>
             <table class='table' id='searchfields'>
@@ -371,10 +373,13 @@ function do_set_lemma_language(el) {
                     {% with searchform|get_morpheme_search_field_for_language:dataset_lang as search_field %}
                     <td>
                         <div class='input-group'>
-                        <label class='input-group-addon' for='id_annotation_idgloss_{{ dataset_lang.language_code_2char }}'>
+                        <label class='input-group-addon' for='id_annotation_idgloss_{{dataset_lang.language_code_2char}}'>
                             {{search_field.label}}
                         </label>
-                        <input id='morphemesearch_{{ dataset_lang.language_code_2char }}' name='morphemesearch_{{ dataset_lang.language_code_2char }}' class='form-control' {% if search_field.value %}value='{{search_field.value}}'{% endif %}>
+                        <input id='morphemesearch_{{dataset_lang.language_code_2char}}'
+                               name='morphemesearch_{{dataset_lang.language_code_2char}}'
+                               type='text'
+                               class='form-control' {% if search_field.value %}value='{{search_field.value}}'{% endif %}>
                         </div>
                     </td>
                     {% endwith %}
@@ -382,17 +387,21 @@ function do_set_lemma_language(el) {
                     {% with searchform|get_lemma_field_for_language:dataset_lang as lemma_field %}
                     <td><div class='input-group'>
 
-                        <label class='input-group-addon' for='id_lemma_{{ dataset_lang.language_code_2char }}'>
+                        <label class='input-group-addon' for='id_lemma_{{dataset_lang.language_code_2char}}'>
                             {{lemma_field.label}}
                         </label>
-                        <input name='lemma_{{ dataset_lang.language_code_2char }}' class='form-control' {% if lemma_field.value %}value='{{lemma_field.value}}'{% endif %}></div>
+                        <input name='lemma_{{dataset_lang.language_code_2char}}'
+                               type='text'
+                               class='form-control' {% if lemma_field.value %}value='{{lemma_field.value}}'{% endif %}></div>
                     </td>
                     {% endwith %}
 
                     {% with searchform|get_keyword_field_for_language:dataset_lang as keyword_field %}
                     <td><div class='input-group'>
-                        <label class='input-group-addon' for='id_keyword_{{ dataset_lang.language_code_2char }}'>{{keyword_field.label}}</label>
-                        <input name='keyword_{{ dataset_lang.language_code_2char }}' class='form-control' {% if keyword_field.value %}value='{{keyword_field.value}}'{% endif %}></div>
+                        <label class='input-group-addon' for='id_keyword_{{dataset_lang.language_code_2char}}'>{{keyword_field.label}}</label>
+                        <input name='keyword_{{dataset_lang.language_code_2char}}'
+                               type='text'
+                               class='form-control' {% if keyword_field.value %}value='{{keyword_field.value}}'{% endif %}></div>
                     </td>
                     {% endwith %}
                 </tr>
@@ -499,11 +508,7 @@ function do_set_lemma_language(el) {
               {% for publication_id, publication_label, publication_field in search_by_publication_fields %}
               <tr>
                   <td style="padding-left:30px;"><label for='id_{{publication_id}}'>{{publication_label}}</label></td>
-                  {% if publication_id == 'definitionRole' %}
-                  <td style="width:600px;">{{publication_field}}</td>
-                  {% else %}
                   <td>{{publication_field}}</td>
-                  {% endif %}
               </tr>
               {% endfor %}
               </table>
@@ -511,44 +516,38 @@ function do_set_lemma_language(el) {
             </div>
     </div>
 </div>
-        <div class='btn-group'>
-            <!-- Make sure no button has the *name* 'submit', otherwise submit() cannot be used -->
-            <div class="btn-group">
-                <a class='btn btn-primary dropdown-toggle' data-toggle="dropdown" type='submit' name='submit_button'>
-                    <span data-bind="label" onclick="do_adminsearch(this);"  name="search_type" value="morpheme">{% trans "Search Morpheme" %}</span>&nbsp;<span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu dropdown-menu-left">
-                    <li><a href="#" onclick="do_adminsearch(this);" type='submit' name="search_type" value="morpheme">{% trans "Search Morpheme" %}</a></li>
-                </ul>
-            </div>
 
-            <!-- The element below adds an invisible submit option, so the 'button' above also works when enter is pressed -->
-            <input type="submit" style="visibility: hidden;"/>
+        <div class='btn-group' style="margin-bottom: 20px">
+           <input class="btn btn-primary"
+                  type="submit" name='morpheme_search'
+                  onclick="do_adminsearch(this);"
+                  value='{% trans "Search Morpheme" %}'>
 
             {% if perms.dictionary.export_csv %}
             <input class='btn btn-default' type='submit' name='format' value='CSV'>
             {% endif %}
-            <!--<input class='btn btn-default' type='submit' name='export_ecv' value='ECV'>-->
-            <input class='btn btn-default' type='submit' onclick="return clearForm(document.adminsearch);" value='{% trans "Reset" %}'>
+
+           <input class='btn btn-default' type='reset' onclick="clearForm();"
+                   value='{% trans "Reset" %}'>
         </div>
 
-        <form name="show_pages">
-        <div class='form-group' id='paginate_by'>
-        <label for='paginate_by'>{% trans "Results Per Page" %}</label>
-        <select class='form-control' name="paginate_by">
-            <option {% if paginate_by == 500 %}selected{% endif %}>500</option>
-            <option {% if paginate_by == 100 %}selected{% endif %}>100</option>
-            <option {% if paginate_by == 50 %}selected{% endif %}>50</option>
-            <option {% if paginate_by == 25 %}selected{% endif %}>25</option>
-            <option {% if paginate_by == 10 %}selected{% endif %}>10</option>
-        </select>
-        {% csrf_token %}
-        <input type="submit" value = '{% trans "Refresh" %}' />
-        </div>
-        </form>
+</div>
+</form>
 
-</div></form>
 <div></div>
+
+<form name="show_pages">
+<div class='form-group' id='paginate_by'>
+<label for='paginate_by'>{% trans "Results Per Page" %}</label>
+<select class='form-control' name="paginate_by">
+    <option {% if paginate_by == 50 %}selected{% endif %}>50</option>
+    <option {% if paginate_by == 25 %}selected{% endif %}>25</option>
+    <option {% if paginate_by == 10 %}selected{% endif %}>10</option>
+</select>
+{% csrf_token %}
+<input type="submit" value = '{% trans "Refresh" %}' />
+</div>
+</form>
 
    {% if perms.dictionary.add_morpheme %}
    <div  class="panel panel-default">
@@ -562,7 +561,7 @@ function do_set_lemma_language(el) {
                          {% if SHOW_DATASET_INTERFACE_OPTIONS %}<th><label for='dataset'>{% trans "Dataset" %}</label></th>{% endif %}
                          <th><label for='id_idgloss'>{% trans "Lemma ID Gloss" %}</label></th>
                          {% for dataset_lang in dataset_languages %}
-                         <th id="add_gloss_dataset_header_{{ dataset_lang.language_code_2char }}"><label for="id_annotation_idgloss_{{ dataset_lang.language_code_2char }}">{% trans "Annotation ID Gloss" %} ({{ dataset_lang.name }})</label></th>
+                         <th id="add_gloss_dataset_header_{{dataset_lang.language_code_2char}}"><label for="id_annotation_idgloss_{{dataset_lang.language_code_2char}}">{% trans "Annotation ID Gloss" %} ({{dataset_lang.name}})</label></th>
                          {% endfor %}
                      </tr>
                      <tr>
@@ -575,20 +574,20 @@ function do_set_lemma_language(el) {
                          {% get_obj_perms request.user for s_dataset as "dataset_perms" %}
                          {% if "change_dataset" in dataset_perms %}
                          {% if last_used_dataset and last_used_dataset == s_dataset.acronym %}
-                         <option value="{{ s_dataset.id }}" selected="selected"
-                                 dataset_languages="{% for dataset_lang in s_dataset.translation_languages.all %}{{ dataset_lang.language_code_2char }}{% if not forloop.last %},{% endif %}{% endfor %}">{{ s_dataset.acronym }}</option>
+                         <option value="{{s_dataset.id}}" selected="selected"
+                                 dataset_languages="{% for dataset_lang in s_dataset.translation_languages.all %}{{dataset_lang.language_code_2char}}{% if not forloop.last %},{% endif %}{% endfor %}">{{s_dataset.acronym}}</option>
                          {% else %}
-                         <option value="{{ s_dataset.id }}"
-                                 dataset_languages="{% for dataset_lang in s_dataset.translation_languages.all %}{{ dataset_lang.language_code_2char }}{% if not forloop.last %},{% endif %}{% endfor %}">{{ s_dataset.acronym }}</option>
+                         <option value="{{s_dataset.id}}"
+                                 dataset_languages="{% for dataset_lang in s_dataset.translation_languages.all %}{{dataset_lang.language_code_2char}}{% if not forloop.last %},{% endif %}{% endfor %}">{{s_dataset.acronym}}</option>
                          {% endif %}
                          {% endif %}
 
                          {% endfor %}
                          {% else %}
-                            <option value="{{ selected_datasets.0.id }}"
-                                 dataset_languages="{% for dataset_lang in selected_datasets.0.translation_languages.all %}{{ dataset_lang.language_code_2char }}{% if not forloop.last %},{% endif %}{% endfor %}">{{ selected_datasets.0.acronym }}</option>
+                            <option value="{{selected_datasets.0.id}}"
+                                 dataset_languages="{% for dataset_lang in selected_datasets.0.translation_languages.all %}{{dataset_lang.language_code_2char}}{% if not forloop.last %},{% endif %}{% endfor %}">{{selected_datasets.0.acronym}}</option>
                          <script type='text/javascript'>
-                         gloss_dataset_id = {{ selected_datasets.0.id }};
+                         gloss_dataset_id = {{selected_datasets.0.id}};
                          language_code = '{{selected_datasets.0.default_language.language_code_2char}}';
                          </script>
                      {% endif %}
@@ -600,10 +599,10 @@ function do_set_lemma_language(el) {
                                  <label for="id_lemma_language_select">
                                  <span id="selected_lemma_language" value="{{default_dataset_lang}}"><p>
                                  {% for dataset_lang in dataset_languages %}
-                                     <input id="lemma_language_{{ dataset_lang.language_code_2char }}"
+                                     <input id="lemma_language_{{dataset_lang.language_code_2char}}"
                                             type="radio" name="lemma_language" onclick="do_set_lemma_language(this)"
-                                            value="{{ dataset_lang.language_code_2char }}"/>
-                                         <label id="lemma_language_label_{{ dataset_lang.language_code_2char }}">{{dataset_lang.name}}</label>
+                                            value="{{dataset_lang.language_code_2char}}"/>
+                                         <label id="lemma_language_label_{{dataset_lang.language_code_2char}}">{{dataset_lang.name}}</label>
                                  {% endfor %}
                                  </p></span>
                                  </label>
@@ -617,10 +616,10 @@ function do_set_lemma_language(el) {
                              </div>
                              <div id="lemma_add">
                                 {% for dataset_lang in dataset_languages %}
-                                 <p><label id="{{ lemma_create_field_prefix }}_header_{{ dataset_lang.language_code_2char }}">{{ dataset_lang.name }}:</label>
-                                <input id="{{ lemma_create_field_prefix }}{{ dataset_lang.language_code_2char }}"
-                                       name="{{ lemma_create_field_prefix }}{{ dataset_lang.language_code_2char }}"
-                                       maxlength="30" type="text"/></p>
+                                 <p><label id="{{lemma_create_field_prefix}}_header_{{dataset_lang.language_code_2char}}">{{dataset_lang.name}}:</label>
+                                <input id="{{lemma_create_field_prefix }}{{dataset_lang.language_code_2char}}"
+                                       name="{{lemma_create_field_prefix }}{{dataset_lang.language_code_2char}}"
+                                       type="text" maxlength="30"></p>
 
                                 {% endfor %}
 
@@ -629,8 +628,8 @@ function do_set_lemma_language(el) {
                              <input type="hidden" id="select_or_new_lemma" name="select_or_new_lemma" value="select"/>
                          </td>
                          {% for dataset_lang in dataset_languages %}
-                         <td id="add_gloss_dataset_value_{{ dataset_lang.language_code_2char }}">
-                             <input id="morphemecreate_{{ dataset_lang.language_code_2char }}" name="morphemecreate_{{ dataset_lang.language_code_2char }}" maxlength="30" type="text"/>
+                         <td id="add_gloss_dataset_value_{{dataset_lang.language_code_2char}}">
+                             <input id="morphemecreate_{{dataset_lang.language_code_2char}}" name="morphemecreate_{{dataset_lang.language_code_2char}}" maxlength="30" type="text"/>
                          </td>
                          {% endfor %}
                          <td><input class='btn btn-primary' type='submit' value='{% trans "Add New Morpheme" %}'></td>
@@ -644,11 +643,6 @@ function do_set_lemma_language(el) {
    <p>{% trans "You are not authorized to add a morpheme" %}</p>
    {% endif %}
 
-             
-             
-
-  
-
 <p>{% trans "Number of Matches:" %} {{page_obj.paginator.count}} {% trans "out of" %} {{glosscount}}.</p>
 
 {% if object_list %}
@@ -657,13 +651,13 @@ function do_set_lemma_language(el) {
       <tr>
           <th></th>
           {% for dataset_lang in dataset_languages %}
-          <th>{% trans "Annotation ID Gloss" %} ({{ dataset_lang.name }})</th>
+          <th>{% trans "Annotation ID Gloss" %} ({{dataset_lang.name}})</th>
           {% endfor %}
            <th>{% trans "Morpheme Type" %}</th>
            {% for dataset_lang in dataset_languages %}
            <th>{% trans "Abstract Meaning" %}
               {% if SHOW_DATASET_INTERFACE_OPTIONS %}
-                ({{ dataset_lang.name }})
+                ({{dataset_lang.name}})
               {% endif %}
            </th>
           {% endfor %}
@@ -752,20 +746,20 @@ function do_set_lemma_language(el) {
         {% with morpheme.gloss_ptr|get_annotation_idgloss_translation_no_default:dataset_lang as annotationidglosstranslation %}
       <td>
           {% if annotationidglosstranslation != "" %}
-            <a href="{{PREFIX_URL}}/dictionary/morpheme/{{morpheme.pk}}/">{{ annotationidglosstranslation }}</a>
+            <a href="{{PREFIX_URL}}/dictionary/morpheme/{{morpheme.pk}}/">{{annotationidglosstranslation}}</a>
           {% endif %}
       </td>
         {% endwith %}
       {% endfor %}
-            <td>{{ morpheme.get_mrpType_display }}</td>
+            <td>{{morpheme.get_mrpType_display}}</td>
             {% for lang, translations in morpheme.abstract_meaning %}
             {% if lang in dataset_languages %}
-            <td>{% for trn in translations %}{{ trn.translation.text|safe }}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+            <td>{% for trn in translations %}{{trn.translation.text|safe}}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
             {% endif %}
             {% endfor %}
 
-            <td>{% if morpheme.handedness %}{{ morpheme.get_handedness_display }}{% else %}-{% endif %}</td>
-            <td>{% if morpheme.locprim %}{{ morpheme.get_locprim_display }}{% else %}-{% endif %}</td>
+            <td>{% if morpheme.handedness %}{{morpheme.get_handedness_display}}{% else %}-{% endif %}</td>
+            <td>{% if morpheme.locprim %}{{morpheme.get_locprim_display}}{% else %}-{% endif %}</td>
             {% load underscore_to_space %}
             <td>{% for tag in morpheme.tags %}<span class='tag'>{{tag.name|underscore_to_space}}</span> {% endfor %}</td>
             
@@ -779,7 +773,7 @@ function do_set_lemma_language(el) {
 
         <ul class='pagination pagination-sm'>
         {% if page_obj.has_previous %}
-            <li><a href="?page={{ page_obj.previous_page_number }}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">&laquo;</a></li>
+            <li><a href="?page={{page_obj.previous_page_number}}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">&laquo;</a></li>
         {% endif %}
           
           {% if  page_obj.number > 10 %}
@@ -790,7 +784,7 @@ function do_set_lemma_language(el) {
           
              {% if p < page_obj.number|add:"10" and  p > page_obj.number|add:"-10" %}
              <li {% if p == page_obj.number %}class='active'{% endif %}>
-             <a href='?page={{ p }}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}'>{% if p == 0 %}Start{% else %}{{p}}{% endif %}</a>
+             <a href='?page={{p}}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}'>{% if p == 0 %}Start{% else %}{{p}}{% endif %}</a>
              </li>
              {% endif %}
          
@@ -799,12 +793,12 @@ function do_set_lemma_language(el) {
           {% if page_obj.paginator.num_pages > page_obj.number|add:"10" %}
             <li><a>...</a></li>
             <li>
-            <a href='?page={{ page_obj.paginator.num_pages }}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}'>{{page_obj.paginator.num_pages}}</a>
+            <a href='?page={{page_obj.paginator.num_pages}}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{key}}={{value}}{% endif %}{% endfor %}'>{{page_obj.paginator.num_pages}}</a>
             </li>
           {% endif %}
       
         {% if page_obj.has_next %}
-            <li><a href="?page={{ page_obj.next_page_number }}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}">&raquo;</a></li>
+            <li><a href="?page={{page_obj.next_page_number}}{% for key,value in request.GET.items %}{% if key != 'page' %}&{{key}}={{value}}{% endif %}{% endfor %}">&raquo;</a></li>
 
             
       </ul>

--- a/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_morpheme_list.html
@@ -156,9 +156,10 @@ $(document).ready(function(){
         var this_id = '#id_' + populate_fields_keys[i];
         var $language_search = $("input[name='"+this_var+"']");
         var query_initial = populate_fields[this_var];
-        if ($language_search) {
+        if ($language_search.length > 0) {
             $language_search.val(query_initial);
         } else {
+            // $select_search = $("select[name='"+this_var+"']");
             $(this_id).val(query_initial);
         }
      }

--- a/signbank/dictionary/templates/dictionary/admin_senses_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_senses_list.html
@@ -573,37 +573,38 @@ function do_toggle_language(el) {
                         {% for dataset_lang in dataset_languages %}
 
                         <tr>
-                            {% with searchform|get_search_field_for_language:dataset_lang as search_field %}
+                            {% with searchform|get_annotation_search_field_for_language:dataset_lang as search_field %}
                             <td>
                                 <div class='input-group'>
-                                <label class='input-group-addon' for='id_annotation_idgloss_{{ dataset_lang.language_code_2char }}'>
+                                <label class='input-group-addon' for='id_annotation_idgloss_{{dataset_lang.language_code_2char}}'>
                                     {{search_field.label}}
                                 </label>
                                 <input id='glosssearch_{{ dataset_lang.language_code_2char }}'
                                        type='text'
-                                       name='glosssearch_{{ dataset_lang.language_code_2char }}' class='form-control' {% if search_field.value %}value='{{search_field.value}}'{% endif %}>
+                                       name='glosssearch_{{ dataset_lang.language_code_2char }}' class='form-control'>
                                 </div>
                             </td>
                             {% endwith %}
 
-                            {% with searchform|get_lemma_field_for_language:dataset_lang as lemma_field %}
+                            {% with searchform|get_lemma_form_field_for_language:dataset_lang as lemma_field %}
                             <td><div class='input-group'>
 
-                                <label class='input-group-addon' for='id_lemma_{{ dataset_lang.language_code_2char }}'>
+                                <label class='input-group-addon' for='id_lemma_{{dataset_lang.language_code_2char}}'>
                                     {{lemma_field.label}}
                                 </label>
                                 <input name='lemma_{{ dataset_lang.language_code_2char }}'
                                        type='text'
-                                       class='form-control' {% if lemma_field.value %}value='{{lemma_field.value}}'{% endif %}></div>
+                                       class='form-control'></div>
                             </td>
                             {% endwith %}
 
-                            {% with searchform|get_keyword_field_for_language:dataset_lang as keyword_field %}
+                            {% with searchform|get_senses_form_field_for_language:dataset_lang as keyword_field %}
                             <td><div class='input-group'>
-                                <label class='input-group-addon' for='id_keyword_{{ dataset_lang.language_code_2char }}'>{{keyword_field.label}}</label>
+                                <label class='input-group-addon' for='id_keyword_{{dataset_lang.language_code_2char}}'>
+                                    {{keyword_field.label}}</label>
                                 <input name='keyword_{{dataset_lang.language_code_2char}}'
                                        type='text'
-                                       class='form-control' {% if keyword_field.value %}value='{{keyword_field.value}}'{% endif %}></div>
+                                       class='form-control'></div>
                             </td>
                             {% endwith %}
                         </tr>

--- a/signbank/dictionary/templates/dictionary/admin_senses_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_senses_list.html
@@ -201,6 +201,14 @@ $(document).ready(function() {
 
      $('#id_sentenceType').val(null).trigger('change');
 
+     if (query_parameters_keys.includes('sentenceType[]')) {
+         var query_initial = query_parameters_dict['sentenceType[]'];
+         $('#id_sentenceType').val(query_initial);
+         $('#id_sentenceType').trigger('change');
+     } else {
+         $('#id_sentenceType').val(null).trigger('change');
+     };
+
      // initialize query parameters in multiple select fields
      for (var i = 0; i < multiple_select_fields.length; i++) {
         var this_id = '#id_' + multiple_select_fields[i];
@@ -311,8 +319,8 @@ function clearForm() {
         var this_field = $(this).attr('name');
         if (this_field == undefined) { return; };
         var this_type = $(this).attr('type');
-        if (this_type == 'hidden' || this_type == 'submit' || this_type == 'radio') { return; };
-        if (this_type == 'date') {
+        if (this_type == 'hidden' || this_type == 'submit' || this_type == 'reset') { return; };
+        if (this_type == 'date' || this_type == 'text') {
             $(this).attr('value', "");
         } else {
             $(this).val('');
@@ -763,6 +771,7 @@ function do_toggle_language(el) {
         <input class='btn btn-default' type='reset' onclick="clearForm();"
                value='{% trans "Reset" %}'>
     </div>
+</form>
 
 
     <div>
@@ -775,7 +784,6 @@ function do_toggle_language(el) {
         {% endfor %}
         {% endif %}
     </div>
-</form>
 
     <div></div>
 

--- a/signbank/dictionary/templates/dictionary/admin_senses_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_senses_list.html
@@ -579,9 +579,9 @@ function do_toggle_language(el) {
                                 <label class='input-group-addon' for='id_annotation_idgloss_{{dataset_lang.language_code_2char}}'>
                                     {{search_field.label}}
                                 </label>
-                                <input id='glosssearch_{{ dataset_lang.language_code_2char }}'
+                                <input id='glosssearch_{{dataset_lang.language_code_2char}}'
                                        type='text'
-                                       name='glosssearch_{{ dataset_lang.language_code_2char }}' class='form-control'>
+                                       name='glosssearch_{{dataset_lang.language_code_2char}}' class='form-control'>
                                 </div>
                             </td>
                             {% endwith %}
@@ -592,7 +592,8 @@ function do_toggle_language(el) {
                                 <label class='input-group-addon' for='id_lemma_{{dataset_lang.language_code_2char}}'>
                                     {{lemma_field.label}}
                                 </label>
-                                <input name='lemma_{{ dataset_lang.language_code_2char }}'
+                                <input name='lemma_{{dataset_lang.language_code_2char}}'
+                                       id='lemma_{{dataset_lang.language_code_2char}}'
                                        type='text'
                                        class='form-control'></div>
                             </td>
@@ -603,6 +604,7 @@ function do_toggle_language(el) {
                                 <label class='input-group-addon' for='id_keyword_{{dataset_lang.language_code_2char}}'>
                                     {{keyword_field.label}}</label>
                                 <input name='keyword_{{dataset_lang.language_code_2char}}'
+                                       id='keyword_{{dataset_lang.language_code_2char}}'
                                        type='text'
                                        class='form-control'></div>
                             </td>

--- a/signbank/dictionary/templatetags/annotation_idgloss_translation.py
+++ b/signbank/dictionary/templatetags/annotation_idgloss_translation.py
@@ -84,6 +84,10 @@ def get_lemma_idgloss_translation_no_default(lemma, language):
 def get_search_field_for_language(form, language):
     return getattr(form, GlossSearchForm.gloss_search_field_prefix + language.language_code_2char)
 
+@register.filter
+def get_annotation_search_field_for_language(form, language):
+    field = GlossSearchForm.gloss_search_field_prefix + language.language_code_2char
+    return form.fields[field]
 
 @register.filter
 def get_morpheme_search_field_for_language(form, language):
@@ -93,6 +97,11 @@ def get_morpheme_search_field_for_language(form, language):
 @register.filter
 def get_keyword_field_for_language(form, language):
     return getattr(form, GlossSearchForm.keyword_search_field_prefix + language.language_code_2char)
+
+@register.filter
+def get_senses_form_field_for_language(form, language):
+    field = GlossSearchForm.keyword_search_field_prefix + language.language_code_2char
+    return form.fields[field]
 
 @register.filter
 def get_keyword_form_field_for_language(form, language):

--- a/signbank/dictionary/templatetags/annotation_idgloss_translation.py
+++ b/signbank/dictionary/templatetags/annotation_idgloss_translation.py
@@ -87,18 +87,26 @@ def get_search_field_for_language(form, language):
 
 @register.filter
 def get_morpheme_search_field_for_language(form, language):
-    return getattr(form, MorphemeSearchForm.gloss_search_field_prefix + language.language_code_2char)
-
+    field = MorphemeSearchForm.gloss_search_field_prefix + language.language_code_2char
+    return form.fields[field]
 
 @register.filter
 def get_keyword_field_for_language(form, language):
     return getattr(form, GlossSearchForm.keyword_search_field_prefix + language.language_code_2char)
 
+@register.filter
+def get_keyword_form_field_for_language(form, language):
+    field = MorphemeSearchForm.keyword_search_field_prefix + language.language_code_2char
+    return form.fields[field]
 
 @register.filter
 def get_lemma_field_for_language(form, language):
     return getattr(form, GlossSearchForm.lemma_search_field_prefix + language.language_code_2char)
 
+@register.filter
+def get_lemma_form_field_for_language(form, language):
+    field = MorphemeSearchForm.lemma_search_field_prefix + language.language_code_2char
+    return form.fields[field]
 
 @register.filter
 def get_type(obj):

--- a/signbank/dictionary/translate_choice_list.py
+++ b/signbank/dictionary/translate_choice_list.py
@@ -95,6 +95,14 @@ def choicelist_queryset_to_field_colors(queryset):
         temp_mapping_dict[choice.machine_value] = getattr(choice, 'field_color')
     return temp_mapping_dict
 
+
+def choicelist_choicelist_to_field_colors(choices):
+    temp_mapping_dict = {}
+    mapping_default = 'ffffff'
+    for key in choices:
+        temp_mapping_dict[key] = mapping_default
+    return temp_mapping_dict
+
 def machine_value_to_translated_human_value(machine_value,choice_list):
 
     if not choice_list or len(choice_list) == 0:

--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -20,17 +20,12 @@ import signbank.dictionary.adminviews
 app_name = 'dictionary'
 urlpatterns = [
 
-    # index page is just the search page
-    re_path(r'^$', signbank.dictionary.views.search),
-
     re_path(r'^tag/(?P<tag>[^/]*)/?$', signbank.dictionary.tagviews.taglist),
 
     # an alternate view for direct display of a gloss
     re_path(r'gloss/(?P<glossid>\d+).html$', signbank.dictionary.views.gloss, name='public_gloss'),
     re_path(r'morpheme/(?P<glossid>\d+).html$', signbank.dictionary.views.morpheme, name='public_morpheme'),
 
-    re_path(r'^search/$', signbank.dictionary.views.search, name="search"),
-    re_path(r'^search_morpheme/$', signbank.dictionary.views.search_morpheme, name="search_morpheme"),
     re_path(r'^update/gloss/(?P<glossid>\d+)$', signbank.dictionary.update.update_gloss, name='update_gloss'),
     re_path(r'^update/handshape/(?P<handshapeid>\d+)$', signbank.dictionary.update.update_handshape, name='update_handshape'),
     re_path(r'^update/morpheme/(?P<morphemeid>\d+)$', signbank.dictionary.update.update_morpheme, name='update_morpheme'),

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -248,24 +248,6 @@ def morpheme(request, glossid):
                                'DEFINITION_FIELDS' : settings.DEFINITION_FIELDS})
 
 
-@login_required_config
-def search(request):
-    """Handle keyword search form submission"""
-
-    form = UserSignSearchForm(request.GET.copy())
-
-    if form.is_valid():
-
-        glossQuery = form.cleaned_data['glossQuery']
-        # Issue #153: make sure + and - signs are translated correctly into the search URL
-        glossQuery = quote(glossQuery)
-        term = form.cleaned_data['query']
-        # Issue #153: do the same with the Translation, encoded by 'query'
-        term = quote(term)
-
-        return HttpResponseRedirect('../../signs/search/?search='+glossQuery+'&keyword='+term)
-
-
 def missing_video_list():
     """A list of signs that don't have an
     associated video file"""
@@ -521,23 +503,6 @@ def add_new_sign(request):
 
     return render(request,'dictionary/add_gloss.html',context)
 
-
-@login_required_config
-def search_morpheme(request):
-    """Handle morpheme search form submission"""
-
-    form = UserMorphemeSearchForm(request.GET.copy())
-
-    if form.is_valid():
-
-        morphQuery = form.cleaned_data['morphQuery']
-        # Issue #153: make sure + and - signs are translated correctly into the search URL
-        morphQuery = quote(morphQuery)
-        term = form.cleaned_data['query']
-        # Issue #153: do the same with the Translation, encoded by 'query'
-        term = quote(term)
-
-        return HttpResponseRedirect('../../morphemes/search/?search='+morphQuery+'&keyword='+term)
 
 def add_new_morpheme(request):
 

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -138,11 +138,23 @@ FIELDS['properties'] = ['hasvideo', 'hasothermedia', 'hasmultiplesenses',
                         'createdBy', 'createdAfter', 'createdBefore',
                         'tags', 'excludeFromEcv']
 FIELDS['relations'] = ['relation', 'hasRelation', 'relationToForeignSign', 'hasRelationToForeignSign']
-FIELDS['morpheme'] = ['morpheme', 'hasComponentOfType', 'hasMorphemeOfType']
+FIELDS['morpheme'] = ['morpheme', 'hasComponentOfType', 'mrpType']
 FIELDS['morpheme_properties'] = ['hasvideo',
                                  'definitionRole', 'definitionContains', 'defspublished',
                                  'createdBy', 'createdAfter', 'createdBefore',
                                  'tags']
+
+GLOSS_CHOICE_FIELDS = ['handedness', 'domhndsh', 'subhndsh', 'handCh', 'relatArtic', 'locprim',
+                       'relOriMov',
+                       'relOriLoc', 'oriCh', 'contType', 'movSh', 'movDir', 'wordClass',
+                       'semField', 'derivHist', 'namEnt', 'valence',
+                       'definitionRole', 'hasComponentOfType', 'mrpType', 'hasRelation']
+
+GLOSSSENSE_CHOICE_FIELDS = ['handedness', 'domhndsh', 'subhndsh', 'handCh', 'relatArtic', 'locprim',
+                            'relOriMov',
+                            'relOriLoc', 'oriCh', 'contType', 'movSh', 'movDir', 'wordClass',
+                            'semField', 'derivHist', 'namEnt', 'valence',
+                            'definitionRole', 'hasComponentOfType']
 
 # these are the multiple select fields for Morpheme Search, the field definitionRole is a search form field,
 # the field mrpType appears in Morpheme, the rest are also in Gloss

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -134,15 +134,15 @@ FIELDS['handshape'] = ['hsNumSel','hsFingSel','hsFingSel2','hsFingConf','hsFingC
 FIELDS['publication'] = ['inWeb', 'isNew']
 
 FIELDS['properties'] = ['hasvideo', 'hasothermedia', 'hasmultiplesenses',
-                                'definitionRole', 'definitionContains', 'defspublished',
-                                'createdBy', 'createdAfter', 'createdBefore',
-                                'useInstr', 'tags', 'excludeFromEcv']
+                        'definitionRole', 'definitionContains', 'defspublished',
+                        'createdBy', 'createdAfter', 'createdBefore',
+                        'tags', 'excludeFromEcv']
 FIELDS['relations'] = ['relation', 'hasRelation', 'relationToForeignSign', 'hasRelationToForeignSign']
 FIELDS['morpheme'] = ['morpheme', 'hasComponentOfType', 'hasMorphemeOfType']
 FIELDS['morpheme_properties'] = ['hasvideo',
                                  'definitionRole', 'definitionContains', 'defspublished',
                                  'createdBy', 'createdAfter', 'createdBefore',
-                                 'useInstr', 'tags']
+                                 'tags']
 
 # Use these fields in the server specific settings to specify frequency fields, if available
 FREQUENCY_CATEGORIES = []

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -139,6 +139,10 @@ FIELDS['properties'] = ['hasvideo', 'hasothermedia', 'hasmultiplesenses',
                                 'useInstr', 'tags', 'excludeFromEcv']
 FIELDS['relations'] = ['relation', 'hasRelation', 'relationToForeignSign', 'hasRelationToForeignSign']
 FIELDS['morpheme'] = ['morpheme', 'hasComponentOfType', 'hasMorphemeOfType']
+FIELDS['morpheme_properties'] = ['hasvideo',
+                                 'definitionRole', 'definitionContains', 'defspublished',
+                                 'createdBy', 'createdAfter', 'createdBefore',
+                                 'useInstr', 'tags']
 
 # Use these fields in the server specific settings to specify frequency fields, if available
 FREQUENCY_CATEGORIES = []
@@ -163,6 +167,7 @@ GLOSS_LIST_DISPLAY_FIELDS = ['handedness','domhndsh','subhndsh','locprim']
 SEARCH_BY = {}
 # the ordering of the list of publication fields is important for the Gloss Search template
 SEARCH_BY['publication'] = FIELDS['publication'] + FIELDS['properties']
+SEARCH_BY['morpheme_publication'] = FIELDS['publication'] + FIELDS['morpheme_properties']
 SEARCH_BY['relations'] = FIELDS['relations']
 SEARCH_BY['morpheme'] = FIELDS['morpheme']
 

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -144,6 +144,12 @@ FIELDS['morpheme_properties'] = ['hasvideo',
                                  'createdBy', 'createdAfter', 'createdBefore',
                                  'tags']
 
+# these are the multiple select fields for Morpheme Search, the field definitionRole is a search form field,
+# the field mrpType appears in Morpheme, the rest are also in Gloss
+MORPHEME_CHOICE_FIELDS = ['handedness', 'handCh', 'relatArtic', 'locprim', 'relOriMov',
+                          'relOriLoc', 'oriCh', 'contType', 'movSh', 'movDir', 'mrpType', 'wordClass',
+                          'semField', 'derivHist', 'namEnt', 'valence', 'definitionRole']
+
 # Use these fields in the server specific settings to specify frequency fields, if available
 FREQUENCY_CATEGORIES = []
 FREQUENCY_REGIONS = []

--- a/signbank/urls.py
+++ b/signbank/urls.py
@@ -62,7 +62,6 @@ urlpatterns = [
     re_path(r'^numbersigns.html$', numbersigns_view),
 
     # Hardcoding a number of special urls:
-    re_path(r'^signs/dictionary/$', signbank.dictionary.views.search),
     re_path(r'^signs/search/$', GlossListView.as_view(), {'show_all': False}, name='signs_search'),
     re_path(r'^signs/show_all/$', GlossListView.as_view(),{'show_all': True}),
     re_path(r'^signs/add/$', signbank.dictionary.views.add_new_sign),
@@ -88,7 +87,6 @@ urlpatterns = [
     re_path(r'^handshapes/show_all/$', HandshapeListView.as_view(), {'show_all': True}),
     re_path(r'^signs/search_handshape/$', permission_required('dictionary.search_gloss')(HandshapeListView.as_view()),
                 name='admin_handshape_list'),
-    re_path(r'^morphemes/dictionary/$', signbank.dictionary.views.search_morpheme),
     re_path(r'^morphemes/search/$', permission_required('dictionary.search_gloss')(MorphemeListView.as_view())),
     re_path(r'^morphemes/show_all/$', login_required(MorphemeListView.as_view()), {'show_all': True}),
     re_path(r'^morphemes/add/$', login_required(signbank.dictionary.views.add_new_morpheme)),


### PR DESCRIPTION
- This fixes the form reset code and makes sure the search parameters just done are still visible in the search form.
- The "yes/no" choices have become translated for morpheme search and the values homogenized.
- Obsolete Django syntax (the `u'`) has been removed from `forms.py`.
- Processing of the "get" parameters has been moved to a separate function to reduce the code in the get_queryset
- To allow sharing of the search form between the get_context_data and the get_queryset, the form has been made a self field of MorphemeListView.
- This allows the code that processes the "get" queryset to receive the search form.
- In order to process the "search form" fields by iterating over the search form, the language fields have been made fields instead of attributes.
