### PR TITLE
#1356: Patch to prevent 7-char sequence and missing objects

### DIFF
--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2328,40 +2328,41 @@ class Gloss(models.Model):
         image_path = self.get_image_path()
         return escape_uri_path(image_path) if image_path else ''
 
-    def get_video_path(self):
-        from signbank.video.models import GlossVideo, get_gloss_video_filepath
-        try:
-            glossvideo = GlossVideo.objects.filter(gloss=self, glossvideonme=None, glossvideoperspective=None).get(version=0)
-            return str(glossvideo.videofile)
-        except ObjectDoesNotExist:
-            relative_path = get_gloss_video_filepath(self)
-            if relative_path:
-                if settings.DEBUG_VIDEOS:
-                    print('get_video_path: already existing file without GlossVideo object found: ', relative_path)
-                # there is a video file but no GlossVideo object
-                video = GlossVideo(gloss=self, glossvideonme=None, glossvideoperspective=None, version=0)
-                video.videofile.name = relative_path
-                video.save()
-                video.make_poster_image()
-                if settings.DEBUG_VIDEOS:
-                    print('get_video_path: GlossVideo object created for already existing file: ', relative_path)
-                return relative_path
-            else:
-                return ''
-        except MultipleObjectsReturned:
-            # Just return the first
-            glossvideos = GlossVideo.objects.filter(gloss=self, glossvideonme=None, glossvideoperspective=None).filter(version=0)
+    def get_video_path(self, check_file_on_disk=True):
+        from signbank.video.models import GlossVideo, get_gloss_path_to_video_file_on_disk
+        glossvideos = GlossVideo.objects.filter(gloss=self, glossvideonme=None, glossvideoperspective=None, version=0)
+        if glossvideos.count() > 0:
+            # in the case of multiple version 0 objects the first is returned
             return str(glossvideos.first().videofile)
+        if not check_file_on_disk:
+            return ""
+        relative_path = get_gloss_path_to_video_file_on_disk(self)
+        if not relative_path:
+            # there is no video file and no GlossVideo object with version 0 for this gloss
+            return ''
+        # a video with the correct name was found
+        if settings.DEBUG_VIDEOS:
+            print('get_video_path: already existing file without GlossVideo object found: ', relative_path)
+        # there is a video file but no GlossVideo object
+        video = GlossVideo(gloss=self, glossvideonme=None, glossvideoperspective=None, version=0)
+        video.videofile.name = relative_path
+        video.save()
+        video.make_poster_image()
+        if settings.DEBUG_VIDEOS:
+            print('get_video_path: GlossVideo object created for already existing file: ', relative_path)
+        return relative_path
+
 
     def get_video(self):
         """Return the video object for this gloss or None if no video available"""
 
         video_path = self.get_video_path()
+        if not video_path:
+            return ''
         filepath = os.path.join(settings.WRITABLE_FOLDER, video_path)
         if os.path.exists(filepath.encode('utf-8')):
             return video_path
-        else:
-            return ''
+        return ''
 
     def get_video_url(self):
         """return  the url of the video for this gloss which may be that of a homophone"""

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2342,6 +2342,7 @@ class Gloss(models.Model):
                 video = GlossVideo(gloss=self, glossvideonme=None, glossvideoperspective=None, version=0)
                 video.videofile.name = relative_path
                 video.save()
+                video.make_poster_image()
                 if settings.DEBUG_VIDEOS:
                     print('get_video_path: GlossVideo object created for already existing file: ', relative_path)
                 return relative_path

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2376,7 +2376,7 @@ class Gloss(models.Model):
 
     def add_video(self, user, videofile, recorded):
         # Preventing circular import
-        from signbank.video.models import GlossVideo, GlossVideoHistory, get_video_file_path, get_gloss_video_filepath
+        from signbank.video.models import GlossVideo, GlossVideoHistory, get_video_file_path, get_gloss_path_to_video_file_on_disk
 
         # Create a new GlossVideo object
         if isinstance(videofile, File) or videofile.content_type == 'django.core.files.uploadedfile.InMemoryUploadedFile':
@@ -2386,7 +2386,7 @@ class Gloss(models.Model):
             for video_object in existing_videos:
                 video_object.reversion(revert=False)
 
-            already_existing_relative_target_path = get_gloss_video_filepath(self)
+            already_existing_relative_target_path = get_gloss_path_to_video_file_on_disk(self)
             if already_existing_relative_target_path:
                 # a video file without a GlossVideo object already exists, remove the file
                 try:

--- a/signbank/dictionary/templates/dictionary/gloss_row.html
+++ b/signbank/dictionary/templates/dictionary/gloss_row.html
@@ -12,7 +12,7 @@
     {% endif %}
 
 
-    <td class="field_hasvideo">{%if focus_gloss.get_image_path %}
+    <td class="field_hasvideo">{% if focus_gloss.get_image_path or focus_gloss.has_video %}
     {% url 'dictionary:protected_media' '' as protected_media_url %}
 
       <div class="thumbnail_container">

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -79,7 +79,7 @@ class ExampleVideoHistory(models.Model):
     def __str__(self):
 
         # Basic feedback from one History item: gloss-action-date
-        name = str(self.examplesentence.id) + ': ' + str(self.action) + ', (' + str(self.datestamp) + ')'
+        name = f"{self.examplesentence.id}: {self.action}, ({self.datestamp})"
         return name
 
     class Meta:
@@ -108,7 +108,7 @@ class GlossVideoHistory(models.Model):
     def __str__(self):
 
         # Basic feedback from one History item: gloss-action-date
-        name = self.gloss.idgloss + ': ' + self.action + ', (' + str(self.datestamp) + ')'
+        name = f"{self.gloss.idgloss}: {self.action}, ({self.datestamp})"
         return name
 
     class Meta:
@@ -131,7 +131,7 @@ class GlossVideoHistory(models.Model):
 # * Changes to the lemmaidglosstranslations: process_lemmaidglosstranslation_changes(...)
 
 
-def get_gloss_video_filepath(gloss):
+def get_gloss_path_to_video_file_on_disk(gloss):
     idgloss = gloss.idgloss
     two_letter_dir = get_two_letter_dir(idgloss)
     dataset_dir = gloss.lemma.dataset.acronym

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -79,8 +79,8 @@ class ExampleVideoHistory(models.Model):
     def __str__(self):
 
         # Basic feedback from one History item: gloss-action-date
-        name = str(self.examplesentence.id) + ': ' + self.action + ', (' + str(self.datestamp) + ')'
-        return str(name.encode('ascii', errors='replace'))
+        name = str(self.examplesentence.id) + ': ' + str(self.action) + ', (' + str(self.datestamp) + ')'
+        return name
 
     class Meta:
         ordering = ['datestamp']
@@ -109,7 +109,7 @@ class GlossVideoHistory(models.Model):
 
         # Basic feedback from one History item: gloss-action-date
         name = self.gloss.idgloss + ': ' + self.action + ', (' + str(self.datestamp) + ')'
-        return str(name.encode('ascii', errors='replace'))
+        return name
 
     class Meta:
         ordering = ['datestamp']
@@ -129,6 +129,19 @@ class GlossVideoHistory(models.Model):
 # * The video path: get_video_file_path(...)
 # * Changes to the dataset, acronym of default language: process_dataset_changes(...)
 # * Changes to the lemmaidglosstranslations: process_lemmaidglosstranslation_changes(...)
+
+
+def get_gloss_video_filepath(gloss):
+    idgloss = gloss.idgloss
+    two_letter_dir = get_two_letter_dir(idgloss)
+    dataset_dir = gloss.lemma.dataset.acronym
+    filename = idgloss + '-' + str(gloss.id) + '.mp4'
+    relative_path = os.path.join(GLOSS_VIDEO_DIRECTORY, dataset_dir, two_letter_dir, filename)
+    file_system_path = os.path.join(WRITABLE_FOLDER, GLOSS_VIDEO_DIRECTORY, dataset_dir, two_letter_dir, filename)
+    if os.path.exists(file_system_path):
+        return relative_path
+    else:
+        return ""
 
 
 def get_video_file_path(instance, filename, nmevideo=False, perspective='', offset=1, version=0):


### PR DESCRIPTION
Remove an existing gloss video file that does not have an object; lazy creation of gloss video object if file does not have it.

Solution thought up by @Jetske and @susanodd when looking at the video storage.

This patch includes two parts.

- if a Gloss Detail page is visited and there is a video file but there is no GlossVideo object pointing to it, an object is created for it.

- if a new video is being uploaded but there already exists a file with this name, but no GlossVideo object, the file is deleted so that the new file can have a correct path, without the 7-char code added to it.

Based on recent video creations, this is happening, so this is necessary.

If you want to try this out on your local signbank, then 

- set DEBUG_VIDEOS to True.
- Then for a particular gloss, remove its videos in Gloss Edit.
- Then on the file system, copy a video file to the "normal" location for this gloss's video file. (I.e., put back the video file, but on the file system, not using the Form upload.
- Then try either "renewing the page" (the new GlossVideo object will be created and you will see messages in the venv log.
- Or immediately upload a new video without reloading the page. Then the "add video" will erase the file before creating a new object. This prevents a weird file name from being created.

TO DO (different branch)
Part 3, if there already is a file with the weird filename, the object and the file both need to be fixed.
This has recently happened with NOORD-KOREA-B. It already had a video, but no GlossVideo object. So the new video has a 7-char sequence.

We don't know how it happens that a GlossVideo object is not created. Perhaps the transaction does not complete or there is a file system error, or the database is locked.