### PR TITLE
#1331: Improve error reporting (phase 1)

### DIFF
--- a/signbank/api_interface.py
+++ b/signbank/api_interface.py
@@ -187,10 +187,7 @@ def check_gloss_existence_for_uploaded_video(dataset):
                     gloss = Gloss.objects.filter(lemma__dataset=dataset, archived=False,
                                                  annotationidglosstranslation__language__language_code_3char=language3char,
                                                  annotationidglosstranslation__text__exact=filename_without_extension).first()
-                    if gloss:
-                        list_of_video_gloss_status[language3char].append((file, True, gloss))
-                    else:
-                        list_of_video_gloss_status[language3char].append((file, False, gloss))
+                    list_of_video_gloss_status[language3char].append((file, True, gloss))
 
     return list_of_video_gloss_status
 

--- a/signbank/api_interface.py
+++ b/signbank/api_interface.py
@@ -183,13 +183,11 @@ def check_gloss_existence_for_uploaded_video(dataset):
             if os.path.isdir(language_subfolder):
                 for file in os.listdir(language_subfolder):
                     video_file_path = os.path.join(goal_directory, language3char, file)
-                    format = probe_format(video_file_path)
                     (filename_without_extension, extension) = os.path.splitext(file)
                     gloss = Gloss.objects.filter(lemma__dataset=dataset, archived=False,
                                                  annotationidglosstranslation__language__language_code_3char=language3char,
                                                  annotationidglosstranslation__text__exact=filename_without_extension).first()
-                    if format.startswith('h264'):
-                        # the output of ffmpeg includes extra information following h264, so only check the prefix
+                    if gloss:
                         list_of_video_gloss_status[language3char].append((file, True, gloss))
                     else:
                         list_of_video_gloss_status[language3char].append((file, False, gloss))
@@ -250,7 +248,7 @@ def get_unzipped_video_files_json(request, datasetid):
     videos_data = dict()
     videos_data['import_videos/'+dataset.acronym] = uploaded_video_files(dataset)
 
-    return JsonResponse(videos_data)
+    return JsonResponse(videos_data, safe=False)
 
 
 @put_api_user_in_request
@@ -361,7 +359,7 @@ def upload_zipped_videos_folder_json(request, datasetid):
         status_request['filename'] = file_name
         status_request['errors'] = error_feedback
         status_request['zippedfiles'] = filenames
-        return JsonResponse(status_request)
+        return JsonResponse(status_request, safe=False)
 
     with atomic():
         unzip_video_files(dataset, goal_zipped_file, VIDEOS_TO_IMPORT_FOLDER)
@@ -370,9 +368,10 @@ def upload_zipped_videos_folder_json(request, datasetid):
 
     videos_data = dict()
     videos_data['filename'] = file_name
+    videos_data['errors'] = ""
     videos_data['unzippedvideos'] = unzipped_files
 
-    return JsonResponse(videos_data)
+    return JsonResponse(videos_data, safe=False)
 
 
 def import_video_to_gloss(request, video_file_path):
@@ -392,23 +391,25 @@ def import_video_to_gloss(request, video_file_path):
                                  annotationidglosstranslation__text__exact=filename_without_extension).first()
     if not gloss:
         errors_deleting = remove_video_file_from_import_videos(video_file_path)
+        if errors_deleting:
+            print('import_video_to_gloss: ', errors_deleting)
+        import_video_data[json_path_key]["gloss"] = ''
+        import_video_data[json_path_key]["videofile"] = filename
         import_video_data[json_path_key]["errors"] = "Gloss not found for " + filename_without_extension + ". "
+        import_video_data[json_path_key]["Video"] = ''
+        import_video_data[json_path_key]["importstatus"] = 'Failed'
         return import_video_data
-    format = probe_format(video_file_path)
-    if format.startswith('h264'):
-        # the output of ffmpeg includes extra information following h264, so only check the prefix
-        status, errors = import_video_file(request, gloss, video_file_path)
+
+    status, errors = import_video_file(request, gloss, video_file_path)
+    if status == 'Success':
         video_path = gloss.get_video_url()
-        import_video_data[json_path_key]["gloss"] = str(gloss.id)
-        import_video_data[json_path_key]["videofile"] = filename
         import_video_data[json_path_key]["Video"] = settings.URL + settings.PREFIX_URL + '/dictionary/protected_media/' + video_path
-        import_video_data[json_path_key]["status"] = status
-        import_video_data[json_path_key]["errors"] = errors
     else:
-        import_video_data[json_path_key]["gloss"] = str(gloss.id)
-        import_video_data[json_path_key]["videofile"] = filename
-        import_video_data[json_path_key]["status"] = "Wrong video format."
-        import_video_data[json_path_key]["errors"] = "Video file is not h264."
+        import_video_data[json_path_key]["Video"] = ''
+    import_video_data[json_path_key]["gloss"] = str(gloss.id)
+    import_video_data[json_path_key]["videofile"] = filename
+    import_video_data[json_path_key]["importstatus"] = status
+    import_video_data[json_path_key]["errors"] = errors
 
     return import_video_data
 

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -1078,14 +1078,16 @@ class GlossDetailView(DetailView):
 
         if dataset_of_requested_gloss not in selected_datasets:
             translated_message = _('The gloss you are trying to view is not in your selected datasets.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         if dataset_of_requested_gloss not in datasets_user_can_view:
             if self.object.inWeb:
                 return HttpResponseRedirect(reverse('dictionary:public_gloss', kwargs={'glossid': self.object.pk}))
             else:
                 translated_message = _('The gloss you are trying to view is not in a dataset you can view.')
-                return show_warning(request, translated_message, selected_datasets)
+                translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.name
+                return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         senses_consistent = consistent_senses(self.object, include_translations=True,
                                               allow_empty_language=True)
@@ -1708,7 +1710,8 @@ class GlossVideosView(DetailView):
 
         if dataset_of_requested_gloss not in selected_datasets:
             translated_message = _('The gloss you are trying to view is not in your selected datasets.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         if dataset_of_requested_gloss not in datasets_user_can_view:
             if self.object.inWeb:
@@ -1820,7 +1823,8 @@ class GlossRelationsDetailView(DetailView):
 
         if dataset_of_requested_gloss not in selected_datasets:
             translated_message = _('The gloss you are trying to view is not in your selected datasets.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         if dataset_of_requested_gloss not in datasets_user_can_view:
             if self.object.inWeb:
@@ -3169,7 +3173,8 @@ class GlossFrequencyView(DetailView):
 
         if dataset_of_requested_gloss not in selected_datasets:
             translated_message = _('The gloss you are trying to view is not in your selected datasets.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         if dataset_of_requested_gloss not in datasets_user_can_view:
             if self.object.inWeb:
@@ -5212,7 +5217,8 @@ class MorphemeDetailView(DetailView):
 
         if dataset_of_requested_morpheme not in selected_datasets:
             translated_message = _('The morpheme you are trying to view is not in your selected datasets.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         if dataset_of_requested_morpheme not in datasets_user_can_view:
             translated_message = _('The morpheme you are trying to view is not in a dataset you can view.')
@@ -6620,11 +6626,13 @@ class LemmaUpdateView(UpdateView):
 
         if dataset_of_requested_lemma not in selected_datasets:
             translated_message = _('The lemma you are trying to view is not in your selected datasets.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         if dataset_of_requested_lemma not in datasets_user_can_view:
             translated_message = _('The lemma you are trying to view is not in a dataset you can view.')
-            return show_warning(request, translated_message, selected_datasets)
+            translated_message2 = _(' It is in dataset ') + dataset_of_requested_gloss.acronym
+            return show_warning(request, translated_message + translated_message2, selected_datasets)
 
         context = self.get_context_data(object=self.object)
         return self.render_to_response(context)

--- a/signbank/zip_interface.py
+++ b/signbank/zip_interface.py
@@ -287,8 +287,9 @@ def import_video_file(request, gloss, video_file_path):
                 # make new GlossVideo object for new video
                 video = GlossVideo(gloss=gloss,
                                    version=0)
+                new_glossvideo_name =os.path.join(video_path, video_file_name)
                 with open(video_file_path, 'rb') as f:
-                    video.videofile.save(os.path.basename(video_file_path), File(f), save=True)
+                    video.videofile.save(new_glossvideo_name, File(f), save=True)
                 video.save()
                 video.make_poster_image()
                 glossvideohistory = GlossVideoHistory(action="import",


### PR DESCRIPTION
in error message feedback

- gloss not in selected datasets => reports dataset gloss is in
- import zipped video archive => does not check h264
- mport zipped video archive => same dictionary for branches in json result
- mport zipped video archive => if video file overwrite existing fails, report error and do not return video url (since not uploaded)
