### PR TITLE
BUG FIXES gloss update API -- stop putting empty things in revision history

### DIFF
--- a/signbank/csv_interface.py
+++ b/signbank/csv_interface.py
@@ -1141,6 +1141,21 @@ def csv_focusgloss_to_minimalpairs(focusgloss, dataset, language_code, csv_rows)
     return csv_rows
 
 
+def normalize_boolean(gloss_field, new_boolean, original_boolean):
+    # return 'True', 'False', 'None' depending on field type
+    print('normalize boolean: ', gloss_field, new_boolean, original_boolean)
+    if gloss_field.name in ['weakdrop', 'weakprop'] and new_boolean.lower() in ['neutral']:
+        return 'None'
+    elif new_boolean.lower() in ['true', 'ja', 'yes']:
+        return 'True'
+    elif new_boolean.lower() in ['false', 'nee', 'no']:
+        return 'False'
+    else:
+        if settings.DEBUG_API:
+            print('normalize_boolean NO MATCH: ', gloss_field, new_boolean)
+        return original_boolean
+
+
 def normalize_field_choice(field_choice):
     # add spaces around > and +
 

--- a/signbank/csv_interface.py
+++ b/signbank/csv_interface.py
@@ -1143,7 +1143,7 @@ def csv_focusgloss_to_minimalpairs(focusgloss, dataset, language_code, csv_rows)
 
 def normalize_boolean(gloss_field, new_boolean, original_boolean):
     # return 'True', 'False', 'None' depending on field type
-    print('normalize boolean: ', gloss_field, new_boolean, original_boolean)
+    # original value returned if there is no match
     if gloss_field.name in ['weakdrop', 'weakprop'] and new_boolean.lower() in ['neutral']:
         return 'None'
     elif new_boolean.lower() in ['true', 'ja', 'yes']:

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -5868,10 +5868,10 @@ def glosslist_ajax_complete(request, gloss_id):
 
     this_gloss = Gloss.objects.get(id=gloss_id, archived=False)
     default_language = this_gloss.lemma.dataset.default_language.language_code_2char
-
+    activate(default_language)
     # TO DO could use the following method to generate the column values
     # but the domain of that method is the column header
-    # gloss_data = this_gloss.get_fields_dict(display_fields)
+    # gloss_data = this_gloss.get_fields_dict(display_fields, default_language)
     # list_gloss_data = list(gloss_data)
     # print(list_gloss_data)
 

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -1399,7 +1399,7 @@ class Gloss(models.Model):
                 other_media_paths.append(other_media_filename)
         return ", ".join(other_media_paths)
 
-    def get_fields_dict(self, fieldnames, language_code='en'):
+    def get_fields_dict(self, fieldnames, language_code):
 
         from django.utils import translation
         translation.activate(language_code)

--- a/signbank/dictionary/tests.py
+++ b/signbank/dictionary/tests.py
@@ -340,7 +340,7 @@ class BasicCRUDTests(TestCase):
         # this calculates the data retrieved by get_gloss_data for packages
         # it shows the format/display of the returned gloss fields
         # note that the value of the phonology fields are numerical rather than human readable
-        result = changed_gloss.get_fields_dict(settings.API_FIELDS)
+        result = changed_gloss.get_fields_dict(settings.API_FIELDS, 'en')
         print('test_package_function: settings.API_FIELDS: ', settings.API_FIELDS)
         print('test_package_function: get_fields_dict: ', result)
 

--- a/signbank/dictionary/views.py
+++ b/signbank/dictionary/views.py
@@ -50,7 +50,6 @@ from django.views.decorators.csrf import csrf_exempt
 from django.utils.timezone import get_current_timezone
 
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist, BadRequest
-from signbank.gloss_update import api_update_gloss_fields
 from django.utils.translation import gettext_lazy as _, activate
 from signbank.abstract_machine import get_interface_language_api
 

--- a/signbank/gloss_update.py
+++ b/signbank/gloss_update.py
@@ -307,7 +307,6 @@ def detect_type_related_problems_for_gloss_update(changes, dataset, language_cod
     # in the following loop, field is either a language field as described above
     # or a field of model Gloss, not a string
     for field, (original_value, new_value) in changes.items():
-        print('field: ', field, type(field))
         if not new_value:
             continue
         if field in language_fields:
@@ -536,7 +535,7 @@ def gloss_pre_update(gloss, input_fields_dict, language_code):
     for language_field in language_fields:
         package_gloss_language_field = human_readable_to_json[language_field]
         combined_fields.append(package_gloss_language_field)
-    # retrieve what the packages knows for these fields
+    # retrieve what the current values for the fields, using the same string representation as package uses
     gloss_package_data_dict = gloss.get_fields_dict(combined_fields, language_code)
     fields_to_update = dict()
     for human_readable_field, new_field_value in input_fields_dict.items():

--- a/signbank/query_parameters.py
+++ b/signbank/query_parameters.py
@@ -25,7 +25,7 @@ from django.utils.dateformat import format
 from django.core.exceptions import ObjectDoesNotExist, EmptyResultSet
 from django.db import OperationalError, ProgrammingError
 from django.db.models import Q, Count, CharField, TextField, Value as V
-from django.db.models.fields import BooleanField, BooleanField
+from django.db.models.fields import BooleanField
 
 from django.urls import reverse
 from tagging.models import TaggedItem, Tag

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -317,6 +317,8 @@ DEBUG_SENSES = False
 
 DEBUG_VIDEOS = False
 
+DEBUG_API = False
+
 # Set this to True to avoid deleting glosses that are in relations with other glosses
 GUARDED_GLOSS_DELETE = False
 


### PR DESCRIPTION
Many small bug fixes. Bugs found during trial and error of all the different fields

- Code for multilingual gloss update translation code #1484

- Renamed functions to make it clear what is being done. CODE IMPROVEMENT

- Added status code 400 to error branches to make sure failure of the operation is observed by caller. CODE IMPROVEMENT

- Fail for transaction error on save BUG FIX

- Repaired code that translated API input json "left hand side". BUG FIX

- _("Senses") translation to Dutch is hard-coded, since it does not work to retrieve the verbose name from the Gloss field. Unknown why, maybe because it's a verbose name on a relation. This used to work. Maybe Django updates.

- Normalise Boolean values (this was not working at all, bug was not reported) BUG FIX

- Only update those fields where the new value differs from the original #1486

- Improved code for comparison of stored and new value depending on type. BUG FIX
