### PR TITLE
Show warning on delete sign in gloss edit view if references other glosses

### DIFF
--- a/signbank/dictionary/admin.py
+++ b/signbank/dictionary/admin.py
@@ -691,6 +691,19 @@ class GlossRevisionAdmin(VersionAdmin):
         return self.list_display_links
 
 
+class DeletedGlossOrMediaAdmin(admin.ModelAdmin):
+    model = DeletedGlossOrMedia
+
+    list_display = ['item_type', 'idgloss', 'annotation_idgloss', 'old_pk', 'filename', 'deletion_date']
+    readonly_fields = ['item_type', 'idgloss', 'annotation_idgloss', 'old_pk', 'filename', 'deletion_date']
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+
 class RegistrationProfileAdmin(admin.ModelAdmin):
     list_display = ('__str__', 'activation_key_expired', )
     search_fields = ('user__username', 'user__first_name', )
@@ -1362,6 +1375,7 @@ admin.site.register(SemanticFieldTranslation, SemanticFieldTranslationAdmin)
 admin.site.register(DerivationHistory, DerivationHistoryAdmin)
 admin.site.register(DerivationHistoryTranslation, DerivationHistoryTranslationAdmin)
 admin.site.register(GlossRevision,GlossRevisionAdmin)
+admin.site.register(DeletedGlossOrMedia, DeletedGlossOrMediaAdmin)
 
 admin.site.register(UserProfile)
 admin.site.register(Language, LanguageAdmin)

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -76,6 +76,7 @@ from signbank.dictionary.senses_display import (senses_per_language, senses_per_
                                                 sensetranslations_per_language_dict,
                                                 senses_translations_per_language_list, senses_sentences_per_language_list)
 from signbank.dictionary.context_data import get_context_data_for_list_view, get_context_data_for_gloss_search_form
+from signbank.dictionary.related_objects import gloss_is_related_to
 
 
 def order_queryset_by_sort_order(get, qs, queryset_language_codes):
@@ -1997,6 +1998,8 @@ class GlossDetailView(DetailView):
                 otherrelations.append((oth_rel,target_display))
 
         context['otherrelations'] = otherrelations
+
+        context['related_objects'] = gloss_is_related_to(gl, interface_language_code, default_language_code)
 
         if hasattr(settings, 'SHOW_DATASET_INTERFACE_OPTIONS') and settings.SHOW_DATASET_INTERFACE_OPTIONS:
             context['dataset_choices'] = {}

--- a/signbank/dictionary/related_objects.py
+++ b/signbank/dictionary/related_objects.py
@@ -3,7 +3,11 @@ from django.utils.translation import override, gettext_lazy as _, activate
 
 
 def gloss_is_related_to(gloss, interface_language_code, default_language_code):
-
+    """
+    This function is used in the Delete Sign modal of the GlossDetailView template
+    It yields a dictionary of different kinds of related objects to the gloss.
+    Because it is used in the template, it computes display appropriate data
+    """
     related_objects = dict()
     related_glosses = [(relation.role, relation.target)
                        for relation in Relation.objects.filter(source=gloss).exclude(target=gloss)]
@@ -73,4 +77,24 @@ def gloss_is_related_to(gloss, interface_language_code, default_language_code):
         related_objects[_('Blend Morphology')] = blends
 
     return related_objects
+
+
+def gloss_related_objects(gloss):
+
+    related_glosses = [relation.target
+                       for relation in Relation.objects.filter(source=gloss).exclude(target=gloss)]
+
+    # the morpheme field of MorphologyDefinition is a ForeignKey to Gloss
+    morphemes = [morpheme.morpheme
+                 for morpheme in MorphologyDefinition.objects.filter(parent_gloss=gloss)]
+
+    # the morpheme field of SimultaneousMorphologyDefinition is a ForeignKey to Morpheme
+    simultaneous = [simdef.morpheme
+                    for simdef in SimultaneousMorphologyDefinition.objects.filter(parent_gloss=gloss)]
+
+    # the glosses field of SimultaneousMorphologyDefinition is a ForeignKey to Gloss
+    blends = [blendmorph.glosses
+              for blendmorph in BlendMorphology.objects.filter(parent_gloss=gloss)]
+
+    return related_glosses + morphemes + simultaneous + blends
 

--- a/signbank/dictionary/related_objects.py
+++ b/signbank/dictionary/related_objects.py
@@ -18,7 +18,8 @@ def gloss_is_related_to(gloss, interface_language_code, default_language_code):
                 sign_display = morph_texts[default_language_code]
         relglosses.append(relrole.upper() + ': ' + sign_display)
     related_glosses = ', '.join(relglosses)
-    related_objects[_('Relations')] = related_glosses
+    if related_glosses:
+        related_objects[_('Relations')] = related_glosses
 
     # the morpheme field of MorphologyDefinition is a ForeignKey to Gloss
     morphdefs = []
@@ -34,7 +35,8 @@ def gloss_is_related_to(gloss, interface_language_code, default_language_code):
         morphdefs.append((translated_role, sign_display))
     morphdefs = sorted(morphdefs, key=lambda tup: tup[0])  # sort by translated_role
     morphemes = ' + '.join([sign_display for (translated_role, sign_display) in morphdefs])
-    related_objects[_('Sequential Morphology')] = morphemes
+    if morphemes:
+        related_objects[_('Sequential Morphology')] = morphemes
 
     # the morpheme field of SimultaneousMorphologyDefinition is a ForeignKey to Morpheme
     simultaneous = [simdef.morpheme
@@ -50,7 +52,8 @@ def gloss_is_related_to(gloss, interface_language_code, default_language_code):
                 sign_display = morph_texts[default_language_code]
         simglosses.append(sign_display)
     simultaneous = ', '.join(simglosses)
-    related_objects[_('Simultaneous Morphology')] = simultaneous
+    if simultaneous:
+        related_objects[_('Simultaneous Morphology')] = simultaneous
 
     # the glosses field of SimultaneousMorphologyDefinition is a ForeignKey to Gloss
     blends = [blendmorph.glosses
@@ -66,7 +69,8 @@ def gloss_is_related_to(gloss, interface_language_code, default_language_code):
                 sign_display = morph_texts[default_language_code]
         blendglosses.append(sign_display)
     blends = ', '.join(blendglosses)
-    related_objects[_('Blend Morphology')] = blends
+    if blends:
+        related_objects[_('Blend Morphology')] = blends
 
     return related_objects
 

--- a/signbank/dictionary/related_objects.py
+++ b/signbank/dictionary/related_objects.py
@@ -1,0 +1,72 @@
+from signbank.dictionary.models import *
+from django.utils.translation import override, gettext_lazy as _, activate
+
+
+def gloss_is_related_to(gloss, interface_language_code, default_language_code):
+
+    related_objects = dict()
+    related_glosses = [(relation.role, relation.target)
+                       for relation in Relation.objects.filter(source=gloss).exclude(target=gloss)]
+    relglosses = []
+    for relrole, relgloss in related_glosses:
+        sign_display = str(relgloss.id)
+        morph_texts = relgloss.get_annotationidglosstranslation_texts()
+        if morph_texts.keys():
+            if interface_language_code in morph_texts.keys():
+                sign_display = morph_texts[interface_language_code]
+            else:
+                sign_display = morph_texts[default_language_code]
+        relglosses.append(relrole.upper() + ': ' + sign_display)
+    related_glosses = ', '.join(relglosses)
+    related_objects[_('Relations')] = related_glosses
+
+    # the morpheme field of MorphologyDefinition is a ForeignKey to Gloss
+    morphdefs = []
+    for morphdef in gloss.parent_glosses.all():
+        translated_role = morphdef.role.name
+        sign_display = str(morphdef.morpheme.id)
+        morph_texts = morphdef.morpheme.get_annotationidglosstranslation_texts()
+        if morph_texts.keys():
+            if interface_language_code in morph_texts.keys():
+                sign_display = morph_texts[interface_language_code]
+            else:
+                sign_display = morph_texts[default_language_code]
+        morphdefs.append((translated_role, sign_display))
+    morphdefs = sorted(morphdefs, key=lambda tup: tup[0])  # sort by translated_role
+    morphemes = ' + '.join([sign_display for (translated_role, sign_display) in morphdefs])
+    related_objects[_('Sequential Morphology')] = morphemes
+
+    # the morpheme field of SimultaneousMorphologyDefinition is a ForeignKey to Morpheme
+    simultaneous = [simdef.morpheme
+                    for simdef in SimultaneousMorphologyDefinition.objects.filter(parent_gloss=gloss)]
+    simglosses = []
+    for simgl in simultaneous:
+        sign_display = str(simgl.id)
+        morph_texts = simgl.get_annotationidglosstranslation_texts()
+        if morph_texts.keys():
+            if interface_language_code in morph_texts.keys():
+                sign_display = morph_texts[interface_language_code]
+            else:
+                sign_display = morph_texts[default_language_code]
+        simglosses.append(sign_display)
+    simultaneous = ', '.join(simglosses)
+    related_objects[_('Simultaneous Morphology')] = simultaneous
+
+    # the glosses field of SimultaneousMorphologyDefinition is a ForeignKey to Gloss
+    blends = [blendmorph.glosses
+              for blendmorph in BlendMorphology.objects.filter(parent_gloss=gloss)]
+    blendglosses = []
+    for blendgloss in blends:
+        sign_display = str(blendgloss.id)
+        morph_texts = blendgloss.get_annotationidglosstranslation_texts()
+        if morph_texts.keys():
+            if interface_language_code in morph_texts.keys():
+                sign_display = morph_texts[interface_language_code]
+            else:
+                sign_display = morph_texts[default_language_code]
+        blendglosses.append(sign_display)
+    blends = ', '.join(blendglosses)
+    related_objects[_('Blend Morphology')] = blends
+
+    return related_objects
+

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -566,7 +566,7 @@ option:not(:checked) {
 
         {% if "change_dataset" in dataset_perms %}
         <div class="modal fade" id="delete_gloss_modal" tabindex="-1" role="dialog" aria-labelledby="#modalTitleDelete" aria-hidden="true">
-             <div class="modal-dialog modal-sm">
+             <div class="modal-dialog modal-dialog-centered modal-lg left-modal">
                 <div class="modal-content">
                     <div class='modal-header'>
                         <h2 id='modalTitleDelete'>{% trans "Delete This Sign" %}</h2>
@@ -577,12 +577,10 @@ option:not(:checked) {
                         <br><br>
                         <table>
                             {% for key, glosses in related_objects.items %}
-                            {% if glosses %}
                             <tr>
-                                <td>{{key}}:</td><td>&nbsp;</td>
+                                <td style="width:240px">{{key}}</td>
                                 <td>{{glosses}}</td>
                             </tr>
-                            {% endif %}
                             {% endfor %}
                         </table>
                         {% else %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -574,12 +574,18 @@ option:not(:checked) {
                 <div class="modal-content">
                     <div class='modal-header'>
                         <h2 id='modalTitleDelete'>{% trans "Delete This Sign" %}</h2>
+                        <br>
+                        {% with gloss.lemma.dataset.default_language as target_default_language %}
+			            {% with annotation_idgloss|get_item:target_default_language as annotation %}
+                        <h4>{% trans "Sign" %}: {{annotation}}</h4>
+                        {% endwith %}
+                        {% endwith %}
                     </div>
                     <div class='modal-body'>
                         {% if related_objects.keys %}
-                        <p>{% trans "WARNING: This sign is related to other signs!" %}</p>
-                        <br><br>
-                        <table>
+                        <p>{% trans "This sign is related to other signs:" %}</p>
+                        <br>
+                        <table class="table table-condensed table-bordered">
                             {% for key, glosses in related_objects.items %}
                             <tr>
                                 <td style="width:240px">{{key}}</td>
@@ -587,9 +593,9 @@ option:not(:checked) {
                             </tr>
                             {% endfor %}
                         </table>
-                        {% else %}
-                        <p>{% trans "This action will delete this sign and all associated records. It cannot be undone." %}</p>
+                        <br><br>
                         {% endif %}
+                        <p>{% trans "This action will delete this sign and all associated records. It cannot be undone." %}</p>
                      </div>
                   <form action="{% url 'dictionary:update_gloss' gloss.id %}" method='post'>
                       {% csrf_token %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -596,10 +596,8 @@ option:not(:checked) {
                       <input type='hidden' name='id' value='deletegloss'>
                       <input type='hidden' name='value' value='confirmed'>
                       <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
-                        {% if not related_objects %}
-                        <input type="submit" class="btn btn-primary" value='{% trans "Confirm Delete" %}'>
-                        {% endif %}
+                        <button type="button" class="btn btn-primary" data-dismiss="modal">{% trans "Cancel" %}</button>
+                        <input type="submit" class="btn btn-danger" value='{% trans "Confirm Delete" %}'>
                       </div>
                   </form>
 

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -572,7 +572,22 @@ option:not(:checked) {
                         <h2 id='modalTitleDelete'>{% trans "Delete This Sign" %}</h2>
                     </div>
                     <div class='modal-body'>
+                        {% if related_objects.keys %}
+                        <p>{% trans "WARNING: This sign is related to other signs!" %}</p>
+                        <br><br>
+                        <table>
+                            {% for key, glosses in related_objects.items %}
+                            {% if glosses %}
+                            <tr>
+                                <td>{{key}}:</td><td>&nbsp;</td>
+                                <td>{{glosses}}</td>
+                            </tr>
+                            {% endif %}
+                            {% endfor %}
+                        </table>
+                        {% else %}
                         <p>{% trans "This action will delete this sign and all associated records. It cannot be undone." %}</p>
+                        {% endif %}
                      </div>
                   <form action="{% url 'dictionary:update_gloss' gloss.id %}" method='post'>
                       {% csrf_token %}
@@ -580,7 +595,9 @@ option:not(:checked) {
                       <input type='hidden' name='value' value='confirmed'>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+                        {% if not related_objects %}
                         <input type="submit" class="btn btn-primary" value='{% trans "Confirm Delete" %}'>
+                        {% endif %}
                       </div>
                   </form>
 

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -22,7 +22,7 @@
     var gloss_phonology = {{gloss_phonology|safe}};
     var language_code = '{{LANGUAGE_CODE}}';
 
-    {% trans "Edit" as edit_mode_str %} 
+    {% trans "Edit" as edit_mode_str %}
     {% trans "Turn Off Edit Mode" as turn_off_edit_mode_str %}
     {% trans "Delete This Gloss" as delete_this_gloss_str %}
     {% trans "Saving..." as saving_str %} 
@@ -501,7 +501,9 @@ option:not(:checked) {
 
          <span id='edit_message' style="padding-right: 1.8em;"></span>
 
-         <button id='enable_edit' class='btn btn-default navbar-btn edit-mode'>{% trans "Edit" %}</button>
+         <button id='enable_edit'
+                 class='btn btn-primary navbar-btn edit-mode'
+                 style="width:auto;padding:3px 12px;">{% trans "Edit" %}</button>
 
          {% if perms.dictionary.add_gloss %}
          <button id='copy_gloss_btn' class='btn btn-primary copy-button' data-toggle='modal' data-target='#copy_gloss_modal'>{% trans "Copy" %}</button>
@@ -789,7 +791,9 @@ option:not(:checked) {
     <div class="editform">
         <fieldset>
          <legend>{% trans "Delete Sign" %}</legend>
-         <button id='delete_gloss_btn' class='btn btn-danger' data-toggle='modal' data-target='#delete_gloss_modal'>{% trans "Delete Sign" %}</button>
+         <button id='delete_gloss_btn' class='btn btn-danger' style="width:auto;"
+                 data-toggle='modal'
+                 data-target='#delete_gloss_modal'>{% trans "Delete Sign" %}</button>
         </fieldset>
     </div>
     {% endif %}
@@ -817,6 +821,7 @@ option:not(:checked) {
                 <td>
                     <div id="lemma_buttons" name="lemma_buttons">
                         <button id='show_edit_lemma_form' name='show_edit_lemma_form'
+                                style="width:auto;"
                                 class='btn btn-primary btn-space lemma-button'>{% trans "Edit Lemma" %}</button>
                         <button id='show_set_lemma_form' name='show_set_lemma_form'
                                 class='btn btn-primary btn-space lemma-button'>{% trans "Choose Other" %}</button>

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -34,6 +34,7 @@ from django.shortcuts import redirect
 from signbank.dictionary.update_senses_mapping import mapping_edit_keywords, mapping_group_keywords, mapping_add_keyword, \
     mapping_edit_senses_matrix, mapping_toggle_sense_tag
 from signbank.dictionary.consistency_senses import reorder_translations
+from signbank.dictionary.related_objects import gloss_related_objects
 
 
 def show_error(request, translated_message, form, dataset_languages):
@@ -741,7 +742,9 @@ def update_gloss(request, glossid):
         if value == 'confirmed':
             # delete the gloss and redirect back to gloss list
 
-            # gloss.delete()
+            related_objects = gloss_related_objects(gloss)
+            if not related_objects:
+                gloss.delete()
 
             return HttpResponseRedirect(reverse('dictionary:admin_gloss_list'))
 

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -35,6 +35,7 @@ from signbank.dictionary.update_senses_mapping import mapping_edit_keywords, map
     mapping_edit_senses_matrix, mapping_toggle_sense_tag
 from signbank.dictionary.consistency_senses import reorder_translations
 
+
 def show_error(request, translated_message, form, dataset_languages):
     # this function is used by the add_gloss function below
     messages.add_message(request, messages.ERROR, translated_message)
@@ -740,9 +741,7 @@ def update_gloss(request, glossid):
         if value == 'confirmed':
             # delete the gloss and redirect back to gloss list
 
-            pk = gloss.pk
-            gloss.delete()
-            gloss.pk = pk
+            # gloss.delete()
 
             return HttpResponseRedirect(reverse('dictionary:admin_gloss_list'))
 

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -743,8 +743,14 @@ def update_gloss(request, glossid):
             # delete the gloss and redirect back to gloss list
 
             related_objects = gloss_related_objects(gloss)
-            if not related_objects:
-                gloss.delete()
+
+            if settings.GUARDED_GLOSS_DELETE and related_objects:
+                reverse_url = 'dictionary:admin_gloss_view'
+                messages.add_message(request, messages.INFO,
+                                     _("GUARDED_GLOSS_DELETE is set to True. The gloss has relations to other glosses and was not deleted."))
+                return HttpResponseRedirect(reverse(reverse_url, kwargs={'pk': gloss.id}))
+
+            gloss.delete()
 
             return HttpResponseRedirect(reverse('dictionary:admin_gloss_list'))
 

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -296,3 +296,6 @@ SHARE_SENSES = False
 DEBUG_CSV = False
 
 DEBUG_SENSES = False
+
+# Set this to True to avoid deleting glosses that are in relations with other glosses
+GUARDED_GLOSS_DELETE = False


### PR DESCRIPTION
Information has been added to the modal for Delete this sign.

At the moment, I commented out the actual gloss.delete() in update.py
Do we want to prevent the user from deleting the gloss if it's related to other objects?
