### PR TITLE
File writing video path bugs avoidance

### DIFF
--- a/media/js/drag_drop_files.js
+++ b/media/js/drag_drop_files.js
@@ -269,12 +269,12 @@ if (image === true){
 
     function handleImageByButton(files) {
         removeImageUploads(false)
-        handleByButton(files, dropContainerImageTitle, ['image/jpeg'], 'img', inputImageArea, imageGallery)
+        handleByButton(files, dropContainerImageTitle, ['image/jpeg', 'image/png'], 'img', inputImageArea, imageGallery)
     }
 
     dropImageArea.addEventListener('drop', handleImageDrop, false)
     function handleImageDrop(e) {
-        handleDrop(e, ['image/jpeg'], 'image', 'img', inputImageArea, imageGallery, dropContainerImageTitle)
+        handleDrop(e, ['image/jpeg', 'image/png'], 'image', 'img', inputImageArea, imageGallery, dropContainerImageTitle)
     }
 
     function removeImageUploads(remove_file_name){

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2335,7 +2335,8 @@ class Gloss(models.Model):
                     return imagefile_path
 
     def get_image_url(self):
-        return escape_uri_path(self.get_image_path())
+        image_path = self.get_image_path()
+        return escape_uri_path(image_path) if image_path else ''
 
     def get_video_path(self):
         from signbank.video.models import GlossVideo

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2352,7 +2352,7 @@ class Gloss(models.Model):
 
     def get_video_path_prefix(self):
         try:
-            glossvideo = self.glossvideo_set.exclude(glossvideonme=True, glossvideoperspective__isnull=False).get(version=0)
+            glossvideo = self.glossvideo_set.exclude(glossvideonme__isnull=False, glossvideoperspective__isnull=False).get(version=0)
             prefix, extension = os.path.splitext(str(glossvideo))
             return prefix
         except ObjectDoesNotExist:
@@ -2371,7 +2371,7 @@ class Gloss(models.Model):
     def count_videos(self):
         """Return a count of the number of videos as indicated in the database"""
 
-        return self.glossvideo_set.exclude(glossvideonme=True, glossvideoperspective__isnull=False).count()
+        return self.glossvideo_set.exclude(glossvideonme__isnull=False, glossvideoperspective__isnull=False).count()
 
     def get_video_url(self):
         """return  the url of the video for this gloss which may be that of a homophone"""
@@ -2390,7 +2390,7 @@ class Gloss(models.Model):
 
         # Create a new GlossVideo object
         if isinstance(videofile, File) or videofile.content_type == 'django.core.files.uploadedfile.InMemoryUploadedFile':
-            video = GlossVideo(gloss=self, upload_to=get_video_file_path, glossvideonme=None)
+            video = GlossVideo(gloss=self, upload_to=get_video_file_path, glossvideonme=None, glossvideoperspective=None)
             # Backup the existing video objects stored in the database
             existing_videos = GlossVideo.objects.filter(gloss=self, glossvideonme=None, glossvideoperspective=None)
             for video_object in existing_videos:

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2327,12 +2327,10 @@ class Gloss(models.Model):
         if check_existence:
             for extension in settings.SUPPORTED_CITATION_IMAGE_EXTENSIONS:
                 imagefile_path = videofile_path_without_extension.replace("glossvideo", "glossimage") + extension
-                try:
-                    imagefile_path_exists = os.path.exists(os.path.join(settings.WRITABLE_FOLDER, imagefile_path))
-                except:
-                    imagefile_path_exists = False
+                imagefile_path_exists = os.path.exists(os.path.join(settings.WRITABLE_FOLDER, imagefile_path))
                 if check_existence and imagefile_path_exists:
                     return imagefile_path
+        return ""
 
     def get_image_url(self):
         image_path = self.get_image_path()

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2348,14 +2348,6 @@ class Gloss(models.Model):
             glossvideos = GlossVideo.objects.filter(gloss=self, glossvideonme=None, glossvideoperspective=None).filter(version=0)
             return str(glossvideos.first().videofile)
 
-    def get_video_path_prefix(self):
-        try:
-            glossvideo = self.glossvideo_set.exclude(glossvideonme__isnull=False, glossvideoperspective__isnull=False).get(version=0)
-            prefix, extension = os.path.splitext(str(glossvideo))
-            return prefix
-        except ObjectDoesNotExist:
-            return ''
-
     def get_video(self):
         """Return the video object for this gloss or None if no video available"""
 
@@ -2366,16 +2358,10 @@ class Gloss(models.Model):
         else:
             return ''
 
-    def count_videos(self):
-        """Return a count of the number of videos as indicated in the database"""
-
-        return self.glossvideo_set.exclude(glossvideonme__isnull=False, glossvideoperspective__isnull=False).count()
-
     def get_video_url(self):
         """return  the url of the video for this gloss which may be that of a homophone"""
-        video_url_or_empty_string = escape_uri_path(self.get_video())
-
-        return video_url_or_empty_string
+        video_path = self.get_video()
+        return escape_uri_path(video_path) if video_path else ''
 
     def has_video(self):
         """Test to see if the video for this sign is present"""

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -1038,6 +1038,7 @@ textarea:focus {
                     {% csrf_token %}
                         <input type='hidden' name='redirect' value='{{PREFIX_URL}}/dictionary/gloss/{{gloss.pk}}/'>
                         <input type='hidden' name='object_type' value='gloss_perspectivevideo'>
+                        <input type='hidden' name='object_id' value='{{gloss.pk}}'>
                         <input type='hidden' name='recorded' value='False'>
                         <table>
                           <tr>
@@ -1048,7 +1049,6 @@ textarea:focus {
                           </tr>
                           <tr>
                             <td id="perspvideo-buttons">
-                                <input type='hidden' name='object_id' value='{{gloss.pk}}'>
                                 <input class='btn btn-primary' type='submit' value='Upload' />
                             </td>
                           </tr>
@@ -1676,6 +1676,7 @@ textarea:focus {
                     {% csrf_token %}
                         <input type='hidden' name='redirect' value='{{PREFIX_URL}}/dictionary/gloss/{{gloss.pk}}/'>
                         <input type='hidden' name='object_type' value='gloss_nmevideo'>
+                        <input type='hidden' name='object_id' value='{{gloss.pk}}'>
                         <input type='hidden' name='recorded' value='False'>
                         <table>
                           <tr>
@@ -1683,7 +1684,6 @@ textarea:focus {
                           </tr>
                           <tr>
                             <td id="nmevideo-buttons">
-                                <input type='hidden' name='object_id' value='{{gloss.pk}}'>
                                 <input class='btn btn-primary' type='submit' value='Upload' />
                             </td>
                           </tr>

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -787,11 +787,11 @@ textarea:focus {
      <!-- {{gloss.get_video}} -->
 
         <div id="player" style="">
-            <video id='videoplayer_middle' src="{{protected_media_url}}{{gloss.get_video_url}}"
+            <video id='videoplayer_middle' src="{{protected_media_url}}{{gloss.get_video_url}}?v={% now 'YmdHis' %}"
                    playsinline type="video/mp4" autoplay muted></video>
 
         {% for perspvideo in gloss.get_perspective_videos %}
-            <video id='videoplayer_{{perspvideo.perspective}}' src="{{protected_media_url}}{{perspvideo.get_video_path}}"
+            <video id='videoplayer_{{perspvideo.perspective}}' src="{{protected_media_url}}{{perspvideo.get_video_path}}?v={% now 'YmdHis' %}"
                    playsinline type="video/mp4" autoplay muted></video>
         {% endfor %}
         </div>
@@ -1013,7 +1013,7 @@ textarea:focus {
                                    <tr>
                                        <td colspan="2">
                                            <div id="perspectiveplayer">
-                                            <video id='videoperspplayer' src="{{protected_media_url}}{{perspvideo.get_video_path}}"
+                                            <video id='videoperspplayer' src="{{protected_media_url}}{{perspvideo.get_video_path}}?v={% now 'YmdHis' %}"
                                                    style="height:200px;width:auto;" controls muted></video>
                                            </div>
                                         </td>
@@ -1467,7 +1467,7 @@ textarea:focus {
                                                     <div id="videocontainer_{{examplesentence.id}}"  style="width:100%">
                                                         {% if examplesentence.has_video %}
                                                             <div id="player">
-                                                                <video id='videoplayer' src="{{protected_media_url}}/{{examplesentence.get_video_path}}" controls type="video/mp4" muted></video>
+                                                                <video id='videoplayer' src="{{protected_media_url}}/{{examplesentence.get_video_path}}?v={% now 'YmdHis' %}" controls type="video/mp4" muted></video>
                                                                 </div>
                                                             <div id="replay"></div>
                                                         {% else %}
@@ -1635,7 +1635,7 @@ textarea:focus {
                                    <tr>
                                        <td colspan="2">
                                            <div id="nmeplayer">
-                                            <video id='videonmeplayer' src="{{protected_media_url}}{{videonme.get_video_path}}"
+                                            <video id='videonmeplayer' src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
                                                    style="height:200px;width:auto;" controls muted></video>
                                            </div>
                                         </td>
@@ -2581,7 +2581,7 @@ textarea:focus {
                                 <style>.highlight {background-color: rgb(255, 149, 63);}</style>
 
                                 <video id="myVideo_{{forloop.counter}}" controls>
-                                    <source src="{{protected_media_url}}/{{annotated_sentence.annotatedvideo.videofile}}" type="video/mp4">
+                                    <source src="{{protected_media_url}}/{{annotated_sentence.annotatedvideo.videofile}}?v={% now 'YmdHis' %}" type="video/mp4">
                                 </video>                               
                             
                                 <br><br><i>{% trans "Glosses" %}</i><br>
@@ -2629,7 +2629,7 @@ textarea:focus {
                                         <i>{% trans "Source" %}</i><br>
                                         {{ annotated_sentence.annotatedvideo.source.source }}
                                         {% if annotated_sentence.annotatedvideo.source.url %}
-                                            , <a href="{{protected_media_url}}/{{annotated_sentence.annotatedvideo.source.get_absolute_url}}">{{ annotated_sentence.annotatedvideo.source.url }}</a>
+                                            , <a href="{{protected_media_url}}/{{annotated_sentence.annotatedvideo.source.get_absolute_url}}?v={% now 'YmdHis' %}">{{ annotated_sentence.annotatedvideo.source.url }}</a>
                                         {% endif %}
                                     {% endif %}
                                 </p>

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -1206,7 +1206,7 @@ def update_nmevideo(user, gloss, field, value):
         if new_offset in existing_offsets or new_offset == nmevideo.offset:
             return HttpResponse(value, {'content-type': 'text/plain'})
         nmevideo.offset = new_offset
-        nmevideo.save(update_fields=['path'])
+        nmevideo.save(update_fields=['offset'])
     elif field.startswith('nmevideo_delete_'):
         nmevideoid = field[len('nmevideo_delete_'):]
         nmevideo = GlossVideoNME.objects.get(id=int(nmevideoid))

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -1206,7 +1206,7 @@ def update_nmevideo(user, gloss, field, value):
         if new_offset in existing_offsets or new_offset == nmevideo.offset:
             return HttpResponse(value, {'content-type': 'text/plain'})
         nmevideo.offset = new_offset
-        nmevideo.save()
+        nmevideo.save(update_fields=['path'])
     elif field.startswith('nmevideo_delete_'):
         nmevideoid = field[len('nmevideo_delete_'):]
         nmevideo = GlossVideoNME.objects.get(id=int(nmevideoid))

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -1830,10 +1830,7 @@ def add_image(request):
             )
             goal_location_str = os.path.join(goal_path, gloss.idgloss + '-' + str(gloss.pk) + extension)
 
-            try:
-                exists = os.path.exists(goal_path)
-            except:
-                exists = False
+            exists = os.path.exists(goal_path)
 
             #First make the dir if needed
             if not exists:
@@ -1888,7 +1885,7 @@ def delete_image(request, pk):
     image_path = gloss.get_image_path()
     if not image_path:
         return redirect(url)
-    full_image_path = settings.WRITABLE_FOLDER + os.sep + image_path
+    full_image_path = settings.WRITABLE_FOLDER + image_path
     default_annotationidglosstranslation = get_default_annotationidglosstranslation(gloss)
     if os.path.exists(full_image_path.encode('utf-8')):
         os.remove(full_image_path.encode('utf-8'))

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -1874,30 +1874,34 @@ def add_image(request):
 
 def delete_image(request, pk):
 
-    if request.method == "POST":
-
-        # deal with any existing video for this sign
-        gloss = get_object_or_404(Gloss, pk=pk, archived=False)
-        image_path = gloss.get_image_path()
-        full_image_path = settings.WRITABLE_FOLDER + os.sep + image_path
-        default_annotationidglosstranslation = get_default_annotationidglosstranslation(gloss)
-        if os.path.exists(full_image_path.encode('utf-8')):
-            os.remove(full_image_path.encode('utf-8'))
-        else:
-            print('delete_image: wrong type for image path, file does not exist')
-        deleted_image = DeletedGlossOrMedia()
-        deleted_image.item_type = 'image'
-        deleted_image.idgloss = gloss.idgloss
-        deleted_image.annotation_idgloss = default_annotationidglosstranslation
-        deleted_image.old_pk = gloss.pk
-        deleted_image.filename = image_path
-        deleted_image.save()
-
     # return to referer
     if 'HTTP_REFERER' in request.META:
         url = request.META['HTTP_REFERER']
     else:
         url = '/'
+
+    if not request.method == "POST":
+        return redirect(url)
+
+    # deal with any existing video for this sign
+    gloss = get_object_or_404(Gloss, pk=pk, archived=False)
+    image_path = gloss.get_image_path()
+    if not image_path:
+        return redirect(url)
+    full_image_path = settings.WRITABLE_FOLDER + os.sep + image_path
+    default_annotationidglosstranslation = get_default_annotationidglosstranslation(gloss)
+    if os.path.exists(full_image_path.encode('utf-8')):
+        os.remove(full_image_path.encode('utf-8'))
+    else:
+        print('delete_image: wrong type for image path, file does not exist')
+    deleted_image = DeletedGlossOrMedia()
+    deleted_image.item_type = 'image'
+    deleted_image.idgloss = gloss.idgloss
+    deleted_image.annotation_idgloss = default_annotationidglosstranslation
+    deleted_image.old_pk = gloss.pk
+    deleted_image.filename = image_path
+    deleted_image.save()
+
     return redirect(url)
 
 

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -902,7 +902,7 @@ def gloss_nmevideo_do_changes(user, gloss, nmevideo, changes, language_code, cre
         elif field == 'offset':
             # this changes the filename and moves the file
             nmevideo.offset = int(new_value)
-            nmevideo.save()
+            nmevideo.save(update_fields=['path'])
 
     operation = 'nmevideo_create' if create else 'nmevideo_update'
     filename = os.path.basename(nmevideo.videofile.name)

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -902,7 +902,7 @@ def gloss_nmevideo_do_changes(user, gloss, nmevideo, changes, language_code, cre
         elif field == 'offset':
             # this changes the filename and moves the file
             nmevideo.offset = int(new_value)
-            nmevideo.save(update_fields=['path'])
+            nmevideo.save(update_fields=['offset'])
 
     operation = 'nmevideo_create' if create else 'nmevideo_update'
     filename = os.path.basename(nmevideo.videofile.name)

--- a/signbank/video/admin.py
+++ b/signbank/video/admin.py
@@ -91,7 +91,7 @@ class GlossVideoExistenceFilter(admin.SimpleListFilter):
 
 class GlossVideoAdmin(admin.ModelAdmin):
 
-    list_display = ['id', 'gloss', 'video_file', 'file_timestamp', 'file_group', 'permissions', 'file_size', 'version']
+    list_display = ['id', 'gloss', 'video_file', 'perspective', 'NME', 'file_timestamp', 'file_group', 'permissions', 'file_size', 'version']
     list_filter = (GlossVideoDatasetFilter, GlossVideoFileSystemGroupFilter, GlossVideoExistenceFilter)
 
     search_fields = ['^gloss__annotationidglosstranslation__text']
@@ -104,6 +104,16 @@ class GlossVideoAdmin(admin.ModelAdmin):
         video_file_full_path = os.path.join(WRITABLE_FOLDER, str(obj.videofile))
 
         return video_file_full_path
+
+    def perspective(self, obj=None):
+        if obj is None:
+            return ""
+        return obj.is_glossvideoperspective() is True
+
+    def NME(self, obj=None):
+        if obj is None:
+            return ""
+        return obj.is_glossvideonme() is True
 
     def file_timestamp(self, obj=None):
         # if the file exists, this will display its timestamp in the list view

--- a/signbank/video/forms.py
+++ b/signbank/video/forms.py
@@ -21,7 +21,7 @@ PERSPECTIVE_CHOICES = (('left', 'Left'),
 
 
 class VideoUploadForObjectForm(forms.Form):
-    """Form for video upload for a particular example sentence"""
+    """Form for video upload for all video types"""
     
     videofile = forms.FileField(label="Upload Video", widget=forms.FileInput(attrs={'accept':'video/mp4, video/quicktime'}))
     object_id = forms.CharField(widget=forms.HiddenInput)

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -821,7 +821,7 @@ class GlossVideo(models.Model):
         Calculates the new path, moves the video file to the new path and updates the videofile field
         :return: 
         """
-        old_path = str(str(self.videofile))
+        old_path = str(self.videofile)
         new_path = get_video_file_path(self, old_path, version=self.version)
         if old_path != new_path:
             if move_files_on_disk:
@@ -918,7 +918,6 @@ class GlossVideoNME(GlossVideo):
             os.remove(oldloc)
 
     def save(self, *args, **kwargs):
-        self.ensure_mp4()
         super(GlossVideoNME, self).save(*args, **kwargs)
 
     def move_video(self, move_files_on_disk=True):

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -1177,10 +1177,14 @@ def delete_files(sender, instance, **kwargs):
     if settings.DEBUG_VIDEOS:
         print('delete_files pre_delete: ', str(instance))
         print('delete_files settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE: ', settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE)
-    if settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE:
-        # default.py has this set to false so primary gloss video files are not deleted
-        instance.delete_files()
-    elif hasattr(instance, 'glossvideonme'):
+    if hasattr(instance, 'glossvideonme'):
+        # before deleting a GlossVideoNME object, delete the files
         instance.delete_files()
     elif hasattr(instance, 'glossvideoperspective'):
+        # before deleting a GlossVideoPerspective object, delete the files
+        instance.delete_files()
+    elif settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE:
+        # before a GlossVideo object, only delete the files if the setting is True
+        # default.py has this set to false so primary gloss video files are (never) deleted
+        # check whether this conflicts with reversion. If the file is not deleted, the object cannot be deleted
         instance.delete_files()

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -1135,6 +1135,9 @@ def process_nmevideo_changes(sender, instance, update_fields=[], **kwargs):
     :param kwargs:
     :return:
     """
+    if settings.DEBUG_VIDEOS:
+        move_videos = not update_fields or 'offset' not in update_fields
+        print('process_nmevideo_changes move videos: ', str(instance), move_videos)
     if not update_fields or 'offset' not in update_fields:
         return
     glossvideo = instance
@@ -1152,7 +1155,7 @@ def process_perspectivevideo_changes(sender, instance, update_fields=[], **kwarg
     :return:
     """
     if settings.DEBUG_VIDEOS:
-        move_videos = update_fields
+        move_videos = not update_fields
         print('process_perspectivevideo_changes move videos: ', str(instance), move_videos)
     if not update_fields:
         return

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -1173,6 +1173,7 @@ def delete_files(sender, instance, **kwargs):
     """
     if settings.DEBUG_VIDEOS:
         print('delete_files pre_delete: ', str(instance))
+        print('delete_files settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE: ', settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE)
     if settings.DELETE_FILES_ON_GLOSSVIDEO_DELETE:
         # default.py has this set to false so primary gloss video files are not deleted
         instance.delete_files()

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -1111,7 +1111,7 @@ def process_gloss_changes(sender, instance, update_fields=[], **kwargs):
     :param kwargs: 
     :return: 
     """
-    if not update_fields or 'path' not in update_fields:
+    if not update_fields:
         return
     gloss = instance
     glossvideos = GlossVideo.objects.filter(gloss=gloss, glossvideonme=None, glossvideoperspective=None)
@@ -1135,7 +1135,7 @@ def process_nmevideo_changes(sender, instance, update_fields=[], **kwargs):
     :param kwargs:
     :return:
     """
-    if not update_fields or 'path' not in update_fields:
+    if not update_fields or 'offset' not in update_fields:
         return
     glossvideo = instance
     glossvideo.move_video(move_files_on_disk=True)
@@ -1152,9 +1152,9 @@ def process_perspectivevideo_changes(sender, instance, update_fields=[], **kwarg
     :return:
     """
     if settings.DEBUG_VIDEOS:
-        move_videos = update_fields or 'path' in update_fields
+        move_videos = update_fields
         print('process_perspectivevideo_changes move videos: ', str(instance), move_videos)
-    if not update_fields or 'path' not in update_fields:
+    if not update_fields:
         return
     glossvideo = instance
     glossvideo.move_video(move_files_on_disk=True)

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -611,7 +611,7 @@ class GlossVideo(models.Model):
         super().__init__(*args, **kwargs)
 
     def save(self, *args, **kwargs):
-        self.ensure_mp4()
+        # self.ensure_mp4()
         super(GlossVideo, self).save(*args, **kwargs)
 
     def process(self):

--- a/signbank/video/urls.py
+++ b/signbank/video/urls.py
@@ -7,7 +7,7 @@ import signbank.video.views
 urlpatterns = [
     re_path(r'^video/(?P<videoid>\d+)$', signbank.video.views.video),
     re_path(r'^upload/', signbank.video.views.addvideo),
-    re_path(r'^delete/(?P<videoid>\d+)$', signbank.video.views.deletevideo),
+    re_path(r'^delete/(?P<glossid>\d+)$', signbank.video.views.deletevideo),
     re_path(r'^deletesentencevideo/(?P<videoid>\d+)$', signbank.video.views.deletesentencevideo),
     re_path(r'^process_eaffile/', signbank.video.views.process_eaffile, name='process_eaffile'),
     re_path(r'^create_still_images/', permission_required('dictionary.change_gloss')(signbank.video.views.create_still_images))

--- a/signbank/video/views.py
+++ b/signbank/video/views.py
@@ -52,12 +52,10 @@ def addvideo(request):
                 if not gloss:
                     redirect(redirect_url)
                 perspective = form.cleaned_data['perspective']
-                try:
-                    gloss.add_perspective_video(request.user, vfile, perspective, recorded)
-                except ValidationError as e:
-                    feedback_message = getattr(e, 'message', repr(e))
-                    messages.add_message(request, messages.ERROR, feedback_message)
-                    return redirect(redirect_url)
+                stringpersp = str(perspective)
+                perspvideo = gloss.add_perspective_video(request.user, vfile, stringpersp, recorded)
+                if settings.DEBUG_VIDEOS:
+                    print('Perspective video created: ', str(perspvideo))
             elif object_type == 'gloss_nmevideo':
                 gloss = Gloss.objects.filter(id=object_id).first()
                 if not gloss:
@@ -97,7 +95,7 @@ def addvideo(request):
                 url = form.cleaned_data['url']
                 annotated_video = annotated_sentence.add_video(request.user, vfile, eaf_file, source, url)
                 
-                if annotated_video == None:
+                if annotated_video is None:
                     messages.add_message(request, messages.ERROR, _('Annotated sentence upload went wrong. Please try again.'))
                     annotated_sentence.delete()
                 else:
@@ -272,13 +270,6 @@ def deletevideo(request, glossid):
     deleted_video.old_pk = gloss.pk
     deleted_video.filename = gloss.get_video_path()
     deleted_video.save()
-
-    try:
-        video = gloss.glossvideo_set.exclude(glossvideonme__isnull=False, glossvideoperspective__isnull=False).get(version=0)
-        # video.make_small_video()
-        video.make_poster_image()
-    except ObjectDoesNotExist:
-        pass
 
     return redirect(url)
 


### PR DESCRIPTION
This fixes some bugs going on here and there. Discovered during testing.

This branch cleans up some messy code and adds lots of log messages (prefaced by settings check)

Motivated by #1354, #1358

Added print logs of video paths when DEBUG_VIDEOS is True

Some extra checks/conversions/explicit making of implicit parameters

OTHER STUFF TO CHECK (subsequent branch)

- Add checks that there are not multiple GlossVideo objects if a file has not been deleted or moved 
- (because of "pass" operations in except at OS level a file may not have been moved/deleted and an object may not have been deleted)
- The control flow is difficult to follow because of code sharing and signals from saves in other models.
- Parameter `upload_to` may be frozen when the object is created. This used to just be '`glossvideo`' (this could be a problem for very old objects) (Informally, the code attempts to "move" old videos based on where they used to be.)