### PR TITLE
#1400: 500 results split up senses, keep same pagination

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -6742,8 +6742,8 @@ class KeywordListView(ListView):
             messages.add_message(self.request, messages.ERROR, feedback_message)
             return []
 
-        if glosses_of_datasets.count() > 100:
-            feedback_message = _('Please refine your query to retrieve fewer than 100 glosses to use this functionality.')
+        if glosses_of_datasets.count() > 500:
+            feedback_message = _('Please refine your query to retrieve fewer than 500 glosses to use this functionality.')
             messages.add_message(self.request, messages.ERROR, feedback_message)
             return []
 


### PR DESCRIPTION
to prevent browser choking on too many nodes. Firefox truncates results if more than circa 1200

This command is safe and can be deployed without reviews

The translation file will need to be updated after deployment. Other translations have also fallen behind.