### PR TITLE
Only add senses to ecv descriptions, not phonology #1325

### DIFF
--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -204,9 +204,9 @@ ECV_FILE = 'myecv.ecv'
 
 #What do you want to include in the ECV file?
 ECV_SETTINGS = {
-    'include_phonology_and_frequencies': False,
+    'include_phonology_and_frequencies': True,
 
-    'description_fields' : [],
+    'description_fields' : ['handedness', 'tokNo'],
 
     # The order of languages matters as the first will
     # be treated as default by ELAN

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -204,9 +204,9 @@ ECV_FILE = 'myecv.ecv'
 
 #What do you want to include in the ECV file?
 ECV_SETTINGS = {
-    'include_phonology_and_frequencies': True,
+    'include_phonology_and_frequencies': False,
 
-    'description_fields' : ['handedness', 'tokNo'],
+    'description_fields' : [],
 
     # The order of languages matters as the first will
     # be treated as default by ELAN

--- a/signbank/settings/server_specific/global_sb_new_aj.py
+++ b/signbank/settings/server_specific/global_sb_new_aj.py
@@ -31,10 +31,9 @@ MODELTRANSLATION_LANGUAGES = ['en','nl','zh-hans','ar','he']
 
 ECV_FILE = ECV_FOLDER+'ngt.ecv'
 ECV_SETTINGS = {
-    'include_phonology_and_frequencies': True,
+    'include_phonology_and_frequencies': False,
 
-    'description_fields': ['handedness', 'domhndsh', 'subhndsh', 'handCh', 'locprim', 'relOriMov', 'movDir', 'movSh',
-                           'tokNo', 'tokNoSgnr'],
+    'description_fields': [],
 
     # The order of languages matters as the first will
     # be treated as default by ELAN

--- a/signbank/tools.py
+++ b/signbank/tools.py
@@ -1993,7 +1993,7 @@ def get_ecv_description_for_gloss(gloss, lang, include_phonology_and_frequencies
             else:
                 desc = desc + ', ' + value
 
-    if desc:
+    if desc and include_phonology_and_frequencies:
         desc += ", "
 
     lang = Language.objects.get(language_code_2char=lang)


### PR DESCRIPTION
@susanodd @Woseseltops @vanlummelhuizen question: MPI want to only have senses in the ECV gloss descriptions, not phonology or other information. Would this be ok to put that in the default settings? Does anyone else use these ECV files?