### PR TITLE
Give feedback on adding affiliation to glosses

### DIFF
--- a/signbank/dictionary/management/commands/add_user_affiliation_to_glosses.py
+++ b/signbank/dictionary/management/commands/add_user_affiliation_to_glosses.py
@@ -48,3 +48,5 @@ class Command(BaseCommand):
                         for ua in user_affiliations:
                             new_affiliation, created = AffiliatedGloss.objects.get_or_create(affiliation=ua.affiliation,
                                                                                              gloss=gloss)
+                            if created:
+                                print("Affiliation added to Gloss ", gloss, " for user ", creator)


### PR DESCRIPTION
Purpose for when user affiliation was missing and has been added recently

This command adds the users affiliation to the glosses created by the user.

This fixes an omission for automatically adding the Radboud affiliation.

Some Radboud users did not have an affiliation assigned.

The command can be applied to add the affiliation for users after being assigned an affiliation.