### PR TITLE
Added left and right camera perspective options

### DIFF
--- a/docs/signbank-api.json
+++ b/docs/signbank-api.json
@@ -748,16 +748,27 @@
                 "type": "object",
                 "properties": 
                 {
-                  "file": 
+                  "center": 
                   {
                     "type": "string",
                     "format": "binary", 
-                    "description": "The video file to upload"
+                    "description": "The video file to upload, default/mid camera perspective/"
+                  },
+                  "left": 
+                  {
+                    "type": "string",
+                    "format": "binary", 
+                    "description": "The video file to upload, left camera perspective."
+                  },
+                  "right": 
+                  {
+                    "type": "string",
+                    "format": "binary", 
+                    "description": "The video file to upload, right camera perspective."
                   }
                 },
                 "required": 
                 [
-                  "file"
                 ]
               }
             }


### PR DESCRIPTION
Extending the new video upload end point with perspective videos, as requested in #1333 . You call it like this

```python
url = 'http://54.93.111.92/dictionary/api_update_gloss/14/video'

# The path to your video file
left_video_file_path = 'left_video.mp4'
right_video_file_path = 'right_video.mp4'

# Auth
headers = {'Authorization': f'Bearer {BEARER_TOKEN}'}

# Open the video file in binary mode and send it in a POST request
files = {'left': open(left_video_file_path, 'rb'), 
         'right': open(right_video_file_path, 'rb')}
response = requests.post(url, files=files, headers=headers)
```