### PR TITLE
API update lemma and annotation fields

### DIFF
--- a/signbank/abstract_machine.py
+++ b/signbank/abstract_machine.py
@@ -82,7 +82,6 @@ def create_gloss_columns_to_value_dict_keys(dataset, language_code):
     required_columns = dict()
     required_columns['Dataset'] = 'dataset'
     dataset_languages = dataset.translation_languages.all()
-    lang_attr_name = 'name_' + DEFAULT_KEYWORDS_LANGUAGE['language_code_2char']
     for language in dataset_languages:
         required_columns[gettext("Annotation ID Gloss") + " (" + language.name + ")"] = (
                 'annotation_id_gloss_' + getattr(language, 'language_code_2char'))

--- a/signbank/api_interface.py
+++ b/signbank/api_interface.py
@@ -7,6 +7,8 @@ from tagging.models import Tag, TaggedItem
 from signbank.dictionary.forms import *
 from django.utils.translation import override, gettext_lazy as _, activate
 from signbank.settings.server_specific import LANGUAGES, LEFT_DOUBLE_QUOTE_PATTERNS, RIGHT_DOUBLE_QUOTE_PATTERNS
+from signbank.api_token import hash_token
+from signbank.abstract_machine import get_interface_language_api
 
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -80,8 +82,24 @@ def api_fields(dataset, language_code='en', advanced=False):
 
 def get_fields_data_json(request, datasetid):
 
-    from signbank.abstract_machine import get_interface_language_api
-    interface_language_code = get_interface_language_api(request, request.user)
+    results = dict()
+    auth_token_request = request.headers.get('Authorization', '')
+    interface_language_code = request.headers.get('Accept-Language', 'en')
+    if interface_language_code not in settings.MODELTRANSLATION_LANGUAGES:
+        interface_language_code = 'en'
+    activate(interface_language_code)
+    if auth_token_request:
+        auth_token = auth_token_request.split('Bearer ')[-1]
+        hashed_token = hash_token(auth_token)
+        signbank_token = SignbankAPIToken.objects.filter(api_token=hashed_token).first()
+        if not signbank_token:
+            results['errors'] = [gettext("Your Authorization Token does not match anything.")]
+            return JsonResponse(results)
+        username = signbank_token.signbank_user.username
+        user = User.objects.get(username=username)
+    else:
+        user = request.user
+        interface_language_code = get_interface_language_api(request, user)
 
     sequence_of_digits = True
     for i in datasetid:
@@ -98,7 +116,7 @@ def get_fields_data_json(request, datasetid):
         # ignore the database in the url if necessary
         dataset = Dataset.objects.get(id=settings.DEFAULT_DATASET_PK)
 
-    if request.user.has_perm('dictionary.change_gloss'):
+    if user.has_perm('dictionary.change_gloss'):
         api_fields_2023 = api_fields(dataset, interface_language_code, advanced=True)
     else:
         api_fields_2023 = api_fields(dataset, interface_language_code, advanced=False)
@@ -110,8 +128,24 @@ def get_fields_data_json(request, datasetid):
 
 def get_gloss_data_json(request, datasetid, glossid):
 
-    from signbank.abstract_machine import get_interface_language_api
-    interface_language_code = get_interface_language_api(request, request.user)
+    results = dict()
+    auth_token_request = request.headers.get('Authorization', '')
+    interface_language_code = request.headers.get('Accept-Language', 'en')
+    if interface_language_code not in settings.MODELTRANSLATION_LANGUAGES:
+        interface_language_code = 'en'
+    activate(interface_language_code)
+    if auth_token_request:
+        auth_token = auth_token_request.split('Bearer ')[-1]
+        hashed_token = hash_token(auth_token)
+        signbank_token = SignbankAPIToken.objects.filter(api_token=hashed_token).first()
+        if not signbank_token:
+            results['errors'] = [gettext("Your Authorization Token does not match anything.")]
+            return JsonResponse(results)
+        username = signbank_token.signbank_user.username
+        user = User.objects.get(username=username)
+    else:
+        user = request.user
+        interface_language_code = get_interface_language_api(request, user)
 
     sequence_of_digits = True
     for i in datasetid:
@@ -124,8 +158,8 @@ def get_gloss_data_json(request, datasetid, glossid):
 
     dataset_id = int(datasetid)
     dataset = Dataset.objects.filter(id=dataset_id).first()
-    if not dataset or not request.user.is_authenticated:
-        # ignore the database in the url if necessary
+    if not dataset or not user.is_authenticated:
+        # ignore the dataset in the url if necessary
         dataset = Dataset.objects.get(id=settings.DEFAULT_DATASET_PK)
 
     sequence_of_digits = True
@@ -143,7 +177,7 @@ def get_gloss_data_json(request, datasetid, glossid):
     if not gloss:
         return JsonResponse({})
 
-    if request.user.has_perm('dictionary.change_gloss'):
+    if user.has_perm('dictionary.change_gloss'):
         api_fields_2023 = api_fields(dataset, interface_language_code, advanced=True)
     else:
         api_fields_2023 = api_fields(dataset, interface_language_code, advanced=False)

--- a/signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html
+++ b/signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html
@@ -19,6 +19,7 @@
     var glossid = '{{gloss.id}}';
     var csrf_token = '{{csrf_token}}';
     var gloss_fields = {{gloss_fields|safe}};
+    var language_2chars = {{language_2chars|safe}};
 </script>
 
 <script type="text/javascript">
@@ -49,6 +50,23 @@ function show_update_results(data) {
 }
 function update_gloss() {
      var update = { };
+     for (var i=0; i < language_2chars.length; i++) {
+        var lang2char = language_2chars[i];
+        var lemma_field = 'lemma_id_gloss_' + lang2char;
+        var lemma_field_lookup = '#'+lemma_field;
+        var lemma_field_key = $(lemma_field_lookup).attr("name");
+        var lemma_field_value = $(lemma_field_lookup).val();
+        if (lemma_field_value != '') {
+            update[lemma_field_key] = lemma_field_value;
+        }
+        var annotation_field = 'annotation_id_gloss_' + lang2char;
+        var annotation_field_lookup = '#'+annotation_field;
+        var annotation_field_key = $(annotation_field_lookup).attr("name");
+        var annotation_field_value = $(annotation_field_lookup).val();
+        if (annotation_field_value != '') {
+            update[annotation_field_key] = annotation_field_value;
+        }
+     }
      for (var field in gloss_fields) {
         var field_lookup = '#field_input_'+field;
         var field_key = $(field_lookup).attr("name");
@@ -58,11 +76,13 @@ function update_gloss() {
         }
         update[field_key] = field_value;
      }
+     var update_json = JSON.stringify(update);
+     console.log(update_json);
      $.ajax({
         url : url + "/dictionary/api_update_gloss/" + datasetid + '/' + glossid + '/',
         type: 'POST',
         headers: { 'Accept-Language': language_code },
-        data: JSON.stringify(update),
+        data: update_json,
         datatype: "json",
         async: false,
         success : show_update_results
@@ -99,6 +119,32 @@ function update_gloss() {
         <p>{% trans "It makes use of the csrf token in the javascript AJAX setup." %}</p>
      <div>
          <table class='table' style='width: 1200px;'>
+             {% for dataset_lang in dataset_languages %}
+             <tr>
+                 <th id="add_gloss_lemma_header_{{dataset_lang.language_code_2char}}" style="width:200px;">
+                     {% trans "Lemma ID Gloss" %} ({{ dataset_lang.name }})
+                 </th>
+                 <td id="add_gloss_lemma_value_{{dataset_lang.language_code_2char}}">
+                     <input id="lemma_id_gloss_{{dataset_lang.language_code_2char}}"
+                            name='{% trans "Lemma ID Gloss" %} ({{ dataset_lang.name }})'
+                            maxlength="30" type="text"
+                            size="50" >
+                 </td>
+             </tr>
+             {% endfor %}
+             {% for dataset_lang in dataset_languages %}
+             <tr>
+                 <th id="add_gloss_annotation_header_{{dataset_lang.language_code_2char}}" style="width:300px;">
+                     {% trans "Annotation ID Gloss" %} ({{ dataset_lang.name }})
+                 </th>
+                 <td id="add_gloss_annotation_value_{{dataset_lang.language_code_2char}}">
+                     <input id="annotation_id_gloss_{{dataset_lang.language_code_2char}}"
+                            name='{% trans "Annotation ID Gloss" %} ({{ dataset_lang.name }})'
+                            maxlength="30" type="text"
+                            size="50" >
+                 </td>
+             </tr>
+             {% endfor %}
              {% for field, field_verbose in gloss_fields.items %}
              <tr>
                  <th id="field_label_{{field}}">

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -2599,7 +2599,7 @@ def gloss_revision_history(request,gloss_pk):
             else:
                 # this shouldn't happen
                 field_name_qualification = ''
-        elif revision.field_name == 'Sense':
+        elif revision.field_name == 'Sense' or revision.field_name == 'senses':
             if revision.old_value and not revision.new_value:
                 # this translation exists in the interface of Gloss Edit View
                 delete_command = str(_('Delete'))

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -3099,12 +3099,15 @@ def test_am_update_gloss(request, datasetid, glossid):
 
     activate(interface_language_code)
     fieldnames = FIELDS['main'] + FIELDS['phonology'] + FIELDS['semantics'] + ['inWeb', 'isNew', 'excludeFromEcv', 'senses']
-    gloss_fields = { fname: Gloss.get_field(fname).verbose_name.title()
-                    for fname in fieldnames if fname in Gloss.get_field_names() }
+    gloss_fields = {fname: Gloss.get_field(fname).verbose_name.title()
+                    for fname in fieldnames if fname in Gloss.get_field_names()}
+
+    language_2chars = [str(language.language_code_2char) for language in dataset.translation_languages.all()]
 
     return render(request, 'dictionary/virtual_machine_gloss_update_api.html',
                   {'selected_datasets': selected_datasets,
                    'dataset': dataset,
+                   'language_2chars': language_2chars,
                    'gloss': gloss,
                    'gloss_fields': gloss_fields,
                    'dataset_languages': dataset_languages,

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -2599,7 +2599,7 @@ def gloss_revision_history(request,gloss_pk):
             else:
                 # this shouldn't happen
                 field_name_qualification = ''
-        elif revision.field_name == 'Sense' or revision.field_name == 'senses':
+        elif revision.field_name in ['Sense', 'Senses', 'senses']:
             if revision.old_value and not revision.new_value:
                 # this translation exists in the interface of Gloss Edit View
                 delete_command = str(_('Delete'))

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -109,7 +109,7 @@ def revision_history_senses(gloss):
     gloss_senses = gloss.senses.all()
     for sense in gloss_senses:
         senses_display_list.append(str(sense))
-    return ', '.join(senses_display_list)
+    return ' ||| '.join(senses_display_list)
 
 
 def update_senses(gloss, new_value): 
@@ -372,8 +372,10 @@ def gloss_update_do_changes(user, gloss, changes, language_code):
                 update_derivation_history_field(gloss, new_value, language_code)
                 changes_done.append((field.name, original_value, new_value))
             elif field.name == "senses" and isinstance(field, models.ManyToManyField):
+                original_senses = revision_history_senses(gloss)
                 update_senses(gloss, new_value)
-                changes_done.append((field.name, original_value, new_value))
+                new_senses = revision_history_senses(gloss)
+                changes_done.append(('Senses', original_senses, new_senses))
             else:
                 # text field
                 setattr(gloss, field.name, new_value)

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -375,7 +375,7 @@ def gloss_update_do_changes(user, gloss, changes, language_code):
                 original_senses = revision_history_senses(gloss)
                 update_senses(gloss, new_value)
                 new_senses = revision_history_senses(gloss)
-                changes_done.append(('Senses', original_senses, new_senses))
+                changes_done.append((field.name, original_senses, new_senses))
             else:
                 # text field
                 setattr(gloss, field.name, new_value)


### PR DESCRIPTION
This is live on signbank-dev !!!!

This checks for database conflicts before allowing to update.

- already used annotations or lemmas for the dataset and language
- shared lemmas cannot be updated

Also for the API update, modification of strings stored in Gloss Revision History for Senses.

The history has some quirks because the senses updates are done as a whole.
This has been done using a loop over the "before" senses and in turn the "after" senses, using the `__str__` method of the Sense class and a join using '`|||`' to separate. These are both modular, but the strings are stored in the history when saved.

The update to the lemma and annotation fields includes mappings between three different "labels" all available in interface languages.

- the display column human-readable header (used in templates)
- the API retrieval JSON header (used in '`package`', it avoids excessive parentheses)
- the internal label with underscores used in form fields


The two first two are multilingual and mapped by model translations. This allows the API user to provide field choice values for e.g., Dutch phonology. For the language fields for lemma and annotations, (2) has been implemented due to the different syntax for these in the API package that already existed.