### PR TITLE
#1400: Unlimited retrieval and 500 glosses per page on Split Senses

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -6656,7 +6656,7 @@ class KeywordListView(ListView):
 
     model = Gloss
     template_name = 'dictionary/admin_batch_edit_senses.html'
-    paginate_by = 25
+    paginate_by = 500
     search_type = 'sign'
     query_parameters = dict()
 
@@ -6738,11 +6738,6 @@ class KeywordListView(ListView):
         # exclude morphemes
         if not glosses_of_datasets:
             feedback_message = _('No glosses found.')
-            messages.add_message(self.request, messages.ERROR, feedback_message)
-            return []
-
-        if glosses_of_datasets.count() > 100:
-            feedback_message = _('Please refine your query to retrieve fewer than 100 glosses to use this functionality.')
             messages.add_message(self.request, messages.ERROR, feedback_message)
             return []
 

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -6657,7 +6657,7 @@ class KeywordListView(ListView):
 
     model = Gloss
     template_name = 'dictionary/admin_batch_edit_senses.html'
-    paginate_by = 500
+    paginate_by = 100
     search_type = 'sign'
     query_parameters = dict()
 


### PR DESCRIPTION
This change is trivial.


- @Woseseltops this is on signbank-susan now.

- You do a Search on the dataset (NGT since that's what we're testing)

- Then go to `Analysis -> Split Up Senses`  (it shows them for the most recent query results)

- The "browser debug window" has trouble showing all the nodes!!!!

- But it does indeed work!!!

- But I suspect it might not be showing all the results????
- In the python code, I set it to display 500 results per page.
- But there are only 2 pages shown.

- Can you experiment with this yourself to see what the browser is doing? I'm using Firefox so I can't test it for Windows

- I also don't know whether Firefox is just throwing stuff away because it's too much???