### PR TITLE
Added citation image API endpoint

### DIFF
--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -262,6 +262,7 @@ urlpatterns = [
     re_path(r'^gloss/(?P<gloss_pk>\d+)/history', signbank.dictionary.views.gloss_revision_history, name='gloss_revision_history'),
     re_path(r'^gloss/(?P<pk>\d+)/glossvideos', GlossVideosView.as_view(), name='gloss_videos'),
     re_path(r'^api_update_gloss/(?P<gloss_id>\d+)/video', signbank.api_interface.api_add_video, name='api_add_video'),
+    re_path(r'^api_update_gloss/(?P<gloss_id>\d+)/image', signbank.api_interface.api_add_image, name='api_add_image'),  
     re_path(r'^gloss/(?P<pk>\d+)', GlossDetailView.as_view(), {'public': False}, name='admin_gloss_view'),
     re_path(r'^gloss_preview/(?P<pk>\d+)', GlossDetailView.as_view(), name='admin_gloss_view_colors'),
     re_path(r'^gloss_frequency/(?P<gloss_id>.*)/$', GlossFrequencyView.as_view(), name='admin_frequency_gloss'),


### PR DESCRIPTION
A new endpoint for poster images as requested by @rem0g . 

The endpoint can be called like this (the test environment will be online for 2 weeks, you can use this temperorary token to test if you want):

```python
import requests

# The URL where the video file will be sent
url = 'http://52.57.57.71/dictionary/api_update_gloss/4483/image'

# The path to your video file
image_file_path = 'VLINDERS-IN-DE-BUIK-B-48960.png'

# Auth
headers = {'Authorization': f'Bearer JZnWi1BoQvtEmzcL'}

# Open the video file in binary mode and send it in a POST request
payload = {'File': open(image_file_path, mode='rb')}
response = requests.post(url, files=payload, headers=headers)

# Print the server's response
print(response.status_code)
print(response.text)
```

When working on this, I created #1475 and #1476, tasks to be picked up once this is live.