### PR TITLE
Move button to switch dataset of gloss

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -55,13 +55,18 @@ from signbank.frequency import import_corpus_speakers, configure_corpus_document
     dictionary_speakers_to_documents, document_has_been_updated, document_to_number_of_glosses, \
     document_to_glosses, get_corpus_speakers, remove_document_from_corpus, document_identifiers_from_paths, \
     eaf_file_from_paths, documents_paths_dictionary
-from signbank.dictionary.frequency_display import collect_speaker_age_data, collect_variants_data, collect_variants_age_range_data, \
-                                                    collect_variants_age_sex_raw_percentage
+from signbank.dictionary.frequency_display import (collect_speaker_age_data, collect_variants_data,
+                                                   collect_variants_age_range_data,
+                                                   collect_variants_age_sex_raw_percentage)
 from signbank.dictionary.senses_display import (senses_per_language, senses_per_language_list,
                                                 sensetranslations_per_language_dict,
-                                                senses_translations_per_language_list, senses_sentences_per_language_list)
-from signbank.dictionary.context_data import get_context_data_for_list_view, get_context_data_for_gloss_search_form, get_web_search
-from signbank.dictionary.related_objects import gloss_is_related_to, gloss_related_objects, okay_to_move_gloss, same_translation_languages
+                                                senses_translations_per_language_list,
+                                                senses_sentences_per_language_list)
+from signbank.dictionary.context_data import (get_context_data_for_list_view, get_context_data_for_gloss_search_form,
+                                              get_web_search)
+from signbank.dictionary.related_objects import (gloss_is_related_to, gloss_related_objects, okay_to_move_gloss,
+                                                 same_translation_languages, okay_to_move_glosses,
+                                                 glosses_in_lemma_group, transitive_related_objects)
 
 
 def order_queryset_by_sort_order(get, qs, queryset_language_codes):
@@ -1238,6 +1243,9 @@ class GlossDetailView(DetailView):
 
         context['related_objects'] = gloss_is_related_to(gl, interface_language_code, default_language_code)
 
+        related_objects = [get_default_annotationidglosstranslation(ro) for ro in transitive_related_objects(gl)]
+        context['extended_related_objects'] = ', '.join(related_objects)
+
         if hasattr(settings, 'SHOW_DATASET_INTERFACE_OPTIONS') and settings.SHOW_DATASET_INTERFACE_OPTIONS:
             context['dataset_choices'] = {}
             user = self.request.user
@@ -1326,7 +1334,8 @@ class GlossDetailView(DetailView):
     def move_gloss(self, context):
         gl = context['gloss']
         context['active_id'] = gl.id
-        related_objects = gloss_related_objects(gl)
+        related_objects = transitive_related_objects(gl)
+
         user = self.request.user
         if not user.is_superuser:
             messages.add_message(self.request, messages.ERROR,
@@ -1336,18 +1345,23 @@ class GlossDetailView(DetailView):
         dataset_pk = self.request.GET.get('dataset')
         dataset = Dataset.objects.get(pk=dataset_pk)
 
-        if gl.lemma.dataset == dataset:
-            # do nothing
-            return HttpResponseRedirect(settings.PREFIX_URL + '/dictionary/gloss/' + str(gl.id))
-
         if not same_translation_languages(gl.lemma.dataset, dataset):
             messages.add_message(self.request, messages.ERROR,
                                  _('The target dataset has different translation languages.'))
             return HttpResponseRedirect(settings.PREFIX_URL + '/dictionary/gloss/' + str(gl.id))
 
-        if not okay_to_move_gloss(gl, gl.lemma.dataset, dataset):
-            messages.add_message(self.request, messages.ERROR,
-                                 _('A similar gloss already exists in the target dataset.'))
+        if gl.lemma.dataset != dataset:
+            okay_to_move, feedback = okay_to_move_gloss(gl, dataset)
+            if not okay_to_move:
+                feedback_message = _('A similar gloss already exists in the target dataset: ') + ', '.join(feedback)
+
+                messages.add_message(self.request, messages.ERROR, feedback_message)
+                return HttpResponseRedirect(settings.PREFIX_URL + '/dictionary/gloss/' + str(gl.id))
+
+        okay_to_move, feedback = okay_to_move_glosses(related_objects, dataset)
+        if not okay_to_move:
+            feedback_message = _('A related gloss already exists in the target dataset: ') + ', '.join(feedback)
+            messages.add_message(self.request, messages.ERROR, feedback_message)
             return HttpResponseRedirect(settings.PREFIX_URL + '/dictionary/gloss/' + str(gl.id))
 
         gloss_lemma = gl.lemma

--- a/signbank/dictionary/related_objects.py
+++ b/signbank/dictionary/related_objects.py
@@ -1,4 +1,5 @@
 from signbank.dictionary.models import *
+from signbank.tools import get_default_annotationidglosstranslation
 from django.utils.translation import override, gettext_lazy as _, activate
 
 
@@ -112,10 +113,20 @@ def gloss_is_related_to(gloss, interface_language_code, default_language_code):
     return related_objects
 
 
+def glosses_in_lemma_group(gloss):
+
+    lemma_group = [gl for gl in Gloss.objects.filter(lemma=gloss.lemma).exclude(id=gloss.id)]
+
+    return lemma_group
+
+
 def gloss_related_objects(gloss):
 
-    related_glosses = [relation.target
-                       for relation in Relation.objects.filter(source=gloss).exclude(target=gloss)]
+    related_glosses_target = [relation.target
+                              for relation in Relation.objects.filter(source=gloss)]
+
+    related_glosses_source = [relation.source
+                              for relation in Relation.objects.filter(target=gloss)]
 
     # the morpheme field of MorphologyDefinition is a ForeignKey to Gloss
     morphemes = [morpheme.morpheme
@@ -152,9 +163,34 @@ def gloss_related_objects(gloss):
             if gl != gloss and gl not in blendsiblings:
                 blendsiblings.append(gl)
 
-    related_gloss_unique = list(set(related_glosses + morphemes + appears_in
+    related_gloss_unique = list(set(related_glosses_target + related_glosses_source + morphemes + appears_in
                                     + siblings + simultaneous + blends + blendsiblings))
     return related_gloss_unique
+
+
+def transitive_related_objects(gloss):
+    related_objects = gloss_related_objects(gloss)
+    # transitive related objects for other glosses in lemma group
+    lemma_group = glosses_in_lemma_group(gloss)
+    # the glosses and the ids are both maintained
+    extended_related_objects = []
+    extended_related_objects_ids = []
+    for ro in related_objects:
+        if ro.id not in extended_related_objects_ids:
+            extended_related_objects_ids.append(ro.id)
+            extended_related_objects.append(ro)
+        related_related = gloss_related_objects(ro)
+        for rr in related_related:
+            if rr.id not in extended_related_objects_ids:
+                extended_related_objects.append(rr)
+                extended_related_objects_ids.append(rr.id)
+    for lgg in lemma_group:
+        lgg_related_objects = gloss_related_objects(lgg)
+        for lggro in lgg_related_objects:
+            if lggro.id not in extended_related_objects_ids:
+                extended_related_objects.append(lggro)
+                extended_related_objects_ids.append(lggro.id)
+    return extended_related_objects
 
 
 def same_translation_languages(dataset1, dataset2):
@@ -168,9 +204,12 @@ def same_translation_languages(dataset1, dataset2):
 def gloss_exists_in_dataset(gloss, dataset):
 
     if gloss.lemma.dataset == dataset:
-        return True
-
+        # this method should not be called in this case
+        # False is returned because there is no conflict
+        return False, []
     gloss_exists = False
+    lemma_exists = False
+    text_overlap = []
     gloss_lemma_translations = gloss.lemma.lemmaidglosstranslation_set.all()
     gloss_annotation_translations = gloss.annotationidglosstranslation_set.all()
     for lemma_translation in gloss_lemma_translations:
@@ -178,7 +217,7 @@ def gloss_exists_in_dataset(gloss, dataset):
                                                                 lemmaidglosstranslation__language=lemma_translation.language)
         if lemmas_with_same_text.count():
             # The lemma translation text is already in use in the dataset
-            gloss_exists = True
+            lemma_exists = True
     target_dataset_glosses = Gloss.objects.filter(lemma__dataset=dataset)
     for gloss_translation in gloss_annotation_translations:
         glosses_with_same_text = target_dataset_glosses.filter(annotationidglosstranslation__text__exact=gloss_translation.text,
@@ -186,15 +225,32 @@ def gloss_exists_in_dataset(gloss, dataset):
         if glosses_with_same_text.count():
             # The gloss annotation text is already in use in the dataset
             gloss_exists = True
-    return gloss_exists
+    if lemma_exists:
+        text_overlap.append("Lemma "+gloss.idgloss)
+    if gloss_exists:
+        text_overlap.append("Gloss "+get_default_annotationidglosstranslation(gloss))
+
+    return lemma_exists or gloss_exists, text_overlap
 
 
-def okay_to_move_gloss(gloss, dataset_source, dataset_target):
+def okay_to_move_gloss(gloss, dataset_target):
 
-    if not same_translation_languages(dataset_source, dataset_target):
-        return False
+    if not same_translation_languages(gloss.lemma.dataset, dataset_target):
+        return False, []
 
-    if gloss_exists_in_dataset(gloss, dataset_target):
-        return False
+    gloss_exists, text_overlap = gloss_exists_in_dataset(gloss, dataset_target)
 
-    return True
+    return not gloss_exists, text_overlap
+
+
+def okay_to_move_glosses(glosses, dataset_target):
+
+    okay_to_move = True
+    text_overlap = []
+    for gloss in glosses:
+        gloss_exists, feedback = gloss_exists_in_dataset(gloss, dataset_target)
+
+        okay_to_move &= not gloss_exists
+        text_overlap += feedback
+
+    return okay_to_move, text_overlap

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -565,7 +565,7 @@ option:not(:checked) {
 
         {% endif %}
 
-        {% if user.is_superuser %}
+        {% if user.is_superuser and selected_datasets|length > 1 %}
          <button id='move_gloss_btn' class='btn btn-primary move-button' data-toggle='modal' data-target='#move_gloss_modal'>{% trans "Move" %}</button>
 
           <div class="modal fade" id="move_gloss_modal" role="dialog" aria-labelledby="#modalGlossMove" aria-hidden="true">
@@ -598,6 +598,10 @@ option:not(:checked) {
                                 <td>{{glosses}}</td>
                             </tr>
                             {% endfor %}
+                            <tr>
+                                <td>{% trans "Related Glosses" %}</td>
+                                <td>{{extended_related_objects}}</td>
+                            </tr>
                         </table>
                         {% endif %}
                      </div>

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -565,7 +565,7 @@ option:not(:checked) {
 
         {% endif %}
 
-        {% if perms.dictionary.add_gloss %}
+        {% if user.is_superuser %}
          <button id='move_gloss_btn' class='btn btn-primary move-button' data-toggle='modal' data-target='#move_gloss_modal'>{% trans "Move" %}</button>
 
           <div class="modal fade" id="move_gloss_modal" role="dialog" aria-labelledby="#modalGlossMove" aria-hidden="true">
@@ -575,7 +575,19 @@ option:not(:checked) {
                         <h2 id='modalGlossMove'>{% trans "Move Gloss" %}</h2>
                     </div>
                     <div class='modal-body'>
-                        <p>{% trans "This will change the dataset of the gloss." %}</p>
+                        <p>{% trans "This command will change the dataset of the gloss." %}</p>
+                        {% if related_objects.keys %}
+                        <p>{% trans "This gloss is related to other glosses:" %}</p>
+                        <table class="table table-condensed table-bordered">
+                            {% for key, glosses in related_objects.items %}
+                            <tr>
+                                <td style="width:240px">{{key}}</td>
+                                <td>{{glosses}}</td>
+                            </tr>
+                            {% endfor %}
+                        </table>
+                        <br>
+                        {% endif %}
                      </div>
                   <form id="move_gloss" method='get'>
                       {% csrf_token %}

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -562,7 +562,60 @@ option:not(:checked) {
                 </div>
               </div>
          </div>
+
         {% endif %}
+
+        {% if perms.dictionary.add_gloss %}
+         <button id='move_gloss_btn' class='btn btn-primary move-button' data-toggle='modal' data-target='#move_gloss_modal'>{% trans "Move" %}</button>
+
+          <div class="modal fade" id="move_gloss_modal" role="dialog" aria-labelledby="#modalGlossMove" aria-hidden="true">
+             <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class='modal-header'>
+                        <h2 id='modalGlossMove'>{% trans "Move Gloss" %}</h2>
+                    </div>
+                    <div class='modal-body'>
+                        <p>{% trans "This will change the dataset of the gloss." %}</p>
+                     </div>
+                  <form id="move_gloss" method='get'>
+                      {% csrf_token %}
+                      <table class='table' style='width: 1200px;margin-left:20px;'>
+                         <tr>
+                             <th>{% trans "Source Dataset" %}</th>
+                             <th>{{gloss.lemma.dataset.acronym}}</th>
+                         </tr>
+                         <tr>
+                             <th><label for='dataset'>{% trans "Target Dataset" %}</label></th>
+                             <td><span>
+                                 {% for s_dataset in selected_datasets %}
+                                 {% get_obj_perms request.user for s_dataset as "dataset_perms" %}
+                                 {% if "change_dataset" in dataset_perms %}
+                                 {% if gloss.lemma.dataset == s_dataset or last_used_dataset == s_dataset.acronym %}
+                                <input type="radio" name="dataset"
+                                       id="dataset_{{s_dataset.id}}" value="{{s_dataset.id}}" checked>
+                                 {% else %}
+                                 <input type="radio" name="dataset"
+                                        id="dataset_{{s_dataset.id}}" value="{{s_dataset.id}}">
+                                 {% endif %}
+                                <label for="dataset_{{s_dataset.id}}">{{s_dataset.acronym}}</label>
+                                 {% endif %}
+                                 {% endfor %}
+                            </span></td>
+                         </tr>
+                      </table>
+                      <input type='hidden' name='format' value='Move'>
+                      <input type='hidden' name='value' value='confirmed'>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Cancel" %}</button>
+                        <input type="submit" class="btn btn-primary" value='{% trans "Confirm Move" %}'>
+                      </div>
+                  </form>
+
+                </div>
+              </div>
+          </div>
+        {% endif %}
+
     </div>
     {% endif %}
 

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -573,9 +573,22 @@ option:not(:checked) {
                 <div class="modal-content">
                     <div class='modal-header'>
                         <h2 id='modalGlossMove'>{% trans "Move Gloss" %}</h2>
+                        {% with gloss.lemma.dataset.default_language as target_default_language %}
+			            {% with annotation_idgloss|get_item:target_default_language as annotation %}
+                        <h4>{{annotation}}</h4>
+                        {% endwith %}
+                        {% endwith %}
                     </div>
                     <div class='modal-body'>
-                        <p>{% trans "This command will change the dataset of the gloss." %}</p>
+                        {% blocktrans %}
+                        <p>This command will change the dataset of the gloss as well as its related glosses
+                            (via relations or morphology).</p>
+                        <p>The target dataset must have the same translation languages.</p>
+                        <p>If a gloss cannot be moved because of a similar gloss in the target dataset,
+                            the user is expected to modify the lemma translations or gloss annotations
+                            to remove ambiguity.</p>
+                        <p>The videos and images of the glosses are also moved to the new dataset.</p>
+                        {% endblocktrans %}
                         {% if related_objects.keys %}
                         <p>{% trans "This gloss is related to other glosses:" %}</p>
                         <table class="table table-condensed table-bordered">
@@ -586,7 +599,6 @@ option:not(:checked) {
                             </tr>
                             {% endfor %}
                         </table>
-                        <br>
                         {% endif %}
                      </div>
                   <form id="move_gloss" method='get'>

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -727,6 +727,21 @@ def process_lemmaidglosstranslation_changes(sender, instance, **kwargs):
         glossvideo.move_video(move_files_on_disk=True)
 
 
+@receiver(models.signals.post_save, sender=LemmaIdgloss)
+def process_lemmaidgloss_changes(sender, instance, **kwargs):
+    """
+    Makes changes to GlossVideos if a LemmaIdgloss has been changed.
+    :param sender:
+    :param instance:
+    :param kwargs:
+    :return:
+    """
+    lemmaidgloss = instance
+    glossvideos = GlossVideo.objects.filter(gloss__lemma=lemmaidgloss)
+    for glossvideo in glossvideos:
+        glossvideo.move_video(move_files_on_disk=True)
+
+
 @receiver(models.signals.post_save, sender=Gloss)
 @receiver(models.signals.post_save, sender=Morpheme)
 def process_gloss_changes(sender, instance, **kwargs):


### PR DESCRIPTION
A button has been added to GlossDetailView to allow moving a gloss to a different dataset. #1119 

This involved updating the lemma field dataset to the new dataset.
To maintain consistency, the dataset of the related glosses (via relations or morphology) are also changed.
To do the morphology, reverse morphology is also retrieved in related objects.
For example, gloss Ijsbeer = Ijs + beer.
If any of these glosses is moved, the others also need to be moved.
This is done in an atomic transaction.

The videos and images of the gloss(es) are also moved to the new dataset.
This is done using a signal. (As for other updates.)

At the moment, there are checks that the user is a superuser in order to do this.
Both datasets must be selected.

The existence of the gloss already in the target dataset is checked.

- An error feedback is shown

If the gloss can't be moved because of a similar gloss in the target dataset:
- Expect the user to change the lemma translations and gloss annotations to remove ambiguity.
- The target dataset must have the same translation languages

Relations can be transitive. Once some glosses that are related are moved, this will also need to move more glosses.

- Assumes that the user will look before jumping.

That the annotation and lemma texts non-overlap are soft constraints on the dataset (This is checked manually by all the code.) The use of one text per language is a Django constraint.

```
      AnnotationIdglossTranslation
                 unique_together = (("gloss", "language"),)

      LemmaIdglossTranslation
                unique_together = (("lemma", "language"),)  # For each combination of lemma and language there is just one text.
```
