### PR TITLE
Dictionary info endpoint: permission change rollback

### DIFF
--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -2310,7 +2310,7 @@ def package(request):
 
 def info(request):
     import guardian
-    user_datasets = guardian.shortcuts.get_objects_for_user(request.user, 'view_dataset', Dataset)
+    user_datasets = guardian.shortcuts.get_objects_for_user(request.user, 'change_dataset', Dataset)
     user_datasets_names = [dataset.acronym for dataset in user_datasets]
 
     # Put the default dataset in first position


### PR DESCRIPTION
Debugging together with Divya, we've figured out that setting the guardian permission to `view_dataset` always results in just `[NGT]`, even though she has view permission on several datasets (which I can verify). If I make it `change_dataset`, like it used to be, the problem goes away. 

Divya has a deadline, so I propose:
* Rollback the situation, so she continue her work AND
* Figure out what's really happening here (is the permission named differently? is there something else happening with view permissions?)

If bullet point 2 takes too long, we can make it a separate issue.