### PR TITLE
Auto affiliation

### DIFF
--- a/signbank/dictionary/management/commands/add_user_affiliation_to_glosses.py
+++ b/signbank/dictionary/management/commands/add_user_affiliation_to_glosses.py
@@ -50,3 +50,5 @@ class Command(BaseCommand):
                                                                                              gloss=gloss)
                             if created:
                                 print("Affiliation added to Gloss ", gloss, " for user ", creator)
+                    else:
+                        print('Creator has no affiliation: ', creator)


### PR DESCRIPTION
Added print statement for when a gloss's creator has no affiliation. For the dataset being processed, the user that created the gloss is printed in the log.