### PR TITLE
Show warning when attempting to delete a morpheme

### DIFF
--- a/signbank/dictionary/templates/dictionary/morpheme_detail.html
+++ b/signbank/dictionary/templates/dictionary/morpheme_detail.html
@@ -433,12 +433,12 @@ function checkKey(e)
                 </td><td style="width:200px;"></td>
             </tr>
 
-            {% for lang, annotation_idgloss_translations in annotation_idgloss.items %}
+            {% for lang, annotation_idgloss_translation in annotation_idgloss.items %}
             <tr>
                 <th>
                     {% trans "Annotation ID Gloss" %} ({{ lang }})
                 </th>
-                <td class='edit edit_text' id='annotation_idgloss_{{lang.language_code_2char}}'>{{ annotation_idgloss_translations.0.text|safe }}</td>
+                <td class='edit edit_text' id='annotation_idgloss_{{lang.language_code_2char}}'>{{annotation_idgloss_translation}}</td>
 
             </tr>
             {% endfor %}
@@ -467,12 +467,31 @@ function checkKey(e)
 
         {% if perms.dictionary.change_morpheme %}
          <div class="modal fade" id="delete_morpheme_modal" tabindex="-1" role="dialog" aria-labelledby="#modalTitleDel" aria-hidden="true">
-             <div class="modal-dialog modal-sm">
+             <div class="modal-dialog modal-dialog-centered modal-lg left-modal">
                 <div class="modal-content">
                     <div class='modal-header'>
                         <h2 id='modalTitleDel'>{% trans "Delete This Morpheme" %}</h2>
+                        <br>
+                        {% with morpheme.lemma.dataset.default_language as target_default_language %}
+			            {% with annotation_idgloss|get_item:target_default_language as annotation %}
+                        <h4>{% trans "Morpheme" %}: {{annotation}}</h4>
+                        {% endwith %}
+                        {% endwith %}
                     </div>
                     <div class='modal-body'>
+                        {% if related_objects.keys %}
+                        <p>{% trans "This morpheme is related to glosses:" %}</p>
+                        <br>
+                        <table class="table table-condensed table-bordered">
+                            {% for key, glosses in related_objects.items %}
+                            <tr>
+                                <td style="width:240px">{{key}}</td>
+                                <td>{{glosses}}</td>
+                            </tr>
+                            {% endfor %}
+                        </table>
+                        <br>
+                        {% endif %}
                         <p>{% trans "This action will delete this morpheme and all associated records. It cannot be undone." %}</p>
                      </div>
                   <form action='{% url "dictionary:update_morpheme" morpheme.id %}' method='post'>

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -34,7 +34,7 @@ from django.shortcuts import redirect
 from signbank.dictionary.update_senses_mapping import mapping_edit_keywords, mapping_group_keywords, mapping_add_keyword, \
     mapping_edit_senses_matrix, mapping_toggle_sense_tag
 from signbank.dictionary.consistency_senses import reorder_translations
-from signbank.dictionary.related_objects import gloss_related_objects
+from signbank.dictionary.related_objects import gloss_related_objects, morpheme_related_objects
 
 
 def show_error(request, translated_message, form, dataset_languages):
@@ -2529,6 +2529,13 @@ def update_morpheme(request, morphemeid):
     if field == 'deletemorpheme':
         if value == 'confirmed':
             # delete the morpheme and redirect back to morpheme list
+            related_objects = morpheme_related_objects(morpheme)
+
+            if settings.GUARDED_MORPHEME_DELETE or related_objects:
+                reverse_url = 'dictionary:admin_morpheme_view'
+                messages.add_message(request, messages.INFO,
+                                     _("GUARDED_MORPHEME_DELETE is set to True or the morpheme has relations to other glosses and was not deleted."))
+                return HttpResponseRedirect(reverse(reverse_url, kwargs={'pk': morpheme.id}))
             morpheme.delete()
             return HttpResponseRedirect(reverse('dictionary:admin_morpheme_list'))
 

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -299,3 +299,5 @@ DEBUG_SENSES = False
 
 # Set this to True to avoid deleting glosses that are in relations with other glosses
 GUARDED_GLOSS_DELETE = False
+
+GUARDED_MORPHEME_DELETE = True


### PR DESCRIPTION
that is referenced by glosses

Added a setting to guard morpheme delete. Default is True since they exist but are in limited use so far.