### PR TITLE
fix: Make EAF file of annotated video use protected_media #1511

### DIFF
--- a/signbank/dictionary/templates/dictionary/edit_annotated_sentence.html
+++ b/signbank/dictionary/templates/dictionary/edit_annotated_sentence.html
@@ -105,7 +105,7 @@
 
         <br><br>
         {% trans "Download the current .eaf file here:" %}
-        <a href="{{ annotated_sentence.annotatedvideo.eaffile.url }}" download>{{ annotated_sentence.annotatedvideo.get_eaffile_name }}</a>
+        <a href="{% url 'dictionary:protected_media' annotated_sentence.annotatedvideo.eaffile %}" download>{{ annotated_sentence.annotatedvideo.get_eaffile_name }}</a>
         <br><br>
         {% trans "Choose the updated annotation file (.eaf) here:" %} 
         <input type="file" id="eaffile" name="eaffile">


### PR DESCRIPTION
Fix for #1511 by using `protected_media` instead of the url from the `eaffile` field.