### PR TITLE
Update senses field added to update gloss API #1202

### DIFF
--- a/signbank/abstract_machine.py
+++ b/signbank/abstract_machine.py
@@ -20,7 +20,7 @@ def convert_string_to_list_of_lists(input_string):
     try:
         list_of_lists = ast.literal_eval(input_string)
     except (ValueError, SyntaxError):
-        return [], 'Sense input if not in the expected format. \nTry: "[[\'sense 1 keyword1\', \'sense 1 keyword2\'],[\'sense 2 keyword1\', \'sense 2 keyword2\'],[\'sense 3 keyword1\', \'sense 3 keyword2\']]"'
+        return [], "Sense input if not in the expected format. \nTry: '[[\"sense 1 keyword1\", \"sense 1 keyword2\"],[\"sense 2 keyword1\", \"sense 2 keyword2\"],[\"sense 3 keyword1\", \"sense 3 keyword2\"]]'"
         
     # Verify if the result is a list of lists
     if isinstance(list_of_lists, list):

--- a/signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html
+++ b/signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html
@@ -87,7 +87,7 @@ function update_gloss() {
                  </th>
                  <td id="field_value_{{field}}">
                      <input name='{{field_verbose}}' id="field_input_{{field}}"
-                            maxlength="30" type="text"
+                            maxlength="200" type="text"
                             size="50" >
                  </td>
              </tr>

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -3088,8 +3088,7 @@ def test_am_update_gloss(request, datasetid, glossid):
      default_language, default_language_code) = get_interface_language_and_default_language_codes(request)
 
     activate(interface_language_code)
-
-    fieldnames = FIELDS['main'] + FIELDS['phonology'] + FIELDS['semantics'] + ['inWeb', 'isNew', 'excludeFromEcv']
+    fieldnames = FIELDS['main'] + FIELDS['phonology'] + FIELDS['semantics'] + ['inWeb', 'isNew', 'excludeFromEcv', 'senses']
     gloss_fields = { fname: Gloss.get_field(fname).verbose_name.title()
                     for fname in fieldnames if fname in Gloss.get_field_names() }
 

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -154,13 +154,11 @@ def update_senses(gloss, new_value):
                     if not kw:
                         continue
                     keyword = Keyword.objects.get_or_create(text=kw)[0]
-                    
                     translation = Translation(translation=keyword,
                                                 language=dataset_language,
                                                 gloss=gloss,
                                                 orderIndex=new_sense_i,
                                                 index=inx)
-                    print(translation.translation, translation.language, translation.gloss, translation.orderIndex, translation.index)
                     translation.save()
                     sensetranslation.translations.add(translation)
                 sensetranslation.save()

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -60,6 +60,15 @@ def gloss_update_fields_check(value_dict, language_code):
             errors[field] = _("Field update not allowed")
     return errors
 
+def remove_duplicates_preserve_order(translation_list):
+    unique_list = []
+    seen = set()
+    for item in translation_list:
+        if item not in seen:
+            unique_list.append(item)
+            seen.add(item)
+    return unique_list
+
 def convert_string_to_dict_of_list_of_lists(input_string):
     """
     Convert a string to a dictionary of lists of lists.
@@ -137,18 +146,21 @@ def update_senses(gloss, new_value):
                     # there should only be one per language
                     sensetranslation = SenseTranslation.objects.create(language=dataset_language)
                     sense.senseTranslations.add(sensetranslation)
-                for inx, kw in enumerate(new_sense, 1):
+                new_sense_translations = remove_duplicates_preserve_order(new_sense)
+                for inx, kw in enumerate(new_sense_translations, 1):
                     # this is a new sense so it has no translations yet
                     # the combination with gloss, language, orderIndex does not exist yet
                     # the index is the order the keyword was entered by the user
                     if not kw:
                         continue
                     keyword = Keyword.objects.get_or_create(text=kw)[0]
+                    
                     translation = Translation(translation=keyword,
                                                 language=dataset_language,
                                                 gloss=gloss,
                                                 orderIndex=new_sense_i,
                                                 index=inx)
+                    print(translation.translation, translation.language, translation.gloss, translation.orderIndex, translation.index)
                     translation.save()
                     sensetranslation.translations.add(translation)
                 sensetranslation.save()


### PR DESCRIPTION
@susanodd When given input for field 'senses', all existing ones are removed from the gloss (for every language) and deleted (if not in another gloss) and the new senses are created. So it doesn't check for each translation/keyword separately. 

Input is in the form of 'senses': '{"en": [["s1w1", "s1w2"],["s2w1"]], "nl":[["s1w1"],["s2w1", "s2w1"]]}"

Can you check if you agree with this implementation?