### PR TITLE
#1436: Set DEBUG to False in base.py settings

### DIFF
--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -5,7 +5,7 @@ from django.utils.encoding import smart_str
 from signbank.settings.server_specific import *
 from datetime import datetime
 
-DEBUG = True
+DEBUG = False
 
 PROJECT_DIR = os.path.dirname(BASE_DIR)
 


### PR DESCRIPTION
This prevents screen dumps of data structures if a command fails