### PR TITLE
1518 update the po files to include recent interface changes

### DIFF
--- a/conf/locale/nl/LC_MESSAGES/django.po
+++ b/conf/locale/nl/LC_MESSAGES/django.po
@@ -4343,18 +4343,20 @@ msgid ""
 "Slide to a point in the video and click 'Set' to define it as the new start "
 "and/or end point"
 msgstr ""
+"Schuif naar een punt in de video en klik op 'Instellen' om een nieuwe begin- "
+"en/of eindpunt in te stellen"
 
 #: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:107
 msgid "Download the current .eaf file here:"
-msgstr ""
+msgstr "Download het annotatiebestand (.eaf) hier:"
 
 #: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:110
 msgid "Choose the updated annotation file (.eaf) here:"
-msgstr ""
+msgstr "Kies het bijgewerkte annotatiebestand (.eaf) hier:"
 
 #: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:118
 msgid "Edit context for the sentence in the following languages:"
-msgstr ""
+msgstr "Bewerk de context van de voorbeeldzin voor de volgende talen:"
 
 #: signbank/dictionary/templates/dictionary/find_and_save_variants.html:7
 msgid "Find and Save Variants"
@@ -4467,7 +4469,7 @@ msgstr "Bron"
 #: signbank/dictionary/templates/dictionary/gloss.html:695
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:2832
 msgid "Original video"
-msgstr ""
+msgstr "Originele video"
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:25
 msgid "Delete This Gloss"
@@ -4480,7 +4482,7 @@ msgstr "Deze idgloss bestaat al"
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:538
 msgid "QUERY"
-msgstr ""
+msgstr "ZOEK"
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:563
 msgid "Default Query Parameters"
@@ -4491,6 +4493,8 @@ msgid ""
 "No active query parameters were used in the search. Here are the non-empty "
 "fields of this gloss."
 msgstr ""
+"Er zijn geen actieve zoekparameters gebruikt bij het zoeken. Hier zijn de niet-lege "
+"velden van deze glos."
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:575
 msgid "No fields are filled in for this gloss."
@@ -4512,7 +4516,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:726
 msgid "This will create a new gloss with identical phonology."
-msgstr ""
+msgstr "Dit zal een nieuwe glos creëren met identieke fonologie."
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:733
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:815
@@ -4553,6 +4557,19 @@ msgid ""
 "moved to the new dataset.</p>\n"
 "                        "
 msgstr ""
+"\n"
+"                        <p>Met deze opdracht wordt de dataset van de glos gewijzigd "
+"evenals de bijbehorende glossen\n"
+"                            (via relaties of morfologie).</p>\n"
+"                        <p>De doeldataset moet dezelfde vertaaltalen hebben.</p>\n"
+"                        <p>Als een glos niet kan worden verplaatst vanwege een vergelijkbare "
+"glos in de doeldataset,\n"
+"                            van de gebruiker wordt verwacht de lemmavertalingen "
+"of gloss-annotaties aan te passen\n"
+"                            om dubbelzinnigheid weg te nemen.</p>\n"
+"                        <p>De video's en afbeeldingen van de glossen zijn ook "
+"verplaatst naar de nieuwe dataset.</p>\n"
+"                        "
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:796
 msgid "This gloss is related to other glosses:"
@@ -4935,15 +4952,15 @@ msgstr "Videos voor %(gloss)s"
 
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:125
 msgid "Citation Form Image"
-msgstr ""
+msgstr "Citaat afbeelding"
 
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:130
 msgid "There is no citation form image for this gloss."
-msgstr "Er is geen citation form image voor deze glos."
+msgstr "Er is geen citaat afbeelding voor deze glos."
 
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:218
 msgid "Your browser does not support this format."
-msgstr ""
+msgstr "Uw browser ondersteunt dit formaat niet."
 
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:7
 msgid "Signbank: Glosses Without Lemma"
@@ -4955,7 +4972,7 @@ msgstr "Glossen zonder lemmata"
 
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:79
 msgid "The following glosses do not have a lemma or dataset."
-msgstr ""
+msgstr "De volgende glossen hebben geen lemma of dataset."
 
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:82
 msgid "Dataset: Translation Languages"
@@ -4990,7 +5007,7 @@ msgstr "Voeg label toe"
 
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:7
 msgid "Signbank: Handshape Details"
-msgstr ""
+msgstr "Signbank: Handvorm details"
 
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:62
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:64
@@ -5255,6 +5272,7 @@ msgstr "Een lege cel zal de bestaande labels wissen."
 msgid ""
 "To update existing glosses, the CSV file must include the first two columns:"
 msgstr ""
+"Om bestaande glossen bij te werken, moet het CSV-bestand de eerste twee kolommen bevatten:"
 
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:277
 msgid ""
@@ -5264,7 +5282,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:278
 msgid "Changes cannot be made to the Lemma ID Gloss fields."
-msgstr ""
+msgstr "Er kunnen geen wijzigingen worden aangebracht in de Lemma ID Glos-velden."
 
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:297
 #: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:139
@@ -5273,11 +5291,11 @@ msgstr "De volgende wijzigingen zijn vastgesteld:"
 
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:304
 msgid "Old Value"
-msgstr ""
+msgstr "Oude waarde"
 
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:305
 msgid "New Value"
-msgstr ""
+msgstr "Nieuwe waarde"
 
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:311
 #, python-format
@@ -5335,7 +5353,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:121
 msgid "Changes can be made to the Lemma ID Gloss fields."
-msgstr ""
+msgstr "Er kunnen wijzigingen worden aangebracht in de Lemma ID Glos-velden."
 
 #: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:144
 msgid "Lemma ID"
@@ -5821,7 +5839,7 @@ msgstr "Je hebt niet genoeg rechten om de geselecteerde dataset te wijzigen."
 
 #: signbank/dictionary/update.py:97
 msgid "The given Lemma Idgloss is a string, not a Lemma."
-msgstr ""
+msgstr "Het gegeven Lemma Idgloss is een string, geen Lemma."
 
 #: signbank/dictionary/update.py:101 signbank/dictionary/update.py:2357
 msgid "The given Lemma Idgloss ID is unknown."
@@ -5845,7 +5863,7 @@ msgstr ""
 
 #: signbank/dictionary/update.py:133
 msgid "Please select or create a lemma."
-msgstr ""
+msgstr "Selecteer of maak een lemma."
 
 #: signbank/dictionary/update.py:217
 msgid "This example sentence was not changed."
@@ -5893,15 +5911,15 @@ msgstr "Betekenis bijgewerkt"
 
 #: signbank/dictionary/update.py:583
 msgid "Sense Creation Not Allowed"
-msgstr ""
+msgstr "Betekenis creatie niet toegestaan"
 
 #: signbank/dictionary/update.py:603
 msgid "No keywords given for new sense."
-msgstr ""
+msgstr "Geen trefwoorden opgegeven voor nieuwe betekenis."
 
 #: signbank/dictionary/update.py:663
 msgid "Sense Deletion Not Allowed"
-msgstr ""
+msgstr "Betekenis verwijdering niet toegestaan"
 
 #: signbank/dictionary/update.py:765
 msgid ""
@@ -5911,16 +5929,16 @@ msgstr ""
 
 #: signbank/dictionary/update.py:940
 msgid "The dataset of the gloss is not the same as that of the lemma."
-msgstr ""
+msgstr "De dataset van de glos is niet dezelfde als die van het lemma."
 
 #: signbank/dictionary/update.py:942 signbank/dictionary/update.py:2596
 msgid "The specified lemma does not exist."
-msgstr "bestaat niet."
+msgstr "Het opgegeven lemma bestaat niet."
 
 #: signbank/dictionary/update.py:1775
 msgid ""
 "Edit Simultaneuous Morphology: The dataset of this gloss has no morphemes."
-msgstr ""
+msgstr "Bewerk Simultane morfologie: De dataset van deze glos heeft geen morfemen."
 
 #: signbank/dictionary/update.py:1778
 msgid "Edit Simultaneuous Morphology: No morpheme selected."
@@ -5928,7 +5946,7 @@ msgstr "Bewerk Simultane morfologie: Geen morfeem geselecteerd."
 
 #: signbank/dictionary/update.py:1792
 msgid "Simultaneuous morphology: no morpheme found with identifier {}."
-msgstr ""
+msgstr "Simultaan morfologie: geen morfeem gevonden met identificatie {}."
 
 #: signbank/dictionary/update.py:2080
 msgid "Annotated Sentence Deletion Not Allowed"

--- a/conf/locale/nl/LC_MESSAGES/django.po
+++ b/conf/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-05 12:26+0200\n"
+"POT-Creation-Date: 2025-03-13 12:47+0100\n"
 "PO-Revision-Date: 2018-03-08 18:54+0100\n"
 "Last-Translator: susanodd\n"
 "Language-Team: Dutch <LL@li.org>\n"
@@ -20,25 +20,27 @@ msgstr ""
 
 #: signbank/abstract_machine.py:58 signbank/abstract_machine.py:86
 #: signbank/abstract_machine.py:104 signbank/abstract_machine.py:180
-#: signbank/abstract_machine.py:218 signbank/api_interface.py:47
-#: signbank/dictionary/batch_edit.py:252 signbank/dictionary/models.py:1447
-#: signbank/dictionary/models.py:3411 signbank/dictionary/models.py:3922
+#: signbank/abstract_machine.py:218 signbank/api_interface.py:109
+#: signbank/dictionary/batch_edit.py:253 signbank/dictionary/models.py:1435
+#: signbank/dictionary/models.py:3520 signbank/dictionary/models.py:4031
 #: signbank/dictionary/templates/dictionary/add_gloss.html:117
 #: signbank/dictionary/templates/dictionary/add_morpheme.html:138
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:374
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1054
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1057
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:523
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:329
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:513
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:603
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:550
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:141
 #: signbank/dictionary/templates/dictionary/annotatedglosslist_headerrow.html:11
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:991
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1623
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1969
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1986
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2004
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2137
+#: signbank/dictionary/templates/dictionary/gloss.html:330
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1339
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1989
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2335
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2352
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2370
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2503
 #: signbank/dictionary/templates/dictionary/gloss_frequency.html:1370
 #: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:14
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:135
@@ -56,64 +58,72 @@ msgstr ""
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:446
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:499
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:551
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:640
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:699
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:643
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:702
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:138
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:142
 #: signbank/dictionary/templates/dictionary/try.html:148
-#: signbank/dictionary/templates/dictionary/update_lemma.html:131
+#: signbank/dictionary/templates/dictionary/update_lemma.html:170
 #: signbank/dictionary/templates/dictionary/virtual_machine.html:133
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:126
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:130
 #: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:138
 #: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:142
 #: signbank/dictionary/templates/dictionary/word.html:115
-#: signbank/dictionary/views.py:2605
+#: signbank/dictionary/views.py:2566
 #: signbank/feedback/templates/feedback/recent_feedback.html:64
-#: signbank/gloss_update.py:26 signbank/gloss_update.py:88
-#: signbank/gloss_update.py:90 signbank/gloss_update.py:394
-#: signbank/query_parameters.py:514
+#: signbank/gloss_update.py:28 signbank/gloss_update.py:90
+#: signbank/gloss_update.py:92 signbank/gloss_update.py:417
+#: signbank/query_parameters.py:522
 msgid "Annotation ID Gloss"
 msgstr "Annotatie-ID-Glos"
 
 #: signbank/abstract_machine.py:60 signbank/abstract_machine.py:88
 #: signbank/abstract_machine.py:107 signbank/abstract_machine.py:171
-#: signbank/abstract_machine.py:204 signbank/api_interface.py:44
-#: signbank/dictionary/batch_edit.py:230 signbank/dictionary/models.py:1441
-#: signbank/dictionary/models.py:3924
+#: signbank/abstract_machine.py:204 signbank/api_interface.py:106
+#: signbank/dictionary/batch_edit.py:231 signbank/dictionary/models.py:1429
+#: signbank/dictionary/models.py:4033
 #: signbank/dictionary/templates/dictionary/add_gloss.html:128
 #: signbank/dictionary/templates/dictionary/add_lemma.html:76
 #: signbank/dictionary/templates/dictionary/add_morpheme.html:98
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1050
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1053
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:337
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:232
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:511
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:560
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:914
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:140
+#: signbank/dictionary/templates/dictionary/gloss.html:319
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1262
 #: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:17
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:132
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:171
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:413
 #: signbank/dictionary/templates/dictionary/recently_added_glosses.html:23
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:125
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:129
 #: signbank/dictionary/templates/dictionary/virtual_machine.html:120
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:113
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:117
 #: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:125
 #: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:129
-#: signbank/dictionary/views.py:2601 signbank/gloss_update.py:28
-#: signbank/gloss_update.py:92 signbank/gloss_update.py:94
-#: signbank/gloss_update.py:373 signbank/query_parameters.py:517
+#: signbank/dictionary/views.py:2562 signbank/gloss_update.py:30
+#: signbank/gloss_update.py:94 signbank/gloss_update.py:96
+#: signbank/gloss_update.py:396 signbank/query_parameters.py:525
 msgid "Lemma ID Gloss"
 msgstr "Lemma-ID-Glos"
 
 #: signbank/abstract_machine.py:62 signbank/abstract_machine.py:90
-#: signbank/abstract_machine.py:110 signbank/api_interface.py:50
-#: signbank/dictionary/forms.py:382 signbank/dictionary/models.py:1079
-#: signbank/dictionary/models.py:1466 signbank/dictionary/models.py:3926
+#: signbank/abstract_machine.py:110 signbank/api_interface.py:112
+#: signbank/dictionary/forms.py:383 signbank/dictionary/models.py:1071
+#: signbank/dictionary/models.py:1454 signbank/dictionary/models.py:4035
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:386
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:474
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1058
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1061
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:215
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:570
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:794
+#: signbank/dictionary/templates/dictionary/gloss.html:359
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1367
 #: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:20
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:103
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:187
@@ -128,7 +138,7 @@ msgstr "Lemma-ID-Glos"
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:139
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:143
 #: signbank/dictionary/templates/dictionary/word.html:138
-#: signbank/query_parameters.py:520 signbank/query_parameters.py:927
+#: signbank/query_parameters.py:528 signbank/query_parameters.py:939
 msgid "Senses"
 msgstr "Betekenissen"
 
@@ -148,14 +158,14 @@ msgstr "Dataset afkorting komt niet overeen met dataset."
 msgid " is empty."
 msgstr " is leeg."
 
-#: signbank/abstract_machine.py:204 signbank/dictionary/batch_edit.py:230
-#: signbank/dictionary/batch_edit.py:253 signbank/gloss_update.py:373
-#: signbank/gloss_update.py:395
+#: signbank/abstract_machine.py:204 signbank/dictionary/batch_edit.py:231
+#: signbank/dictionary/batch_edit.py:254 signbank/gloss_update.py:396
+#: signbank/gloss_update.py:418
 msgid "already exists."
 msgstr "bestaat al."
 
-#: signbank/abstract_machine.py:209 signbank/dictionary/batch_edit.py:235
-#: signbank/gloss_update.py:378
+#: signbank/abstract_machine.py:209 signbank/dictionary/batch_edit.py:236
+#: signbank/gloss_update.py:401
 msgid "Lemma translations refer to different already existing lemmas."
 msgstr "Lemmavertalingen verwijzen naar verschillende reeds bestaande lemma's."
 
@@ -169,9 +179,9 @@ msgstr ""
 "Bij de verschillende talen staat een verschillend aantal betekennissen."
 
 #: signbank/abstract_machine.py:374 signbank/gloss_morphology_update.py:170
-#: signbank/gloss_update.py:551 signbank/gloss_update.py:687
-#: signbank/gloss_update.py:767 signbank/gloss_update.py:941
-#: signbank/gloss_update.py:1084 signbank/gloss_update.py:1168
+#: signbank/gloss_update.py:599 signbank/gloss_update.py:728
+#: signbank/gloss_update.py:808 signbank/gloss_update.py:982
+#: signbank/gloss_update.py:1115 signbank/gloss_update.py:1199
 msgid "Dataset ID does not exist."
 msgstr "Dataset ID bestaat niet."
 
@@ -180,13 +190,13 @@ msgid "No change permission for dataset for user "
 msgstr "Geen toestemming om dataset te bewerken."
 
 #: signbank/abstract_machine.py:383 signbank/gloss_morphology_update.py:213
-#: signbank/gloss_update.py:594 signbank/gloss_update.py:730
-#: signbank/gloss_update.py:810 signbank/gloss_update.py:984
-#: signbank/gloss_update.py:1127 signbank/gloss_update.py:1211
+#: signbank/gloss_update.py:642 signbank/gloss_update.py:771
+#: signbank/gloss_update.py:851 signbank/gloss_update.py:1025
+#: signbank/gloss_update.py:1158 signbank/gloss_update.py:1242
 msgid "No change gloss permission."
 msgstr "Geen verander-glos toestemming."
 
-#: signbank/api_interface.py:54 signbank/dictionary/models.py:973
+#: signbank/api_interface.py:116 signbank/dictionary/models.py:965
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:503
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:679
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:526
@@ -203,7 +213,7 @@ msgstr "Geen verander-glos toestemming."
 msgid "Handedness"
 msgstr "Handigheid"
 
-#: signbank/api_interface.py:55 signbank/dictionary/models.py:980
+#: signbank/api_interface.py:117 signbank/dictionary/models.py:972
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:512
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:697
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:527
@@ -219,7 +229,7 @@ msgstr "Handigheid"
 msgid "Strong Hand"
 msgstr "Sterke hand"
 
-#: signbank/api_interface.py:56 signbank/dictionary/models.py:984
+#: signbank/api_interface.py:118 signbank/dictionary/models.py:976
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:521
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:716
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:528
@@ -235,7 +245,7 @@ msgstr "Sterke hand"
 msgid "Weak Hand"
 msgstr "Zwakke hand"
 
-#: signbank/api_interface.py:57 signbank/dictionary/models.py:1004
+#: signbank/api_interface.py:119 signbank/dictionary/models.py:996
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:545
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:773
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:614
@@ -251,45 +261,53 @@ msgstr "Zwakke hand"
 msgid "Location"
 msgstr "Plaats"
 
-#: signbank/api_interface.py:58 signbank/dictionary/models.py:1209
-#: signbank/dictionary/models.py:3769
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2027
+#: signbank/api_interface.py:120 signbank/dictionary/models.py:1201
+#: signbank/dictionary/models.py:3878
+#: signbank/dictionary/templates/dictionary/gloss.html:592
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2393
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:603
 msgid "Semantic Field"
 msgstr "Semantisch veld"
 
-#: signbank/api_interface.py:59
+#: signbank/api_interface.py:121
 #: signbank/dictionary/templates/dictionary/admin_toggle_view.html:257
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:550
 msgid "Word Class"
 msgstr "Woordsoort"
 
-#: signbank/api_interface.py:60 signbank/dictionary/models.py:1206
+#: signbank/api_interface.py:122 signbank/dictionary/models.py:1198
 #: signbank/dictionary/templates/dictionary/admin_toggle_view.html:259
 msgid "Named Entity"
 msgstr "Naam"
 
-#: signbank/api_interface.py:61 signbank/api_interface.py:64
-#: signbank/dictionary/models.py:1495 signbank/dictionary/models.py:1575
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:757
+#: signbank/api_interface.py:123 signbank/api_interface.py:127
+#: signbank/dictionary/models.py:1483 signbank/dictionary/models.py:1561
+#: signbank/dictionary/models.py:1588
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:760
 msgid "Link"
 msgstr ""
 
-#: signbank/api_interface.py:62 signbank/api_interface.py:65
-#: signbank/dictionary/models.py:1499
+#: signbank/api_interface.py:124 signbank/api_interface.py:128
+#: signbank/dictionary/models.py:1487
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:615
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:106
+#: signbank/dictionary/templates/dictionary/update_lemma.html:167
 msgid "Video"
 msgstr "Video"
 
-#: signbank/api_interface.py:66 signbank/dictionary/forms.py:193
-#: signbank/dictionary/forms.py:223 signbank/dictionary/forms.py:285
-#: signbank/dictionary/forms.py:345 signbank/dictionary/forms.py:460
-#: signbank/dictionary/forms.py:523 signbank/dictionary/forms.py:1050
-#: signbank/dictionary/models.py:1505 signbank/dictionary/models.py:3908
+#: signbank/api_interface.py:125 signbank/api_interface.py:129
+#: signbank/dictionary/models.py:1550
+msgid "Perspective Videos"
+msgstr "Perspectief video's"
+
+#: signbank/api_interface.py:130 signbank/dictionary/forms.py:193
+#: signbank/dictionary/forms.py:223 signbank/dictionary/forms.py:286
+#: signbank/dictionary/forms.py:346 signbank/dictionary/forms.py:461
+#: signbank/dictionary/forms.py:524 signbank/dictionary/forms.py:1051
+#: signbank/dictionary/models.py:1497 signbank/dictionary/models.py:4017
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:272
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:313
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1070
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1073
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:190
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:217
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:615
@@ -308,58 +326,89 @@ msgstr "Video"
 msgid "Tags"
 msgstr "Labels"
 
-#: signbank/api_interface.py:67 signbank/dictionary/models.py:1516
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2277
+#: signbank/api_interface.py:131 signbank/dictionary/models.py:1508
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2643
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:674
 msgid "Notes"
 msgstr "Aantekeningen"
 
-#: signbank/api_interface.py:68 signbank/dictionary/forms.py:212
-#: signbank/dictionary/models.py:1533 signbank/dictionary/models.py:3337
-#: signbank/dictionary/models.py:3348
+#: signbank/api_interface.py:132 signbank/dictionary/forms.py:212
+#: signbank/dictionary/models.py:1525 signbank/dictionary/models.py:3446
+#: signbank/dictionary/models.py:3457
 msgid "Affiliation"
 msgstr "Affiliatie"
 
-#: signbank/api_interface.py:69 signbank/dictionary/adminviews.py:5904
-#: signbank/dictionary/adminviews.py:6000 signbank/dictionary/forms.py:255
-#: signbank/dictionary/models.py:1543 signbank/dictionary/models.py:3713
+#: signbank/api_interface.py:133 signbank/dictionary/adminviews.py:5910
+#: signbank/dictionary/adminviews.py:6006 signbank/dictionary/forms.py:256
+#: signbank/dictionary/models.py:1535 signbank/dictionary/models.py:3822
 #: signbank/dictionary/related_objects.py:91
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1556
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:612
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:641
-#: signbank/dictionary/views.py:2593 signbank/gloss_morphology_update.py:35
+#: signbank/dictionary/templates/dictionary/gloss.html:459
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1922
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:611
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:644
+#: signbank/dictionary/views.py:2554 signbank/gloss_morphology_update.py:35
 #: signbank/gloss_morphology_update.py:54
 #: signbank/gloss_morphology_update.py:65
 msgid "Sequential Morphology"
 msgstr "Sequentiële morfologie"
 
-#: signbank/api_interface.py:70 signbank/dictionary/adminviews.py:5905
-#: signbank/dictionary/adminviews.py:6001 signbank/dictionary/forms.py:238
-#: signbank/dictionary/models.py:1548 signbank/dictionary/related_objects.py:35
+#: signbank/api_interface.py:134 signbank/dictionary/adminviews.py:5911
+#: signbank/dictionary/adminviews.py:6007 signbank/dictionary/forms.py:239
+#: signbank/dictionary/models.py:1540 signbank/dictionary/related_objects.py:35
 #: signbank/dictionary/related_objects.py:125
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1634
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:727
-#: signbank/dictionary/views.py:2595 signbank/gloss_morphology_update.py:36
+#: signbank/dictionary/templates/dictionary/gloss.html:441
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2000
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:730
+#: signbank/dictionary/views.py:2556 signbank/gloss_morphology_update.py:36
 #: signbank/gloss_morphology_update.py:55
 #: signbank/gloss_morphology_update.py:66
 msgid "Simultaneous Morphology"
 msgstr "Simultane morfologie"
 
-#: signbank/api_interface.py:71 signbank/dictionary/models.py:1553
+#: signbank/api_interface.py:135 signbank/dictionary/models.py:1545
 #: signbank/dictionary/related_objects.py:142
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1726
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:670
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:700
-#: signbank/dictionary/views.py:2597 signbank/gloss_morphology_update.py:37
+#: signbank/dictionary/templates/dictionary/gloss.html:475
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2092
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:673
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:703
+#: signbank/dictionary/views.py:2558 signbank/gloss_morphology_update.py:37
 #: signbank/gloss_morphology_update.py:56
 #: signbank/gloss_morphology_update.py:67
 msgid "Blend Morphology"
 msgstr "Blend-morfologie"
 
-#: signbank/api_interface.py:84 signbank/dictionary/models.py:1558
-#: signbank/gloss_update.py:851
+#: signbank/api_interface.py:148 signbank/dictionary/models.py:1571
+#: signbank/gloss_update.py:892
 msgid "NME Videos"
 msgstr "NME Video's"
+
+#: signbank/api_interface.py:271
+#: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:208
+#: signbank/gloss_update.py:1388
+msgid "Translation"
+msgstr "Vertaling"
+
+#: signbank/api_interface.py:272 signbank/gloss_update.py:1389
+msgid "Context"
+msgstr "Contekst"
+
+#: signbank/api_interface.py:452 signbank/api_interface.py:514
+#: signbank/dictionary/templates/dictionary/dataset_frequency.html:186
+#: signbank/gloss_update.py:1079 signbank/gloss_update.py:1165
+msgid "File"
+msgstr "Bestand"
+
+#: signbank/api_interface.py:646
+msgid "Dataset not found."
+msgstr "Dataset niet gevonden."
+
+#: signbank/api_interface.py:649
+msgid "No permission to change dataset"
+msgstr "Geen toestemming om dataset te veranderen."
+
+#: signbank/api_interface.py:655
+msgid "You must be in group Dataset Manager to import gloss videos."
+msgstr "Je moet in groep Dataset Manager zijn om glos-video's te importeren."
 
 #: signbank/api_token.py:44
 msgid "No Authorization token found"
@@ -382,43 +431,44 @@ msgstr ""
 msgid "URL"
 msgstr "URL"
 
-#: signbank/dictionary/admin.py:230
+#: signbank/dictionary/admin.py:235
 msgid "number of senses"
 msgstr "aantal betekenissen"
 
-#: signbank/dictionary/admin.py:243
+#: signbank/dictionary/admin.py:248
 msgid "No Senses"
 msgstr "Geen betekenissen"
 
-#: signbank/dictionary/admin.py:244
+#: signbank/dictionary/admin.py:249
 msgid "More than one"
 msgstr "Meer dan een"
 
-#: signbank/dictionary/admin.py:577
+#: signbank/dictionary/admin.py:590
 msgid "The derivation history name is required"
 msgstr ""
 
-#: signbank/dictionary/admin.py:648 signbank/dictionary/models.py:3338
+#: signbank/dictionary/admin.py:661 signbank/dictionary/models.py:3447
 #: signbank/dictionary/templates/dictionary/gloss_revision_history.html:64
 #: signbank/feedback/templates/feedback/recent_feedback.html:62
 #: signbank/gloss_morphology_update.py:163
 msgid "User"
 msgstr "Gebruiker"
 
-#: signbank/dictionary/admin.py:666 signbank/dictionary/models.py:3458
+#: signbank/dictionary/admin.py:679 signbank/dictionary/models.py:3567
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:206
 #: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:297
 #: signbank/dictionary/templates/dictionary/admin_frequency_list.html:247
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1051
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1054
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:525
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:325
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:230
 #: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:401
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:510
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:607
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:139
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:123
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:227
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2255
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2621
 #: signbank/dictionary/templates/dictionary/glosslist_headerrow.html:34
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:128
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:167
@@ -437,7 +487,7 @@ msgstr "Gebruiker"
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:552
 #: signbank/dictionary/templates/dictionary/senselist_headerrow.html:28
 #: signbank/dictionary/templates/dictionary/unused_videos.html:23
-#: signbank/dictionary/templates/dictionary/update_lemma.html:124
+#: signbank/dictionary/templates/dictionary/update_lemma.html:162
 #: signbank/dictionary/templates/dictionary/virtual_machine.html:108
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:101
 #: signbank/feedback/admin.py:18 signbank/feedback/admin.py:74
@@ -445,518 +495,543 @@ msgstr "Gebruiker"
 #: signbank/feedback/templates/feedback/show_feedback_morphemes.html:94
 #: signbank/feedback/templates/feedback/show_feedback_signs.html:94
 #: signbank/gloss_morphology_update.py:170
-#: signbank/gloss_morphology_update.py:177 signbank/gloss_update.py:551
-#: signbank/gloss_update.py:558 signbank/gloss_update.py:687
-#: signbank/gloss_update.py:694 signbank/gloss_update.py:767
-#: signbank/gloss_update.py:774 signbank/gloss_update.py:941
-#: signbank/gloss_update.py:948 signbank/gloss_update.py:1084
-#: signbank/gloss_update.py:1091 signbank/gloss_update.py:1168
-#: signbank/gloss_update.py:1175 signbank/video/admin.py:15
-#: signbank/video/admin.py:176 signbank/video/admin.py:218
+#: signbank/gloss_morphology_update.py:177 signbank/gloss_update.py:599
+#: signbank/gloss_update.py:606 signbank/gloss_update.py:728
+#: signbank/gloss_update.py:735 signbank/gloss_update.py:808
+#: signbank/gloss_update.py:815 signbank/gloss_update.py:982
+#: signbank/gloss_update.py:989 signbank/gloss_update.py:1115
+#: signbank/gloss_update.py:1122 signbank/gloss_update.py:1199
+#: signbank/gloss_update.py:1206 signbank/video/admin.py:15
+#: signbank/video/admin.py:186 signbank/video/admin.py:228
+#: signbank/video/admin_update.py:20 signbank/video/admin_update.py:354
+#: signbank/video/admin_update.py:396
 msgid "Dataset"
 msgstr "Dataset"
 
-#: signbank/dictionary/admin.py:1102 signbank/dictionary/admin.py:1130
+#: signbank/dictionary/admin.py:1092 signbank/dictionary/admin.py:1127
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:333
 #: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:175
 msgid "Make changes"
 msgstr "Wijzig"
 
-#: signbank/dictionary/admin.py:1339
+#: signbank/dictionary/admin.py:1342
 msgid "Change Title of Saved Query"
 msgstr "Bewerk naam query"
 
-#: signbank/dictionary/adminviews.py:312
+#: signbank/dictionary/adminviews.py:313
 msgid "Error in search field "
 msgstr "Fout in zoekveld "
 
-#: signbank/dictionary/adminviews.py:314
+#: signbank/dictionary/adminviews.py:315
 msgid ": A regular expression is expected due to special characters. "
 msgstr ": Vanwege speciale tekens is een reguliere expressie vereist. "
 
-#: signbank/dictionary/adminviews.py:315
+#: signbank/dictionary/adminviews.py:316
 msgid "Please use a backslash before special characters: "
 msgstr "Plaats een backslash voor de speciale karakters."
 
-#: signbank/dictionary/adminviews.py:625 signbank/dictionary/adminviews.py:3781
-#: signbank/dictionary/adminviews.py:3900
-#: signbank/dictionary/adminviews.py:4047
-#: signbank/dictionary/adminviews.py:4521
-#: signbank/dictionary/adminviews.py:4997
-#: signbank/dictionary/adminviews.py:5036
-#: signbank/dictionary/adminviews.py:5076
-#: signbank/dictionary/adminviews.py:5607
-#: signbank/dictionary/adminviews.py:5653
+#: signbank/dictionary/adminviews.py:637 signbank/dictionary/adminviews.py:3701
+#: signbank/dictionary/adminviews.py:3820
+#: signbank/dictionary/adminviews.py:3958
+#: signbank/dictionary/adminviews.py:4433
+#: signbank/dictionary/adminviews.py:4909
+#: signbank/dictionary/adminviews.py:4948
+#: signbank/dictionary/adminviews.py:4988
+#: signbank/dictionary/adminviews.py:5613
+#: signbank/dictionary/adminviews.py:5659
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:118
-#: signbank/dictionary/update.py:3479 signbank/frequency.py:1133
-#: signbank/manage_videos.py:39
+#: signbank/dictionary/update.py:3515 signbank/dictionary/views.py:312
+#: signbank/frequency.py:1133 signbank/manage_videos.py:38
 msgid "Please login to use this functionality."
 msgstr "Log alsjeblieft in om deze functionaliteit te gebruiken."
 
-#: signbank/dictionary/adminviews.py:633
+#: signbank/dictionary/adminviews.py:645
 msgid "No dataset with that name found."
 msgstr "Geen dataset gevonden."
 
-#: signbank/dictionary/adminviews.py:641 signbank/dictionary/adminviews.py:3922
+#: signbank/dictionary/adminviews.py:653 signbank/dictionary/adminviews.py:3842
 msgid "No permission to export dataset."
 msgstr "Geen toestemming om dataset te exporteren."
 
-#: signbank/dictionary/adminviews.py:648 signbank/dictionary/adminviews.py:3935
+#: signbank/dictionary/adminviews.py:660 signbank/dictionary/adminviews.py:3855
 msgid "ECV successfully updated."
 msgstr "ECV met succes bijgewerkt."
 
-#: signbank/dictionary/adminviews.py:650
+#: signbank/dictionary/adminviews.py:662
 msgid "No ECV created for dataset."
 msgstr "Geen ECV aangemaakt voor dataset."
 
-#: signbank/dictionary/adminviews.py:1062
-#: signbank/dictionary/adminviews.py:1692
-#: signbank/dictionary/adminviews.py:1804
-#: signbank/dictionary/adminviews.py:3153
+#: signbank/dictionary/adminviews.py:1079
+#: signbank/dictionary/adminviews.py:1633
+#: signbank/dictionary/adminviews.py:1746
+#: signbank/dictionary/adminviews.py:3085
 msgid "The requested gloss does not exist."
 msgstr "Aangevraagd glos bestaat niet."
 
-#: signbank/dictionary/adminviews.py:1066
-#: signbank/dictionary/adminviews.py:1696
-#: signbank/dictionary/adminviews.py:1808
-#: signbank/dictionary/adminviews.py:3157
+#: signbank/dictionary/adminviews.py:1083
+#: signbank/dictionary/adminviews.py:1637
+#: signbank/dictionary/adminviews.py:1750
+#: signbank/dictionary/adminviews.py:3089
 msgid "Requested gloss has no lemma or dataset."
 msgstr "Aangevraagd glos heeft geen lemma nog dataset."
 
-#: signbank/dictionary/adminviews.py:1080
-#: signbank/dictionary/adminviews.py:1710
-#: signbank/dictionary/adminviews.py:1822
-#: signbank/dictionary/adminviews.py:3171
+#: signbank/dictionary/adminviews.py:1089
+msgid "Requested dataset is not available for public viewing."
+msgstr "Aangevraagd dataset niet beschikbaar voor publiek."
+
+#: signbank/dictionary/adminviews.py:1093
+msgid "Requested gloss is not available for public viewing."
+msgstr "Aangevraagd glos niet beschikbaar voor publiek."
+
+#: signbank/dictionary/adminviews.py:1097
+#: signbank/dictionary/adminviews.py:1651
+#: signbank/dictionary/adminviews.py:1764
+#: signbank/dictionary/adminviews.py:3103
 msgid "The gloss you are trying to view is not in your selected datasets."
-msgstr ""
+msgstr "De aangevraagde glos bevindt zich niet in de geselecteerde datasets."
 
-#: signbank/dictionary/adminviews.py:1087
-#: signbank/dictionary/adminviews.py:1717
-#: signbank/dictionary/adminviews.py:1829
-#: signbank/dictionary/adminviews.py:3178
+#: signbank/dictionary/adminviews.py:1098
+#: signbank/dictionary/adminviews.py:1110
+#: signbank/dictionary/adminviews.py:1652
+#: signbank/dictionary/adminviews.py:1765
+#: signbank/dictionary/adminviews.py:3104
+#: signbank/dictionary/adminviews.py:5126
+#: signbank/dictionary/adminviews.py:6635
+#: signbank/dictionary/adminviews.py:6640
+msgid " It is in dataset "
+msgstr " Hij behoort tot de dataset "
+
+#: signbank/dictionary/adminviews.py:1109
+#: signbank/dictionary/adminviews.py:1659
+#: signbank/dictionary/adminviews.py:1772
+#: signbank/dictionary/adminviews.py:3111
 msgid "The gloss you are trying to view is not in a dataset you can view."
-msgstr ""
+msgstr "De aangevraagde glos bevindt zich niet in een dataset die u kunt bekijken."
 
-#: signbank/dictionary/adminviews.py:1628
-#: signbank/dictionary/adminviews.py:4840
+#: signbank/dictionary/adminviews.py:1569
+#: signbank/dictionary/adminviews.py:4752
 msgid "You must be superuser to use the requested functionality."
 msgstr "Je moet superuser zijn om deze functionaliteit te gebruiken."
 
-#: signbank/dictionary/adminviews.py:1636
+#: signbank/dictionary/adminviews.py:1577
 msgid "The target dataset has different translation languages."
 msgstr "De doel-dataset heeft andere vertaaltalen."
 
-#: signbank/dictionary/adminviews.py:1642
+#: signbank/dictionary/adminviews.py:1583
 msgid "A similar gloss already exists in the target dataset: "
 msgstr "Een vergelijkbare glos bestaat al in de doel-dataset: "
 
-#: signbank/dictionary/adminviews.py:1649
+#: signbank/dictionary/adminviews.py:1590
 msgid "A related gloss already exists in the target dataset: "
 msgstr "Een verwant gebaar bestaat al in de doel-dataset: "
 
-#: signbank/dictionary/adminviews.py:1666
+#: signbank/dictionary/adminviews.py:1607
 msgid "Error moving the gloss and related glosses to the requested dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:1671
+#: signbank/dictionary/adminviews.py:1612
 msgid "Gloss moved to dataset "
 msgstr "Glos verplaatst naar dataset "
 
-#: signbank/dictionary/adminviews.py:2259
+#: signbank/dictionary/adminviews.py:2200
 msgid "Handshape not configured."
 msgstr "Handvorm niet geconfigureerd."
 
-#: signbank/dictionary/adminviews.py:2391
+#: signbank/dictionary/adminviews.py:2332
 msgid "SemanticField not configured for this machine value."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:2488
+#: signbank/dictionary/adminviews.py:2421
 msgid "DerivationHistory not configured for this machine value."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:2624
+#: signbank/dictionary/adminviews.py:2547
 msgid "Please select a single dataset to view minimal pairs."
 msgstr "Selecteer een enkel dataset om minimale paren te bekijken."
 
-#: signbank/dictionary/adminviews.py:2901
+#: signbank/dictionary/adminviews.py:2833
 msgid "Query View Save"
 msgstr "Opgeslagen in Query-weergave"
 
-#: signbank/dictionary/adminviews.py:2986
+#: signbank/dictionary/adminviews.py:2918
 msgid "Language "
 msgstr "Taal "
 
-#: signbank/dictionary/adminviews.py:3789
-#: signbank/dictionary/adminviews.py:3908
-#: signbank/dictionary/adminviews.py:4086
-#: signbank/dictionary/adminviews.py:5005
-#: signbank/dictionary/adminviews.py:5044
-#: signbank/dictionary/adminviews.py:5084
+#: signbank/dictionary/adminviews.py:3709
+#: signbank/dictionary/adminviews.py:3828
+#: signbank/dictionary/adminviews.py:3997
+#: signbank/dictionary/adminviews.py:4917
+#: signbank/dictionary/adminviews.py:4956
+#: signbank/dictionary/adminviews.py:4996
 msgid "Dataset name must be non-empty."
 msgstr "Naam van de dataset mag niet leeg zijn."
 
-#: signbank/dictionary/adminviews.py:3795
-#: signbank/dictionary/adminviews.py:4092
+#: signbank/dictionary/adminviews.py:3715
+#: signbank/dictionary/adminviews.py:4003
 msgid "No dataset found with that name."
 msgstr "Geen dataset gevonden."
 
-#: signbank/dictionary/adminviews.py:3802
+#: signbank/dictionary/adminviews.py:3722
 msgid "Dataset must have at least one owner."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:3816
-#: signbank/dictionary/adminviews.py:4185
+#: signbank/dictionary/adminviews.py:3736
+#: signbank/dictionary/adminviews.py:4096
 msgid "View permission for user successfully granted."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:3820
+#: signbank/dictionary/adminviews.py:3740
 msgid "View permission for user requested."
 msgstr "Lees-toestemming voor gebruiker aangevraagd."
 
-#: signbank/dictionary/adminviews.py:3824
+#: signbank/dictionary/adminviews.py:3744
 msgid "You can already view this dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:3914
+#: signbank/dictionary/adminviews.py:3834
 msgid "No dataset found with that acronym."
 msgstr "Geen dataset gevonden."
 
-#: signbank/dictionary/adminviews.py:3928
+#: signbank/dictionary/adminviews.py:3848
 msgid "The dataset is empty, export ECV is not available."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:3937
+#: signbank/dictionary/adminviews.py:3857
 msgid "No ECV created for the dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4056
-#: signbank/dictionary/adminviews.py:4414
-#: signbank/dictionary/adminviews.py:4530
-#: signbank/dictionary/adminviews.py:4744 signbank/dictionary/update.py:2924
-#: signbank/manage_videos.py:48
+#: signbank/dictionary/adminviews.py:3967
+#: signbank/dictionary/adminviews.py:4326
+#: signbank/dictionary/adminviews.py:4442
+#: signbank/dictionary/adminviews.py:4656 signbank/dictionary/update.py:2958
+#: signbank/manage_videos.py:47
 msgid "No group Dataset_Manager found."
 msgstr "Geen groep Dataset_Manager gevonden."
 
-#: signbank/dictionary/adminviews.py:4062
-#: signbank/dictionary/adminviews.py:4535
+#: signbank/dictionary/adminviews.py:3973
+#: signbank/dictionary/adminviews.py:4447
 msgid "You must be in group Dataset Manager to modify dataset permissions."
 msgstr "Je moet in groep Dataset Manager zijn om deze dataset te wijzigen."
 
-#: signbank/dictionary/adminviews.py:4070
+#: signbank/dictionary/adminviews.py:3981
 msgid "No permission to modify dataset permissions."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4107
+#: signbank/dictionary/adminviews.py:4018
 msgid ""
 "Username must be non-empty. Please make a selection using the drop-down list."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4113
-#: signbank/dictionary/adminviews.py:4549
+#: signbank/dictionary/adminviews.py:4024
+#: signbank/dictionary/adminviews.py:4461
 msgid "No user with that username found."
 msgstr "Geen gebruikers met username gevonden."
 
-#: signbank/dictionary/adminviews.py:4136
+#: signbank/dictionary/adminviews.py:4047
 msgid "The default language of {} is set to {}."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4140
+#: signbank/dictionary/adminviews.py:4051
 msgid "{} is not in the set of languages of dataset {}."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4144
+#: signbank/dictionary/adminviews.py:4055
 msgid "Something went wrong setting the default language for "
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4176
+#: signbank/dictionary/adminviews.py:4087
 msgid ""
 "User already has view permission for this dataset as staff or superuser."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4179
+#: signbank/dictionary/adminviews.py:4090
 msgid "User already has view permission for this dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4216
+#: signbank/dictionary/adminviews.py:4127
 msgid "Error assigning view dataset permission to user."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4225
+#: signbank/dictionary/adminviews.py:4136
 msgid ""
 "User already has change permission for this dataset as staff or superuser."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4228
+#: signbank/dictionary/adminviews.py:4139
 msgid "User already has change permission for this dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4233
+#: signbank/dictionary/adminviews.py:4144
 msgid ""
 "User does not have view permission for this dataset. Please grant view "
 "permission first."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4253
+#: signbank/dictionary/adminviews.py:4164
 msgid "Change permission for user successfully granted."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4255
+#: signbank/dictionary/adminviews.py:4166
 msgid "Error assigning change dataset permission to user."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4264
+#: signbank/dictionary/adminviews.py:4175
 msgid ""
 "User has view permission for this dataset as staff or superuser. This cannot "
 "be modified here."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4272
+#: signbank/dictionary/adminviews.py:4184
 msgid "View (and change) permission for user successfully revoked."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4275
+#: signbank/dictionary/adminviews.py:4187
 msgid "Error revoking view dataset permission for user."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4279
+#: signbank/dictionary/adminviews.py:4191
 msgid "User currently has no permission to view this dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4288
+#: signbank/dictionary/adminviews.py:4200
 msgid ""
 "User has change permission for this dataset as staff or superuser. This "
 "cannot be modified here."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4304
+#: signbank/dictionary/adminviews.py:4216
 msgid "Change permission for user successfully revoked."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4307
+#: signbank/dictionary/adminviews.py:4219
 msgid "Error revoking change dataset permission for user."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4311
+#: signbank/dictionary/adminviews.py:4223
 msgid "User currently has no permission to change this dataset."
 msgstr "Gebruiker heeft geen rechten om de geselecteerde dataset te wijzigen."
 
-#: signbank/dictionary/adminviews.py:4316
+#: signbank/dictionary/adminviews.py:4228
 msgid "Unrecognised argument to dataset manager url."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4419
-#: signbank/dictionary/adminviews.py:4749
+#: signbank/dictionary/adminviews.py:4331
+#: signbank/dictionary/adminviews.py:4661
 msgid ""
 "You must be in group Dataset_Manager to use the requested functionality."
 msgstr ""
 "Je moet in groep Dataset Manager zijn om deze functionaliteit te gebruiken."
 
-#: signbank/dictionary/adminviews.py:4459
-#: signbank/dictionary/adminviews.py:4586
-#: signbank/dictionary/adminviews.py:4861
+#: signbank/dictionary/adminviews.py:4371
+#: signbank/dictionary/adminviews.py:4498
+#: signbank/dictionary/adminviews.py:4773
+#: signbank/dictionary/dataset_views.py:36
 msgid "The requested dataset does not exist."
 msgstr "Aangevraagd dataset bestaat niet."
 
-#: signbank/dictionary/adminviews.py:4543
+#: signbank/dictionary/adminviews.py:4455
 msgid "Username must be non-empty."
 msgstr "Gebruikersnaam is leeg."
 
-#: signbank/dictionary/adminviews.py:4559
+#: signbank/dictionary/adminviews.py:4471
 msgid "User successfully made (co-)owner of this dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4771
-#: signbank/dictionary/adminviews.py:4844
+#: signbank/dictionary/adminviews.py:4683
+#: signbank/dictionary/adminviews.py:4756
 msgid "Please login to use the requested functionality."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4872
+#: signbank/dictionary/adminviews.py:4784
 msgid "You do not have permission to view this corpus."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4939
+#: signbank/dictionary/adminviews.py:4851
 msgid "Modified"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4960
+#: signbank/dictionary/adminviews.py:4872
 msgid "Male"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4960
+#: signbank/dictionary/adminviews.py:4872
 msgid "Female"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4960
+#: signbank/dictionary/adminviews.py:4872
 msgid "Other"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4961
+#: signbank/dictionary/adminviews.py:4873
 msgid "Right"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4961
+#: signbank/dictionary/adminviews.py:4873
 msgid "Left"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4961
+#: signbank/dictionary/adminviews.py:4873
 msgid "Ambidextrous"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:4961
+#: signbank/dictionary/adminviews.py:4873
 msgid "Unknown"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5011
-#: signbank/dictionary/adminviews.py:5050
-#: signbank/dictionary/adminviews.py:5090
+#: signbank/dictionary/adminviews.py:4923
+#: signbank/dictionary/adminviews.py:4962
+#: signbank/dictionary/adminviews.py:5002
 msgid "No dataset with that acronym found."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5019
+#: signbank/dictionary/adminviews.py:4931
 msgid "No permission to import speakers for this dataset."
 msgstr "Geen toestemming om gebaarders te importeren voor deze dataset."
 
-#: signbank/dictionary/adminviews.py:5026
-#: signbank/dictionary/adminviews.py:5065
-#: signbank/dictionary/adminviews.py:5109
+#: signbank/dictionary/adminviews.py:4938
+#: signbank/dictionary/adminviews.py:4977
+#: signbank/dictionary/adminviews.py:5021
 msgid "Error processing participants meta data for this dataset."
 msgstr "Er is iets misgelopen bij het verwerken van de metadata."
 
-#: signbank/dictionary/adminviews.py:5029
+#: signbank/dictionary/adminviews.py:4941
 msgid "Speakers successfully processed."
 msgstr "Gebaarders met succes bijgewerkt."
 
-#: signbank/dictionary/adminviews.py:5058
+#: signbank/dictionary/adminviews.py:4970
 msgid "No permission to create a corpus for this dataset."
 msgstr "Geen toestemming om een corpus te maken voor deze dataset."
 
-#: signbank/dictionary/adminviews.py:5069
+#: signbank/dictionary/adminviews.py:4981
 msgid "Corpus successfully created."
 msgstr "Corpus met succes gecreëerd."
 
-#: signbank/dictionary/adminviews.py:5098
+#: signbank/dictionary/adminviews.py:5010
 msgid "No permission to update the corpus for this dataset."
 msgstr "Geen toestemming om het corpus bij te werken."
 
-#: signbank/dictionary/adminviews.py:5115
+#: signbank/dictionary/adminviews.py:5027
 msgid "Corpus successfully updated."
 msgstr "Corpus met succes bijgewerkt."
 
-#: signbank/dictionary/adminviews.py:5195
+#: signbank/dictionary/adminviews.py:5107
 msgid "The requested morpheme does not exist."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5199
+#: signbank/dictionary/adminviews.py:5111
 msgid "Requested morpheme has no lemma or dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5213
+#: signbank/dictionary/adminviews.py:5125
 msgid "The morpheme you are trying to view is not in your selected datasets."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5217
+#: signbank/dictionary/adminviews.py:5130
 msgid "The morpheme you are trying to view is not in a dataset you can view."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5764
-#: signbank/dictionary/adminviews.py:5778
-#: signbank/dictionary/adminviews.py:6943 signbank/dictionary/forms.py:351
-#: signbank/dictionary/forms.py:527 signbank/dictionary/forms.py:807
-#: signbank/dictionary/forms.py:880 signbank/dictionary/forms.py:902
-#: signbank/dictionary/forms.py:1089 signbank/dictionary/forms.py:1483
-#: signbank/dictionary/forms.py:1585 signbank/dictionary/models.py:1394
-#: signbank/dictionary/models.py:2518 signbank/dictionary/models.py:2525
-#: signbank/dictionary/models.py:2532 signbank/dictionary/models.py:3866
+#: signbank/dictionary/adminviews.py:5770
+#: signbank/dictionary/adminviews.py:5784
+#: signbank/dictionary/adminviews.py:6958 signbank/dictionary/forms.py:352
+#: signbank/dictionary/forms.py:528 signbank/dictionary/forms.py:808
+#: signbank/dictionary/forms.py:881 signbank/dictionary/forms.py:903
+#: signbank/dictionary/forms.py:1090 signbank/dictionary/forms.py:1522
+#: signbank/dictionary/forms.py:1624 signbank/dictionary/models.py:1382
+#: signbank/dictionary/models.py:2616 signbank/dictionary/models.py:2623
+#: signbank/dictionary/models.py:2630 signbank/dictionary/models.py:3975
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:580
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:588
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:59
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:67
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:99
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:60
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:68
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:100
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:344
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:22
+#: signbank/dictionary/templates/dictionary/gloss.html:566
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:36
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1945
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2207
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2266
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2332
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2311
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2573
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2632
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2698
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:113
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:582
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:661
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:665
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:723
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:764
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:767
 #: signbank/dictionary/templatetags/field_choice.py:48
 #: signbank/dictionary/translate_choice_list.py:160
-#: signbank/dictionary/update.py:884 signbank/dictionary/update.py:888
-#: signbank/dictionary/update.py:895 signbank/dictionary/update.py:899
-#: signbank/dictionary/update.py:907 signbank/dictionary/update.py:911
-#: signbank/dictionary/update.py:985 signbank/dictionary/update.py:987
-#: signbank/dictionary/update.py:2584 signbank/dictionary/update.py:2586
+#: signbank/dictionary/update.py:887 signbank/dictionary/update.py:891
+#: signbank/dictionary/update.py:898 signbank/dictionary/update.py:902
+#: signbank/dictionary/update.py:910 signbank/dictionary/update.py:914
+#: signbank/dictionary/update.py:992 signbank/dictionary/update.py:994
+#: signbank/dictionary/update.py:2618 signbank/dictionary/update.py:2620
 #: signbank/dictionary/update_glosses.py:521
 #: signbank/dictionary/update_glosses.py:547 signbank/query_parameters.py:78
-#: signbank/query_parameters.py:536 signbank/query_parameters.py:539
-#: signbank/query_parameters.py:613
+#: signbank/query_parameters.py:544 signbank/query_parameters.py:547
+#: signbank/query_parameters.py:621
 msgid "Yes"
 msgstr "Ja"
 
-#: signbank/dictionary/adminviews.py:5766
-#: signbank/dictionary/adminviews.py:5780 signbank/dictionary/forms.py:353
-#: signbank/dictionary/models.py:2518 signbank/dictionary/models.py:2525
-#: signbank/dictionary/models.py:2532 signbank/dictionary/models.py:3864
+#: signbank/dictionary/adminviews.py:5772
+#: signbank/dictionary/adminviews.py:5786 signbank/dictionary/forms.py:354
+#: signbank/dictionary/models.py:2616 signbank/dictionary/models.py:2623
+#: signbank/dictionary/models.py:2630 signbank/dictionary/models.py:3973
 #: signbank/dictionary/translate_choice_list.py:171
-#: signbank/query_parameters.py:536
+#: signbank/query_parameters.py:544
 msgid "Neutral"
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:5768
-#: signbank/dictionary/adminviews.py:5782
-#: signbank/dictionary/adminviews.py:6944 signbank/dictionary/forms.py:351
-#: signbank/dictionary/forms.py:527 signbank/dictionary/forms.py:807
-#: signbank/dictionary/forms.py:880 signbank/dictionary/forms.py:902
-#: signbank/dictionary/forms.py:1089 signbank/dictionary/forms.py:1483
-#: signbank/dictionary/forms.py:1585 signbank/dictionary/models.py:1394
-#: signbank/dictionary/models.py:2518 signbank/dictionary/models.py:2525
-#: signbank/dictionary/models.py:2532 signbank/dictionary/models.py:3868
+#: signbank/dictionary/adminviews.py:5774
+#: signbank/dictionary/adminviews.py:5788
+#: signbank/dictionary/adminviews.py:6959 signbank/dictionary/forms.py:352
+#: signbank/dictionary/forms.py:528 signbank/dictionary/forms.py:808
+#: signbank/dictionary/forms.py:881 signbank/dictionary/forms.py:903
+#: signbank/dictionary/forms.py:1090 signbank/dictionary/forms.py:1522
+#: signbank/dictionary/forms.py:1624 signbank/dictionary/models.py:1382
+#: signbank/dictionary/models.py:2616 signbank/dictionary/models.py:2623
+#: signbank/dictionary/models.py:2630 signbank/dictionary/models.py:3977
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:580
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:588
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:61
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:69
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:101
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:62
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:70
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:102
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:345
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:23
+#: signbank/dictionary/templates/dictionary/gloss.html:566
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:37
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1945
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2207
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2266
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2332
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2311
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2573
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2632
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2698
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:114
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:582
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:661
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:665
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:723
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:764
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:767
 #: signbank/dictionary/templatetags/field_choice.py:46
 #: signbank/dictionary/translate_choice_list.py:157
-#: signbank/dictionary/update.py:890 signbank/dictionary/update.py:901
-#: signbank/dictionary/update.py:913 signbank/dictionary/update.py:989
-#: signbank/dictionary/update.py:2588 signbank/dictionary/update_glosses.py:521
+#: signbank/dictionary/update.py:893 signbank/dictionary/update.py:904
+#: signbank/dictionary/update.py:916 signbank/dictionary/update.py:996
+#: signbank/dictionary/update.py:2622 signbank/dictionary/update_glosses.py:521
 #: signbank/dictionary/update_glosses.py:547 signbank/query_parameters.py:78
-#: signbank/query_parameters.py:536 signbank/query_parameters.py:539
-#: signbank/query_parameters.py:615
+#: signbank/query_parameters.py:544 signbank/query_parameters.py:547
+#: signbank/query_parameters.py:623
 msgid "No"
 msgstr "Nee"
 
-#: signbank/dictionary/adminviews.py:5900
-#: signbank/dictionary/adminviews.py:5996
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:910
+#: signbank/dictionary/adminviews.py:5906
+#: signbank/dictionary/adminviews.py:6002
+#: signbank/dictionary/templates/dictionary/gloss.html:374
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1258
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:487
-#: signbank/query_parameters.py:479 signbank/query_parameters.py:695
-#: signbank/query_parameters.py:957
+#: signbank/query_parameters.py:487 signbank/query_parameters.py:703
+#: signbank/query_parameters.py:970
 msgid "Dialect"
 msgstr "Dialect"
 
-#: signbank/dictionary/adminviews.py:5901
-#: signbank/dictionary/adminviews.py:5997
+#: signbank/dictionary/adminviews.py:5907
+#: signbank/dictionary/adminviews.py:6003
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:125
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:229
 #: signbank/dictionary/templates/dictionary/unassigned_glosses.html:20
@@ -966,561 +1041,618 @@ msgstr "Dialect"
 #: signbank/feedback/templates/feedback/show_feedback_missing_signs.html:108
 #: signbank/feedback/templates/feedback/show_feedback_morphemes.html:86
 #: signbank/feedback/templates/feedback/show_feedback_signs.html:86
-#: signbank/query_parameters.py:481 signbank/query_parameters.py:956
+#: signbank/query_parameters.py:489 signbank/query_parameters.py:969
 msgid "Sign Language"
 msgstr "Gebarentaal"
 
-#: signbank/dictionary/adminviews.py:5902
-#: signbank/dictionary/adminviews.py:5998 signbank/dictionary/forms.py:289
-#: signbank/dictionary/forms.py:480 signbank/dictionary/models.py:187
-#: signbank/query_parameters.py:483
+#: signbank/dictionary/adminviews.py:5908
+#: signbank/dictionary/adminviews.py:6004 signbank/dictionary/forms.py:290
+#: signbank/dictionary/forms.py:481 signbank/dictionary/models.py:187
+#: signbank/query_parameters.py:491
 msgid "Note Type"
 msgstr "Type aantekening"
 
-#: signbank/dictionary/adminviews.py:5903
-#: signbank/dictionary/adminviews.py:5999 signbank/dictionary/forms.py:227
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2476
+#: signbank/dictionary/adminviews.py:5909
+#: signbank/dictionary/adminviews.py:6005 signbank/dictionary/forms.py:227
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2848
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:206
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:765
 msgid "Other Media"
 msgstr "Andere media"
 
-#: signbank/dictionary/adminviews.py:5906 signbank/dictionary/forms.py:609
-#: signbank/dictionary/models.py:964
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:667
+#: signbank/dictionary/adminviews.py:5912 signbank/dictionary/forms.py:610
+#: signbank/dictionary/models.py:956
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:670
 msgid "Blend"
 msgstr "Blend"
 
-#: signbank/dictionary/adminviews.py:5907
+#: signbank/dictionary/adminviews.py:5913
 #: signbank/dictionary/related_objects.py:158
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:697
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:700
 msgid "Part of Blend"
 msgstr "Onderdeel blend"
 
-#: signbank/dictionary/adminviews.py:5908
-#: signbank/dictionary/adminviews.py:6004 signbank/dictionary/forms.py:295
+#: signbank/dictionary/adminviews.py:5914
+#: signbank/dictionary/adminviews.py:6010 signbank/dictionary/forms.py:296
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:605
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:481
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:730
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:733
 msgid "Morpheme Type"
 msgstr "Morfeem-type"
 
-#: signbank/dictionary/adminviews.py:5909
-#: signbank/dictionary/adminviews.py:6005 signbank/dictionary/forms.py:234
+#: signbank/dictionary/adminviews.py:5915
+#: signbank/dictionary/adminviews.py:6011 signbank/dictionary/forms.py:235
 msgid "Gloss of Related Sign"
 msgstr "Glos van een verwant gebaar"
 
-#: signbank/dictionary/adminviews.py:5910
-#: signbank/dictionary/adminviews.py:6006 signbank/dictionary/forms.py:248
-#: signbank/dictionary/models.py:3849
+#: signbank/dictionary/adminviews.py:5916
+#: signbank/dictionary/adminviews.py:6012 signbank/dictionary/forms.py:249
+#: signbank/dictionary/models.py:3958
 msgid "Related to Foreign Sign"
 msgstr "Verwant gebaar uit andere gebarentaal"
 
-#: signbank/dictionary/adminviews.py:5911
-#: signbank/dictionary/adminviews.py:6007 signbank/dictionary/forms.py:236
+#: signbank/dictionary/adminviews.py:5917
+#: signbank/dictionary/adminviews.py:6013 signbank/dictionary/forms.py:237
 msgid "Gloss of Foreign Sign"
 msgstr "Glos in een andere gebarentaal"
 
-#: signbank/dictionary/adminviews.py:5924
+#: signbank/dictionary/adminviews.py:5930
 msgid "Relation: "
 msgstr "Relatie: "
 
-#: signbank/dictionary/adminviews.py:6002 signbank/dictionary/forms.py:240
-#: signbank/dictionary/models.py:3851
+#: signbank/dictionary/adminviews.py:6008 signbank/dictionary/forms.py:241
+#: signbank/dictionary/models.py:3960
 msgid "Is a Blend"
 msgstr "Is een blend"
 
-#: signbank/dictionary/adminviews.py:6003 signbank/dictionary/forms.py:243
-#: signbank/dictionary/models.py:3853
+#: signbank/dictionary/adminviews.py:6009 signbank/dictionary/forms.py:244
+#: signbank/dictionary/models.py:3962
 msgid "Is Part of a Blend"
 msgstr "Is onderdeel van een blend"
 
-#: signbank/dictionary/adminviews.py:6017
-#: signbank/dictionary/adminviews.py:6020 signbank/dictionary/forms.py:251
+#: signbank/dictionary/adminviews.py:6023
+#: signbank/dictionary/adminviews.py:6026 signbank/dictionary/forms.py:252
 msgid "Type of Relation"
 msgstr "Type relatie"
 
-#: signbank/dictionary/adminviews.py:6269
+#: signbank/dictionary/adminviews.py:6282
 msgid "You have no permission to delete lemmas."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6274
+#: signbank/dictionary/adminviews.py:6287
 msgid "Incorrect deletion code."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6280
 #: signbank/dictionary/adminviews.py:6293
+#: signbank/dictionary/adminviews.py:6306
 msgid ""
 "You do not have change permission on the dataset of the lemma you are "
 "attempting to delete."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6358
-#: signbank/dictionary/adminviews.py:6550
+#: signbank/dictionary/adminviews.py:6371
+#: signbank/dictionary/adminviews.py:6563
 msgid "Lemma ID Gloss is not unique for that language."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6395
+#: signbank/dictionary/adminviews.py:6408
 msgid "The specified gloss does not exist."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6414
+#: signbank/dictionary/adminviews.py:6427
 msgid "Lemma ID Gloss not unique for language."
 msgstr "Lemma-ID-Glos is niet uniek."
 
-#: signbank/dictionary/adminviews.py:6427
+#: signbank/dictionary/adminviews.py:6440
 msgid "The form contains errors."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6575
+#: signbank/dictionary/adminviews.py:6588
 msgid "The changes to the lemma have been saved."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6582
+#: signbank/dictionary/adminviews.py:6595
 msgid "There must be at least one translation for this lemma."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6606
+#: signbank/dictionary/adminviews.py:6619
 msgid "The requested lemma does not exist."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6610
+#: signbank/dictionary/adminviews.py:6623
 msgid "Requested lemma has no dataset."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6621
+#: signbank/dictionary/adminviews.py:6634
 msgid "The lemma you are trying to view is not in your selected datasets."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6625
+#: signbank/dictionary/adminviews.py:6639
 msgid "The lemma you are trying to view is not in a dataset you can view."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6639
+#: signbank/dictionary/adminviews.py:6654
 msgid "There are glosses using this lemma."
 msgstr ""
 
-#: signbank/dictionary/adminviews.py:6663
-#: signbank/dictionary/adminviews.py:6699
-#: signbank/dictionary/adminviews.py:7133
+#: signbank/dictionary/adminviews.py:6678
+#: signbank/dictionary/adminviews.py:6716
+#: signbank/dictionary/adminviews.py:7148
 msgid "Please select a single dataset to view keywords."
 msgstr "Kies alsjeblieft een enkel dataset om trefwoorden te bekijken."
 
-#: signbank/dictionary/adminviews.py:6669 signbank/dictionary/models.py:1529
+#: signbank/dictionary/adminviews.py:6684 signbank/dictionary/models.py:1521
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:459
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:504
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:604
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:471
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2293
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2659
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:684
 msgid "Text"
 msgstr "Tekst"
 
-#: signbank/dictionary/adminviews.py:6706
-#: signbank/dictionary/adminviews.py:6989
+#: signbank/dictionary/adminviews.py:6724
+#: signbank/dictionary/adminviews.py:7004
 msgid "Your query result is not glosses."
 msgstr "De resultaat van uw zoekopdracht bevat geen glossen"
 
-#: signbank/dictionary/adminviews.py:6730
+#: signbank/dictionary/adminviews.py:6748
 msgid "No glosses found."
 msgstr "Geen glossen gevonden."
 
-#: signbank/dictionary/adminviews.py:6735
-msgid ""
-"Please refine your query to retrieve fewer than 100 glosses to use this "
-"functionality."
-msgstr ""
-"Verfijn uw zoekopdracht tot minder dan 100 glossen om deze functionaliteit "
-"te gebruiken."
-
-#: signbank/dictionary/adminviews.py:6983
+#: signbank/dictionary/adminviews.py:6998
 msgid "Please select a single dataset to use Batch Edit."
 msgstr "Selecteer een enkel dataset om Batchbewerking te gebruiken."
 
-#: signbank/dictionary/adminviews.py:7197
+#: signbank/dictionary/adminviews.py:7212
 msgid "Annotated Sentence not available."
 msgstr "Voorbeeldzin niet beschikbaar"
 
-#: signbank/dictionary/adminviews.py:7493
+#: signbank/dictionary/adminviews.py:7501
 msgid "Sentence ID"
 msgstr "Voorbeeldzin ID"
 
-#: signbank/dictionary/adminviews.py:7494
+#: signbank/dictionary/adminviews.py:7502
 #: signbank/dictionary/templates/dictionary/annotated_sentence_detail.html:67
 msgid "Annotated Sentence"
 msgstr "Voorbeeldzin"
 
-#: signbank/dictionary/adminviews.py:7495 signbank/dictionary/forms.py:1559
-#: signbank/query_parameters.py:498 signbank/query_parameters.py:701
+#: signbank/dictionary/adminviews.py:7503 signbank/dictionary/forms.py:1598
+#: signbank/query_parameters.py:506 signbank/query_parameters.py:709
 msgid "Is Representative"
 msgstr "Is representatief"
 
-#: signbank/dictionary/adminviews.py:7496
+#: signbank/dictionary/adminviews.py:7504
 msgid "Annotated Video"
 msgstr "Geannoteerde video"
 
-#: signbank/dictionary/batch_edit.py:197
+#: signbank/dictionary/adminviews.py:7505
+msgid "EAF File"
+msgstr "EAF-bestand"
+
+#: signbank/dictionary/batch_edit.py:198
 msgid "Lemma field is empty."
 msgstr "Lemma-veld is leeg."
 
-#: signbank/dictionary/batch_edit.py:206 signbank/gloss_update.py:351
+#: signbank/dictionary/batch_edit.py:207 signbank/gloss_update.py:374
 msgid "More than one gloss in lemma group."
 msgstr "Meer dan een glos in lemma groep"
 
-#: signbank/dictionary/batch_edit.py:214
+#: signbank/dictionary/batch_edit.py:215
 msgid "Annotation field is empty."
 msgstr "Annotatie-veld is leeg."
 
-#: signbank/dictionary/batch_edit.py:256 signbank/gloss_update.py:398
+#: signbank/dictionary/batch_edit.py:257 signbank/gloss_update.py:421
 msgid "Annotation translations refer to different already existing glosses."
 msgstr ""
 "Annotatie-vertalingen verwijzen naar verschillende reeds bestaande glossen."
 
-#: signbank/dictionary/batch_edit.py:320
+#: signbank/dictionary/batch_edit.py:321
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:217
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:176
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:336
 #: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:178
-#: signbank/dictionary/views.py:1502
+#: signbank/dictionary/views.py:1391
 msgid "No changes were found."
 msgstr "Geen veranderingen gevonden."
 
-#: signbank/dictionary/batch_edit.py:354 signbank/dictionary/update.py:3521
+#: signbank/dictionary/batch_edit.py:355 signbank/dictionary/update.py:3558
 msgid "Gloss saved to dataset"
 msgstr "Gebaar opgeslagen"
 
-#: signbank/dictionary/forms.py:78 signbank/dictionary/forms.py:375
-#: signbank/dictionary/forms.py:1511 signbank/dictionary/models.py:3349
+#: signbank/dictionary/forms.py:78 signbank/dictionary/forms.py:376
+#: signbank/dictionary/forms.py:1550 signbank/dictionary/models.py:3458
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:346
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:212
 #: signbank/dictionary/templates/dictionary/admin_toggle_view.html:252
+#: signbank/dictionary/templates/dictionary/gloss.html:478
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:551
 #: signbank/gloss_morphology_update.py:187
 #: signbank/gloss_morphology_update.py:195
 #: signbank/gloss_morphology_update.py:201
 #: signbank/gloss_morphology_update.py:207
-#: signbank/gloss_morphology_update.py:213 signbank/gloss_update.py:568
-#: signbank/gloss_update.py:576 signbank/gloss_update.py:582
-#: signbank/gloss_update.py:588 signbank/gloss_update.py:594
-#: signbank/gloss_update.py:704 signbank/gloss_update.py:712
-#: signbank/gloss_update.py:718 signbank/gloss_update.py:724
-#: signbank/gloss_update.py:730 signbank/gloss_update.py:784
-#: signbank/gloss_update.py:792 signbank/gloss_update.py:798
-#: signbank/gloss_update.py:804 signbank/gloss_update.py:810
-#: signbank/gloss_update.py:958 signbank/gloss_update.py:966
-#: signbank/gloss_update.py:972 signbank/gloss_update.py:978
-#: signbank/gloss_update.py:984 signbank/gloss_update.py:1101
-#: signbank/gloss_update.py:1109 signbank/gloss_update.py:1115
-#: signbank/gloss_update.py:1121 signbank/gloss_update.py:1127
-#: signbank/gloss_update.py:1185 signbank/gloss_update.py:1193
-#: signbank/gloss_update.py:1199 signbank/gloss_update.py:1205
-#: signbank/gloss_update.py:1211 signbank/query_parameters.py:916
+#: signbank/gloss_morphology_update.py:213 signbank/gloss_update.py:616
+#: signbank/gloss_update.py:624 signbank/gloss_update.py:630
+#: signbank/gloss_update.py:636 signbank/gloss_update.py:642
+#: signbank/gloss_update.py:745 signbank/gloss_update.py:753
+#: signbank/gloss_update.py:759 signbank/gloss_update.py:765
+#: signbank/gloss_update.py:771 signbank/gloss_update.py:825
+#: signbank/gloss_update.py:833 signbank/gloss_update.py:839
+#: signbank/gloss_update.py:845 signbank/gloss_update.py:851
+#: signbank/gloss_update.py:999 signbank/gloss_update.py:1007
+#: signbank/gloss_update.py:1013 signbank/gloss_update.py:1019
+#: signbank/gloss_update.py:1025 signbank/gloss_update.py:1132
+#: signbank/gloss_update.py:1140 signbank/gloss_update.py:1146
+#: signbank/gloss_update.py:1152 signbank/gloss_update.py:1158
+#: signbank/gloss_update.py:1216 signbank/gloss_update.py:1224
+#: signbank/gloss_update.py:1230 signbank/gloss_update.py:1236
+#: signbank/gloss_update.py:1242 signbank/query_parameters.py:928
 msgid "Gloss"
 msgstr "Glos"
 
-#: signbank/dictionary/forms.py:142 signbank/dictionary/forms.py:588
-#: signbank/dictionary/forms.py:601
+#: signbank/dictionary/forms.py:142 signbank/dictionary/forms.py:589
+#: signbank/dictionary/forms.py:602
+#: signbank/dictionary/templates/dictionary/gloss.html:444
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:503
 #: signbank/feedback/templates/feedback/show_feedback_morphemes.html:100
 msgid "Morpheme"
 msgstr "Morfeem"
 
-#: signbank/dictionary/forms.py:221 signbank/dictionary/forms.py:458
-#: signbank/dictionary/forms.py:1059 signbank/dictionary/models.py:3920
+#: signbank/dictionary/forms.py:221 signbank/dictionary/forms.py:459
+#: signbank/dictionary/forms.py:1060 signbank/dictionary/models.py:4029
 #: templates/ASL-templates/menu.html:46 templates/global-templates/menu.html:86
 msgid "Search Gloss"
 msgstr "Glos zoeken"
 
-#: signbank/dictionary/forms.py:222 signbank/dictionary/forms.py:459
-#: signbank/dictionary/forms.py:705 signbank/dictionary/forms.py:865
-#: signbank/dictionary/forms.py:886 signbank/dictionary/forms.py:1060
+#: signbank/dictionary/forms.py:222 signbank/dictionary/forms.py:460
+#: signbank/dictionary/forms.py:706 signbank/dictionary/forms.py:866
+#: signbank/dictionary/forms.py:887 signbank/dictionary/forms.py:1061
 msgid "Sort Order"
 msgstr "Volgorde"
 
-#: signbank/dictionary/forms.py:224 signbank/dictionary/forms.py:461
-#: signbank/dictionary/forms.py:1061 signbank/query_parameters.py:522
-#: signbank/query_parameters.py:550
+#: signbank/dictionary/forms.py:224 signbank/dictionary/forms.py:462
+#: signbank/dictionary/forms.py:1062 signbank/query_parameters.py:530
+#: signbank/query_parameters.py:558
 msgid "Search Senses"
 msgstr "Zoek betekenissen"
 
-#: signbank/dictionary/forms.py:225 signbank/dictionary/forms.py:462
-#: signbank/dictionary/models.py:3855
+#: signbank/dictionary/forms.py:225 signbank/dictionary/forms.py:463
+#: signbank/dictionary/models.py:3964
 msgid "Has Video"
 msgstr "Video beschikbaar"
 
-#: signbank/dictionary/forms.py:229 signbank/dictionary/forms.py:484
-#: signbank/dictionary/models.py:3845
+#: signbank/dictionary/forms.py:229 signbank/dictionary/forms.py:485
+#: signbank/dictionary/models.py:3954
 msgid "All Definitions Published"
 msgstr "Alle definities gepubliceerd"
 
-#: signbank/dictionary/forms.py:231 signbank/dictionary/models.py:3847
+#: signbank/dictionary/forms.py:231 signbank/dictionary/models.py:3956
 msgid "Has Multiple Senses"
 msgstr "Heeft meerdere betekenissen"
 
-#: signbank/dictionary/forms.py:246 signbank/dictionary/forms.py:466
-#: signbank/dictionary/models.py:1173
+#: signbank/dictionary/forms.py:233
+msgid "Has Annotated Sentences"
+msgstr "Heeft voorbeeldzinnen"
+
+#: signbank/dictionary/forms.py:247 signbank/dictionary/forms.py:467
+#: signbank/dictionary/models.py:1165
 msgid "Phonology Other"
 msgstr "Fonologie: overig"
 
-#: signbank/dictionary/forms.py:259 signbank/dictionary/forms.py:468
-#: signbank/dictionary/forms.py:1063
+#: signbank/dictionary/forms.py:260 signbank/dictionary/forms.py:469
+#: signbank/dictionary/forms.py:1064
 msgid "Repeating Movement"
 msgstr "Herhaalde beweging"
 
-#: signbank/dictionary/forms.py:261 signbank/dictionary/forms.py:471
-#: signbank/dictionary/forms.py:1065 signbank/dictionary/models.py:1146
+#: signbank/dictionary/forms.py:262 signbank/dictionary/forms.py:472
+#: signbank/dictionary/forms.py:1066 signbank/dictionary/models.py:1138
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:585
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:868
 msgid "Alternating Movement"
 msgstr "Alternerende beweging"
 
-#: signbank/dictionary/forms.py:264 signbank/dictionary/models.py:977
+#: signbank/dictionary/forms.py:265 signbank/dictionary/models.py:969
 msgid "Weak Prop"
 msgstr "Weak Prop"
 
-#: signbank/dictionary/forms.py:266 signbank/dictionary/models.py:976
+#: signbank/dictionary/forms.py:267 signbank/dictionary/models.py:968
 msgid "Weak Drop"
 msgstr "Week Drop"
 
-#: signbank/dictionary/forms.py:269 signbank/dictionary/forms.py:274
+#: signbank/dictionary/forms.py:270 signbank/dictionary/forms.py:275
 msgid "letter"
 msgstr "letter"
 
-#: signbank/dictionary/forms.py:271 signbank/dictionary/forms.py:276
+#: signbank/dictionary/forms.py:272 signbank/dictionary/forms.py:277
 #: signbank/pages/models.py:37
 msgid "number"
 msgstr "nummer"
 
-#: signbank/dictionary/forms.py:279 signbank/dictionary/forms.py:475
+#: signbank/dictionary/forms.py:280 signbank/dictionary/forms.py:476
 msgid "Is a proposed new sign"
 msgstr "Voorstel voor nieuw gebaar"
 
-#: signbank/dictionary/forms.py:281 signbank/dictionary/forms.py:477
+#: signbank/dictionary/forms.py:282 signbank/dictionary/forms.py:478
 msgid "Is in Web Dictionary"
 msgstr "In woordenboek"
 
-#: signbank/dictionary/forms.py:283 signbank/dictionary/models.py:1059
+#: signbank/dictionary/forms.py:284 signbank/dictionary/models.py:1051
 msgid "Exclude from ECV"
 msgstr "Buiten ECV houden"
 
-#: signbank/dictionary/forms.py:292 signbank/dictionary/forms.py:482
-#: signbank/dictionary/models.py:3910
+#: signbank/dictionary/forms.py:293 signbank/dictionary/forms.py:483
+#: signbank/dictionary/models.py:4019
 msgid "Note Contains"
 msgstr "Aantekening bevat"
 
-#: signbank/dictionary/forms.py:299 signbank/dictionary/forms.py:494
-#: signbank/dictionary/forms.py:1037 signbank/dictionary/models.py:3912
+#: signbank/dictionary/forms.py:300 signbank/dictionary/forms.py:495
+#: signbank/dictionary/forms.py:1038 signbank/dictionary/models.py:4021
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:317
 #: signbank/dictionary/templates/dictionary/admin_toggle_view.html:226
 msgid "Created By"
 msgstr "Toegevoegd door"
 
-#: signbank/dictionary/forms.py:300 signbank/dictionary/forms.py:490
-#: signbank/dictionary/models.py:3916
+#: signbank/dictionary/forms.py:301 signbank/dictionary/forms.py:491
+#: signbank/dictionary/models.py:4025
 msgid "Created After"
 msgstr "Aangemaakt na"
 
-#: signbank/dictionary/forms.py:303 signbank/dictionary/forms.py:487
-#: signbank/dictionary/models.py:3914
+#: signbank/dictionary/forms.py:304 signbank/dictionary/forms.py:488
+#: signbank/dictionary/models.py:4023
 msgid "Created Before"
 msgstr "Toegevoegd vóór"
 
-#: signbank/dictionary/forms.py:353 signbank/dictionary/forms.py:355
-#: signbank/dictionary/models.py:3870
+#: signbank/dictionary/forms.py:354 signbank/dictionary/forms.py:356
+#: signbank/dictionary/models.py:3979
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:138
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:176
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:200
-#: signbank/query_parameters.py:537 signbank/query_parameters.py:538
+#: signbank/query_parameters.py:545 signbank/query_parameters.py:546
 msgid "True"
 msgstr "Ja"
 
-#: signbank/dictionary/forms.py:353 signbank/dictionary/forms.py:355
-#: signbank/dictionary/models.py:3872
+#: signbank/dictionary/forms.py:354 signbank/dictionary/forms.py:356
+#: signbank/dictionary/models.py:3981
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:140
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:178
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:202
-#: signbank/query_parameters.py:537 signbank/query_parameters.py:538
+#: signbank/query_parameters.py:545 signbank/query_parameters.py:546
 msgid "False"
 msgstr "Nee"
 
-#: signbank/dictionary/forms.py:389 signbank/dictionary/forms.py:885
-#: signbank/dictionary/forms.py:933 signbank/dictionary/forms.py:982
-#: signbank/dictionary/forms.py:1505
+#: signbank/dictionary/forms.py:390 signbank/dictionary/forms.py:886
+#: signbank/dictionary/forms.py:934 signbank/dictionary/forms.py:983
+#: signbank/dictionary/forms.py:1544
 #: signbank/dictionary/templates/dictionary/add_morpheme.html:116
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:431
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:561
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:959
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:135
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:166
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:196
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:239
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:271
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:310
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:348
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1307
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:429
-#: signbank/query_parameters.py:934
+#: signbank/query_parameters.py:946
 msgid "Lemma"
 msgstr ""
 
-#: signbank/dictionary/forms.py:464 signbank/dictionary/models.py:955
+#: signbank/dictionary/forms.py:465 signbank/dictionary/models.py:947
 msgid "Annotation instructions"
 msgstr "Annotatieinstructies"
 
-#: signbank/dictionary/forms.py:532
+#: signbank/dictionary/forms.py:533
 msgid "Enter New Note"
 msgstr "Vul nieuwe aantekening in"
 
-#: signbank/dictionary/forms.py:540 signbank/dictionary/forms.py:586
-#: signbank/dictionary/forms.py:625 signbank/dictionary/forms.py:1480
-#: signbank/dictionary/models.py:1528 signbank/dictionary/models.py:3040
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2292
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2491
+#: signbank/dictionary/forms.py:541 signbank/dictionary/forms.py:587
+#: signbank/dictionary/forms.py:626 signbank/dictionary/forms.py:1519
+#: signbank/dictionary/models.py:1520 signbank/dictionary/models.py:3138
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2658
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2863
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:683
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:774
 #: signbank/dictionary/templates/dictionary/senselist_headerrow.html:52
 msgid "Type"
 msgstr "Type"
 
-#: signbank/dictionary/forms.py:551 signbank/dictionary/forms.py:563
-#: signbank/dictionary/forms.py:572
+#: signbank/dictionary/forms.py:552 signbank/dictionary/forms.py:564
+#: signbank/dictionary/forms.py:573
 msgid "Source Gloss"
 msgstr "Bron-glos"
 
-#: signbank/dictionary/forms.py:552 signbank/dictionary/forms.py:564
+#: signbank/dictionary/forms.py:553 signbank/dictionary/forms.py:565
 msgid "Target Gloss"
 msgstr "Doel-glos"
 
-#: signbank/dictionary/forms.py:573
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2168
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2222
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:754
+#: signbank/dictionary/forms.py:574
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2534
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2588
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:757
 msgid "Related Language"
 msgstr "Verwante taal"
 
-#: signbank/dictionary/forms.py:574
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2169
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2223
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:755
+#: signbank/dictionary/forms.py:575
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2535
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2589
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:758
 msgid "Gloss in Related Language"
 msgstr "Glos in een verwante taal"
 
-#: signbank/dictionary/forms.py:585
+#: signbank/dictionary/forms.py:586
 msgid "Parent Gloss"
 msgstr "Ouder-glos"
 
-#: signbank/dictionary/forms.py:599 signbank/dictionary/forms.py:607
+#: signbank/dictionary/forms.py:600 signbank/dictionary/forms.py:608
 msgid "Host Gloss"
 msgstr "Ouder-glos"
 
-#: signbank/dictionary/forms.py:600
+#: signbank/dictionary/forms.py:601
 #: signbank/feedback/templates/feedback/show_feedback_missing_signs.html:114
 msgid "Meaning"
 msgstr "Betekenis"
 
-#: signbank/dictionary/forms.py:608
+#: signbank/dictionary/forms.py:609
 msgid "Role"
 msgstr "Rol"
 
-#: signbank/dictionary/forms.py:641
+#: signbank/dictionary/forms.py:642
 msgid "Please choose a type description when uploading other media."
 msgstr ""
 
-#: signbank/dictionary/forms.py:648
+#: signbank/dictionary/forms.py:649
 msgid "Please choose a video or image file to upload."
 msgstr ""
 
-#: signbank/dictionary/forms.py:755
+#: signbank/dictionary/forms.py:756
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:363
 msgid "Unselected Fingers Extended"
 msgstr "Gestrekte ongeselecteerde vingers"
 
-#: signbank/dictionary/forms.py:763 signbank/dictionary/models.py:302
+#: signbank/dictionary/forms.py:764 signbank/dictionary/models.py:302
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:361
 msgid "Quantity"
 msgstr "Aantal"
 
-#: signbank/dictionary/forms.py:771 signbank/dictionary/models.py:320
+#: signbank/dictionary/forms.py:772 signbank/dictionary/models.py:320
 msgid "Finger configuration"
 msgstr "Vingerconfiguratie"
 
-#: signbank/dictionary/forms.py:779 signbank/dictionary/models.py:326
+#: signbank/dictionary/forms.py:780 signbank/dictionary/models.py:326
 msgid "Finger configuration 2"
 msgstr "Vingerconfiguratie 2"
 
-#: signbank/dictionary/forms.py:787 signbank/dictionary/models.py:344
+#: signbank/dictionary/forms.py:788 signbank/dictionary/models.py:344
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:364
 msgid "Spreading"
 msgstr "Spreiding"
 
-#: signbank/dictionary/forms.py:795 signbank/dictionary/models.py:332
+#: signbank/dictionary/forms.py:796 signbank/dictionary/models.py:332
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:365
 msgid "Aperture"
 msgstr "Opening"
 
-#: signbank/dictionary/forms.py:864
+#: signbank/dictionary/forms.py:865
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:245
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:340
 msgid "Search"
 msgstr "Zoeken"
 
-#: signbank/dictionary/forms.py:866 signbank/dictionary/forms.py:887
+#: signbank/dictionary/forms.py:867 signbank/dictionary/forms.py:888
 msgid "Only show results without glosses"
 msgstr "Alleen resultaten tonen zonder glossen"
 
-#: signbank/dictionary/forms.py:868 signbank/dictionary/forms.py:889
+#: signbank/dictionary/forms.py:869 signbank/dictionary/forms.py:890
 msgid "Only show results with glosses"
 msgstr "Alleen resultaten tonen met glossen"
 
-#: signbank/dictionary/forms.py:1181
+#: signbank/dictionary/forms.py:1113
+msgid "Days"
+msgstr "Dagen"
+
+#: signbank/dictionary/forms.py:1114
+msgid "90 days"
+msgstr "90 dagen"
+
+#: signbank/dictionary/forms.py:1115
+msgid "60 days"
+msgstr "60 dagen"
+
+#: signbank/dictionary/forms.py:1116
+msgid "30 days"
+msgstr "30 dagen"
+
+#: signbank/dictionary/forms.py:1117
+msgid "14 days"
+msgstr "14 dagen"
+
+#: signbank/dictionary/forms.py:1118
+msgid "7 days"
+msgstr "7 dagen"
+
+#: signbank/dictionary/forms.py:1121
+msgid "Chronological"
+msgstr "Chronologisch"
+
+#: signbank/dictionary/forms.py:1121
+msgid "Reverse chronological"
+msgstr "Omgekeerd chronologisch"
+
+#: signbank/dictionary/forms.py:1123
+msgid "Timeline"
+msgstr "Tijdlijn"
+
+#: signbank/dictionary/forms.py:1126
+msgid "Time Field"
+msgstr "Tijd veld"
+
+#: signbank/dictionary/forms.py:1127 signbank/dictionary/models.py:1231
+msgid "Creation date"
+msgstr "Aanmaakdatum"
+
+#: signbank/dictionary/forms.py:1127 signbank/dictionary/models.py:1232
+msgid "Last updated"
+msgstr "Laatste update"
+
+#: signbank/dictionary/forms.py:1220
 msgid "The Field Choice Category is required"
 msgstr ""
 
-#: signbank/dictionary/forms.py:1191
+#: signbank/dictionary/forms.py:1230
 msgid "The Name fields for all languages are required"
 msgstr ""
 
-#: signbank/dictionary/forms.py:1198 signbank/dictionary/forms.py:1208
+#: signbank/dictionary/forms.py:1237 signbank/dictionary/forms.py:1247
 msgid "The combination "
 msgstr "De combinatie "
 
-#: signbank/dictionary/forms.py:1354 signbank/dictionary/forms.py:1374
-#: signbank/dictionary/forms.py:1395 signbank/dictionary/models.py:3702
+#: signbank/dictionary/forms.py:1393 signbank/dictionary/forms.py:1413
+#: signbank/dictionary/forms.py:1434 signbank/dictionary/models.py:3811
 #: signbank/dictionary/templates/dictionary/admin_frequency_list.html:248
 #: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:404
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2005
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2371
 #: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:7
 msgid "Field Name"
 msgstr "Veldnaam"
 
-#: signbank/dictionary/forms.py:1358 signbank/dictionary/forms.py:1378
-#: signbank/dictionary/models.py:3703 signbank/dictionary/models.py:3839
+#: signbank/dictionary/forms.py:1397 signbank/dictionary/forms.py:1417
+#: signbank/dictionary/models.py:3812 signbank/dictionary/models.py:3948
 msgid "Field Value"
 msgstr "Veld waarde"
 
-#: signbank/dictionary/forms.py:1399
+#: signbank/dictionary/forms.py:1438
 msgid "Language"
 msgstr "Taal"
 
-#: signbank/dictionary/forms.py:1440 signbank/dictionary/forms.py:1445
+#: signbank/dictionary/forms.py:1479 signbank/dictionary/forms.py:1484
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:128
 msgid "Parameters"
 msgstr ""
 
-#: signbank/dictionary/forms.py:1454
+#: signbank/dictionary/forms.py:1493
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:143
 #: signbank/dictionary/templates/dictionary/senselist_headerrow.html:54
-#: signbank/query_parameters.py:496 signbank/query_parameters.py:699
+#: signbank/query_parameters.py:504 signbank/query_parameters.py:707
 msgid "Negative"
 msgstr "Negatief"
 
-#: signbank/dictionary/forms.py:1456 signbank/query_parameters.py:500
-#: signbank/query_parameters.py:703
+#: signbank/dictionary/forms.py:1495 signbank/query_parameters.py:508
+#: signbank/query_parameters.py:711
 msgid "Sentence Contains"
 msgstr "Betekenis bevat"
 
-#: signbank/dictionary/forms.py:1543
+#: signbank/dictionary/forms.py:1582
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:392
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:541
 #: signbank/dictionary/templates/dictionary/senselist_headerrow.html:17
-#: signbank/dictionary/views.py:2577
+#: signbank/dictionary/views.py:2538
 msgid "Sense"
 msgstr "Betekenis"
 
-#: signbank/dictionary/forms.py:1561 signbank/query_parameters.py:502
-#: signbank/query_parameters.py:705
+#: signbank/dictionary/forms.py:1600 signbank/query_parameters.py:510
+#: signbank/query_parameters.py:713
 msgid "Annotated Sentence Contains"
 msgstr "Voorbeeldzin bevat"
 
@@ -1624,454 +1756,476 @@ msgstr "ISO 639-3 taalcode (3 karakters) van een geschreven taal."
 
 #: signbank/dictionary/models.py:560
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:142
-#: signbank/query_parameters.py:697
+#: signbank/query_parameters.py:705
 msgid "Sentence Type"
 msgstr "Zintype"
 
-#: signbank/dictionary/models.py:697
+#: signbank/dictionary/models.py:689
 msgid "Example sentences"
 msgstr "Voorbeeldzinnen"
 
-#: signbank/dictionary/models.py:698
+#: signbank/dictionary/models.py:690
 msgid "Examplesentences in this Sense"
 msgstr "Voorbeeldzinnen voor dit betekenis"
 
-#: signbank/dictionary/models.py:859 signbank/dictionary/models.py:2753
+#: signbank/dictionary/models.py:851 signbank/dictionary/models.py:2851
 msgid "Order"
 msgstr "Volgorde"
 
-#: signbank/dictionary/models.py:860
+#: signbank/dictionary/models.py:852
 msgid "What order to display this examplesentence within the sense."
 msgstr "Op welke volgorde deze betekenis-voorbeeldzin te tonen."
 
-#: signbank/dictionary/models.py:867
+#: signbank/dictionary/models.py:859
 msgid "Sense exampleSentence"
 msgstr "Betekenis voorbeeldzin"
 
-#: signbank/dictionary/models.py:868
+#: signbank/dictionary/models.py:860
 msgid "Sense exampleSentences"
 msgstr "Betekenis voorbeeldzinnen"
 
-#: signbank/dictionary/models.py:936
-#: signbank/dictionary/templates/dictionary/update_lemma.html:138
+#: signbank/dictionary/models.py:928
+#: signbank/dictionary/templates/dictionary/update_lemma.html:187
 msgid "Archived"
 msgstr "Gearchiveerd"
 
-#: signbank/dictionary/models.py:944
+#: signbank/dictionary/models.py:936
 msgid "BSL sign"
 msgstr "BSL-gebaar"
 
-#: signbank/dictionary/models.py:945
+#: signbank/dictionary/models.py:937
 msgid "ASL sign"
 msgstr "ASL-gebaar"
 
-#: signbank/dictionary/models.py:948
+#: signbank/dictionary/models.py:940
 msgid "ASL gloss"
 msgstr "ASL-glos"
 
-#: signbank/dictionary/models.py:949
+#: signbank/dictionary/models.py:941
 msgid "ASL loan sign"
 msgstr "Leengebaar uit ASL"
 
-#: signbank/dictionary/models.py:952
+#: signbank/dictionary/models.py:944
 msgid "BSL gloss"
 msgstr "BSL-glos"
 
-#: signbank/dictionary/models.py:953
+#: signbank/dictionary/models.py:945
 msgid "BSL loan sign"
 msgstr "Leengebaar uit BSL"
 
-#: signbank/dictionary/models.py:956
+#: signbank/dictionary/models.py:948
 msgid "Remarks"
 msgstr "Opmerkingen"
 
-#: signbank/dictionary/models.py:963
+#: signbank/dictionary/models.py:955
 msgid "Blend of"
 msgstr "Blend van"
 
-#: signbank/dictionary/models.py:966
+#: signbank/dictionary/models.py:958
 msgid "Compound of"
 msgstr "Samenstelling van"
 
-#: signbank/dictionary/models.py:967
+#: signbank/dictionary/models.py:959
 msgid "Compound"
 msgstr "Samenstelling"
 
-#: signbank/dictionary/models.py:988
+#: signbank/dictionary/models.py:980
 msgid "Strong hand number"
 msgstr "Sterke hand cijfer"
 
-#: signbank/dictionary/models.py:989
+#: signbank/dictionary/models.py:981
 msgid "Strong hand letter"
 msgstr "Sterke hand letter"
 
-#: signbank/dictionary/models.py:990
+#: signbank/dictionary/models.py:982
 msgid "Weak hand number"
 msgstr "Zwakke hand cijfer"
 
-#: signbank/dictionary/models.py:991
+#: signbank/dictionary/models.py:983
 msgid "Weak hand letter"
 msgstr "Zwakke hand letter"
 
-#: signbank/dictionary/models.py:994
+#: signbank/dictionary/models.py:986
 msgid "Final Dominant Handshape"
 msgstr ""
 
-#: signbank/dictionary/models.py:998
+#: signbank/dictionary/models.py:990
 msgid "Final Subordinate Handshape"
 msgstr ""
 
-#: signbank/dictionary/models.py:1010
+#: signbank/dictionary/models.py:1002
 msgid "Final Primary Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:1013
+#: signbank/dictionary/models.py:1005
 msgid "Virtual Object"
 msgstr "Virtueel object"
 
-#: signbank/dictionary/models.py:1018
+#: signbank/dictionary/models.py:1010
 msgid "Secondary Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:1024
+#: signbank/dictionary/models.py:1016
 msgid "Initial Subordinate Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:1030
+#: signbank/dictionary/models.py:1022
 msgid "Final Subordinate Location"
 msgstr ""
 
-#: signbank/dictionary/models.py:1034
+#: signbank/dictionary/models.py:1026
 msgid "Initial Palm Orientation"
 msgstr ""
 
-#: signbank/dictionary/models.py:1035
+#: signbank/dictionary/models.py:1027
 msgid "Final Palm Orientation"
 msgstr ""
 
-#: signbank/dictionary/models.py:1037
+#: signbank/dictionary/models.py:1029
 msgid "Initial Interacting Dominant Hand Part"
 msgstr ""
 
-#: signbank/dictionary/models.py:1039
+#: signbank/dictionary/models.py:1031
 msgid "Final Interacting Dominant Hand Part"
 msgstr ""
 
-#: signbank/dictionary/models.py:1054
+#: signbank/dictionary/models.py:1046
 msgid "Abduction change"
 msgstr "Abductieverandering"
 
-#: signbank/dictionary/models.py:1055
+#: signbank/dictionary/models.py:1047
 msgid "Flexion change"
 msgstr "Flectieverandering"
 
-#: signbank/dictionary/models.py:1057
+#: signbank/dictionary/models.py:1049
 msgid "In the Web dictionary"
 msgstr "In het woordenboek"
 
-#: signbank/dictionary/models.py:1058
+#: signbank/dictionary/models.py:1050
 msgid "Is this a proposed new sign?"
 msgstr "Voorstel voor nieuw gebaar?"
 
-#: signbank/dictionary/models.py:1063
+#: signbank/dictionary/models.py:1055
 msgid "Morphemic Analysis"
 msgstr "Morfeemanalyse"
 
-#: signbank/dictionary/models.py:1068
+#: signbank/dictionary/models.py:1060
 msgid "Signed English definition available"
 msgstr ""
 
-#: signbank/dictionary/models.py:1070
+#: signbank/dictionary/models.py:1062
 msgid "Signed English gloss"
 msgstr ""
 
-#: signbank/dictionary/models.py:1072
+#: signbank/dictionary/models.py:1064
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:141
 msgid "Sense Number"
 msgstr ""
 
-#: signbank/dictionary/models.py:1080
+#: signbank/dictionary/models.py:1072
 msgid "Senses in this Gloss"
 msgstr "Betekenissen deze glos"
 
-#: signbank/dictionary/models.py:1094
+#: signbank/dictionary/models.py:1086
 msgid "Sign Number"
 msgstr "Gebaarnummer"
 
-#: signbank/dictionary/models.py:1106
+#: signbank/dictionary/models.py:1098
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:537
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:754
 msgid "Relation between Articulators"
 msgstr "Relatie tussen articulatoren"
 
-#: signbank/dictionary/models.py:1112
+#: signbank/dictionary/models.py:1104
 msgid "Absolute Orientation: Palm"
 msgstr "Absolute oriëntatie: palm"
 
-#: signbank/dictionary/models.py:1118
+#: signbank/dictionary/models.py:1110
 msgid "Absolute Orientation: Fingers"
 msgstr "Absolute oriëntatie: vingers"
 
-#: signbank/dictionary/models.py:1124
+#: signbank/dictionary/models.py:1116
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:593
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:887
 msgid "Relative Orientation: Movement"
 msgstr "Relatieve oriëntatie: beweging"
 
-#: signbank/dictionary/models.py:1130
+#: signbank/dictionary/models.py:1122
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:601
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:906
 msgid "Relative Orientation: Location"
 msgstr "Relatieve oriëntatie: locatie"
 
-#: signbank/dictionary/models.py:1136
+#: signbank/dictionary/models.py:1128
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:609
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:925
 msgid "Orientation Change"
 msgstr "Oriëntatieverandering"
 
-#: signbank/dictionary/models.py:1142
+#: signbank/dictionary/models.py:1134
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:529
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:735
 msgid "Handshape Change"
 msgstr "Handvormverandering"
 
-#: signbank/dictionary/models.py:1145
+#: signbank/dictionary/models.py:1137
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:577
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:849
 msgid "Repeated Movement"
 msgstr "Herhaalde beweging"
 
-#: signbank/dictionary/models.py:1151
+#: signbank/dictionary/models.py:1143
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:561
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:811
 msgid "Movement Shape"
 msgstr "Vorm van de beweging"
 
-#: signbank/dictionary/models.py:1157
+#: signbank/dictionary/models.py:1149
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:569
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:830
 msgid "Movement Direction"
 msgstr "Richting van de beweging"
 
-#: signbank/dictionary/models.py:1163
+#: signbank/dictionary/models.py:1155
 msgid "Movement Manner"
 msgstr "Manier van bewegen"
 
-#: signbank/dictionary/models.py:1169
+#: signbank/dictionary/models.py:1161
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:553
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:792
 msgid "Contact Type"
 msgstr "Type contact"
 
-#: signbank/dictionary/models.py:1175
+#: signbank/dictionary/models.py:1167
 msgid "Mouth Gesture"
 msgstr "Orale component"
 
-#: signbank/dictionary/models.py:1176
+#: signbank/dictionary/models.py:1168
 msgid "Mouthing"
 msgstr "Gesproken component"
 
-#: signbank/dictionary/models.py:1177
+#: signbank/dictionary/models.py:1169
 msgid "Phonetic Variation"
 msgstr "Fonetische variatie"
 
-#: signbank/dictionary/models.py:1182
+#: signbank/dictionary/models.py:1174
 msgid "Placement Active Articulator LH"
 msgstr ""
 
-#: signbank/dictionary/models.py:1185
+#: signbank/dictionary/models.py:1177
 msgid "Placement Focal Site RH"
 msgstr ""
 
-#: signbank/dictionary/models.py:1186
+#: signbank/dictionary/models.py:1178
 msgid "Placement Focal site LH"
 msgstr ""
 
-#: signbank/dictionary/models.py:1187
+#: signbank/dictionary/models.py:1179
 msgid "Orientation RH (initial)"
 msgstr ""
 
-#: signbank/dictionary/models.py:1188
+#: signbank/dictionary/models.py:1180
 msgid "Orientation RH (final)"
 msgstr ""
 
-#: signbank/dictionary/models.py:1189
+#: signbank/dictionary/models.py:1181
 msgid "Orientation LH (initial)"
 msgstr ""
 
-#: signbank/dictionary/models.py:1190
+#: signbank/dictionary/models.py:1182
 msgid "Orientation LH (final)"
 msgstr ""
 
-#: signbank/dictionary/models.py:1194
+#: signbank/dictionary/models.py:1186
 msgid "Iconic Image"
 msgstr "Iconisch beeld"
 
-#: signbank/dictionary/models.py:1199
+#: signbank/dictionary/models.py:1191
 msgid "Type of iconicity"
 msgstr "Type iconiciteit"
 
-#: signbank/dictionary/models.py:1214
+#: signbank/dictionary/models.py:1206
 msgid "Word class"
 msgstr "Woordsoort"
 
-#: signbank/dictionary/models.py:1220
+#: signbank/dictionary/models.py:1212
 msgid "Word class 2"
 msgstr "Woordsoort 2"
 
-#: signbank/dictionary/models.py:1223
+#: signbank/dictionary/models.py:1215
 msgid "Derivation history"
 msgstr "Derivatieachtergrond"
 
-#: signbank/dictionary/models.py:1225
+#: signbank/dictionary/models.py:1217
 msgid "Lexical category notes"
 msgstr "Opmerkingen over woordsoort"
 
-#: signbank/dictionary/models.py:1230
+#: signbank/dictionary/models.py:1222
 msgid "Valence"
 msgstr "Valence"
 
-#: signbank/dictionary/models.py:1233
+#: signbank/dictionary/models.py:1225
 msgid "Concepticon Concept Set"
 msgstr ""
 
-#: signbank/dictionary/models.py:1236
+#: signbank/dictionary/models.py:1228
 msgid "Number of Occurrences"
 msgstr "Aantal voorkomens"
 
-#: signbank/dictionary/models.py:1237
+#: signbank/dictionary/models.py:1229
 msgid "Number of Signers"
 msgstr "Aantal gebaarders"
 
-#: signbank/dictionary/models.py:1239
-msgid "Creation date"
-msgstr "Aanmaakdatum"
-
-#: signbank/dictionary/models.py:1240
-msgid "Last updated"
-msgstr "Laatste update"
-
-#: signbank/dictionary/models.py:1526
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2290
+#: signbank/dictionary/models.py:1518
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2656
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:681
 msgid "Published"
 msgstr "Gepubliceerd"
 
-#: signbank/dictionary/models.py:1527 signbank/dictionary/models.py:1566
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1484
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1523
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2291
+#: signbank/dictionary/models.py:1519 signbank/dictionary/models.py:1579
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1849
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1888
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2657
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:682
-#: signbank/gloss_update.py:836 signbank/gloss_update.py:1026
+#: signbank/gloss_update.py:877 signbank/gloss_update.py:1070
 msgid "Index"
 msgstr "Volgorde"
 
-#: signbank/dictionary/models.py:1568
+#: signbank/dictionary/models.py:1581 signbank/dictionary/models.py:4338
 #: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:44
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:115
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:117
 #: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:49
 #: signbank/dictionary/templates/dictionary/semanticfield_detail.html:73
-#: signbank/gloss_update.py:839 signbank/gloss_update.py:844
-#: signbank/gloss_update.py:846 signbank/gloss_update.py:1057
-#: signbank/video/forms.py:42 signbank/video/forms.py:43
+#: signbank/gloss_update.py:880 signbank/gloss_update.py:885
+#: signbank/gloss_update.py:887 signbank/gloss_update.py:1088
+#: signbank/video/forms.py:51 signbank/video/forms.py:52
 msgid "Description"
 msgstr "Omschrijving"
 
-#: signbank/dictionary/models.py:2754
+#: signbank/dictionary/models.py:2852
 msgid "What order to display this sense within the gloss."
 msgstr ""
 
-#: signbank/dictionary/models.py:2759
+#: signbank/dictionary/models.py:2857
 msgid "Gloss sense"
 msgstr "Glos-betekenis"
 
-#: signbank/dictionary/models.py:2760
+#: signbank/dictionary/models.py:2858
 msgid "Gloss senses"
 msgstr "Glos-betekenissen"
 
-#: signbank/dictionary/models.py:2806
+#: signbank/dictionary/models.py:2904
 msgid "Morphology Type"
 msgstr "Morfologie-type"
 
-#: signbank/dictionary/models.py:2834
+#: signbank/dictionary/models.py:2932
 msgid "Has morpheme type"
 msgstr "Heeft morfeem-type"
 
-#: signbank/dictionary/models.py:3311 signbank/dictionary/models.py:3317
+#: signbank/dictionary/models.py:3420 signbank/dictionary/models.py:3426
 msgid "Token"
 msgstr ""
 
-#: signbank/dictionary/models.py:3312
+#: signbank/dictionary/models.py:3421
 msgid "Signbank User"
 msgstr "Signbank-gebruiker"
 
-#: signbank/dictionary/models.py:3314
+#: signbank/dictionary/models.py:3423
 msgid "Created"
 msgstr "Toegevoegd"
 
-#: signbank/dictionary/models.py:3318
+#: signbank/dictionary/models.py:3427
 msgid "Tokens"
 msgstr ""
 
-#: signbank/dictionary/models.py:3459
+#: signbank/dictionary/models.py:3568
 msgid "Dataset a lemma is part of"
 msgstr "Dataset waar een lemma in zit"
 
-#: signbank/dictionary/models.py:3485
+#: signbank/dictionary/models.py:3594
 msgid "Lemma ID Gloss translation"
 msgstr "Lemma-ID-Glos vertaling"
 
-#: signbank/dictionary/models.py:3601
+#: signbank/dictionary/models.py:3710
 msgid "Multiple Select"
 msgstr ""
 
-#: signbank/dictionary/models.py:3602
+#: signbank/dictionary/models.py:3711
 msgid "Is this a multiselect parameter?"
 msgstr ""
 
-#: signbank/dictionary/models.py:3744
+#: signbank/dictionary/models.py:3853
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:355
 msgid "Handshape"
 msgstr "Handvorm"
 
-#: signbank/dictionary/models.py:3790
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2034
+#: signbank/dictionary/models.py:3899
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2400
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:611
 msgid "Derivation History"
 msgstr "Derivatieachtergrond"
 
-#: signbank/dictionary/models.py:3838
+#: signbank/dictionary/models.py:3947
 msgid "NullBooleanField"
 msgstr ""
 
-#: signbank/dictionary/models.py:3857
+#: signbank/dictionary/models.py:3966
 msgid "Has Other Media"
 msgstr "Heeft andere media"
 
-#: signbank/dictionary/models.py:3902
+#: signbank/dictionary/models.py:4011
 msgid "Text Search Field"
 msgstr "Tekst zoekveld"
 
-#: signbank/dictionary/models.py:3904
+#: signbank/dictionary/models.py:4013
 msgid "Text Search Value"
 msgstr "Tekst zoek waarde"
 
-#: signbank/dictionary/models.py:3918
+#: signbank/dictionary/models.py:4027
 msgid "Search Translation"
 msgstr "Vertaling zoeken"
 
-#: signbank/dictionary/models.py:3937
+#: signbank/dictionary/models.py:4046
 msgid "Query Date"
 msgstr "Query-datum"
 
-#: signbank/dictionary/models.py:3940
+#: signbank/dictionary/models.py:4049
 msgid "Abbreviation for the query"
 msgstr "Afkorting voor de query"
 
+#: signbank/dictionary/models.py:4335
+#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:34
+#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:35
+#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:22
+#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:356
+#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:22
+msgid "Name"
+msgstr "Naam"
+
+#: signbank/dictionary/models.py:4336
+#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:195
+msgid "Lemmas"
+msgstr "Lemmata"
+
+#: signbank/dictionary/models.py:4337
+msgid "Url"
+msgstr ""
+
+#: signbank/dictionary/models.py:4339
+#: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:211
+#: signbank/dictionary/templates/dictionary/annotated_sentence_detail.html:126
+#: signbank/dictionary/templates/dictionary/gloss.html:644
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2781
+#: signbank/dictionary/templates/dictionary/lemma_frequency.html:93
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:168
+#: signbank/dictionary/templates/dictionary/update_lemma.html:166
+msgid "Glosses"
+msgstr "Glossen"
+
 #: signbank/dictionary/related_objects.py:73
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:502
+#: signbank/dictionary/templates/dictionary/gloss.html:232
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:688
 #: signbank/dictionary/templates/dictionary/gloss_frequency.html:1343
 #: signbank/dictionary/templates/dictionary/gloss_revision_history.html:43
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:86
@@ -2113,9 +2267,14 @@ msgstr "Bron:"
 
 #: signbank/dictionary/templates/dictionary/add_annotated_sentence.html:70
 #: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:135
-#: signbank/query_parameters.py:537 signbank/query_parameters.py:538
+#: signbank/query_parameters.py:545 signbank/query_parameters.py:546
 msgid "-"
 msgstr "-"
+
+#: signbank/dictionary/templates/dictionary/add_annotated_sentence.html:77
+#: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:142
+msgid "Url:"
+msgstr ""
 
 #: signbank/dictionary/templates/dictionary/add_gloss.html:9
 msgid "Signbank: Add New Sign"
@@ -2182,7 +2341,7 @@ msgid "Add New Morpheme"
 msgstr "Voeg nieuw morfeem toe"
 
 #: signbank/dictionary/templates/dictionary/add_nme_video.html:21
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1502
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1867
 msgid "Upload New NME Video"
 msgstr "Nieuwe NME-video uploaden"
 
@@ -2211,14 +2370,14 @@ msgid "Search by Language and Basic Properties"
 msgstr "Zoek op Taal en Basiseigenschappen"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:663
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:806
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:807
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:391
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:665
 msgid "Search by Phonology"
 msgstr "Zoek op Fonologie"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:704
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:844
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:848
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:419
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:706
 msgid "Search by Semantics"
@@ -2230,7 +2389,7 @@ msgid "Search Annotated Gloss"
 msgstr "Zoek glos met voorbeeldzin"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:753
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:887
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:888
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:447
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:758
 msgid "Search by Publication Status and Notes"
@@ -2240,7 +2399,7 @@ msgstr "Zoek op Publicatiestatus en Aantekeningen"
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:183
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_senses.html:282
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:327
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:955
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:956
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:334
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:200
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:191
@@ -2259,7 +2418,7 @@ msgstr "Glossen met voorbeeldzin"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:790
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:188
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:982
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:983
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:345
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:509
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:198
@@ -2270,7 +2429,7 @@ msgstr "Aantal hits:"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:790
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:188
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:982
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:985
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:345
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:509
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:198
@@ -2281,7 +2440,7 @@ msgstr "van"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:793
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:191
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:985
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:988
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:511
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:201
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:798
@@ -2289,14 +2448,15 @@ msgid "Datasets:"
 msgstr "Datasets:"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:805
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:999
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1002
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:489
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:810
 msgid "Results Per Page"
 msgstr "Hits per pagina"
 
-#: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:814
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1008
+#: signbank/dictionary/templates/dictionary/admin_annotatedgloss_list.html:812
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:114
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:1011
 #: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:394
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:496
 #: signbank/dictionary/templates/dictionary/admin_senses_list.html:819
@@ -2316,19 +2476,6 @@ msgstr "Zoek voorbeeldzin"
 msgid "Show All"
 msgstr "Laat alles zien"
 
-#: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:208
-msgid "Translation"
-msgstr "Vertaling"
-
-#: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:211
-#: signbank/dictionary/templates/dictionary/annotated_sentence_detail.html:126
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2415
-#: signbank/dictionary/templates/dictionary/lemma_frequency.html:93
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:168
-#: signbank/dictionary/templates/dictionary/update_lemma.html:128
-msgid "Glosses"
-msgstr "Glossen"
-
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:213
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:234
 msgid "Number of Glosses"
@@ -2339,17 +2486,17 @@ msgstr "Aantal gebaren"
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:452
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:236
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:266
-#: signbank/dictionary/templates/dictionary/update_lemma.html:117
-#: signbank/dictionary/views.py:2589 signbank/dictionary/views.py:2638
-#: signbank/dictionary/views.py:2651 signbank/dictionary/views.py:2664
+#: signbank/dictionary/templates/dictionary/update_lemma.html:153
+#: signbank/dictionary/views.py:2550 signbank/dictionary/views.py:2599
+#: signbank/dictionary/views.py:2612 signbank/dictionary/views.py:2625
 msgid "Update"
 msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:216
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:270
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:161
-#: signbank/dictionary/views.py:2587 signbank/dictionary/views.py:2630
-#: signbank/dictionary/views.py:2643 signbank/dictionary/views.py:2656
+#: signbank/dictionary/views.py:2548 signbank/dictionary/views.py:2591
+#: signbank/dictionary/views.py:2604 signbank/dictionary/views.py:2617
 #: signbank/feedback/templates/feedback/recent_feedback.html:87
 #: signbank/feedback/templates/feedback/show_feedback_missing_signs.html:120
 #: signbank/feedback/templates/feedback/show_feedback_morphemes.html:111
@@ -2359,20 +2506,20 @@ msgid "Delete"
 msgstr "Verwijder"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:337
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2390
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2756
 msgid "Delete this annotated sentence"
 msgstr "Verwijder dit voorbeeldzin"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:340
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1058
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1237
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1580
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1670
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1750
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2096
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2186
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2393
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2509
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1404
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1583
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1946
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2036
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2116
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2462
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2552
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2759
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2881
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:793
 msgid "Are you sure you want to delete this? This cannot be undone."
 msgstr ""
@@ -2383,31 +2530,33 @@ msgstr ""
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:367
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:188
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:453
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:572
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:654
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:703
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:967
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:982
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1065
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1114
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1244
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1282
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1346
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1390
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1453
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1587
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1677
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1757
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2103
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2193
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2320
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2400
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2516
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:758
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:840
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:889
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1179
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1315
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1330
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1411
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1460
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1590
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1628
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1692
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1736
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1818
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1953
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2043
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2123
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2469
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2559
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2686
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2766
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2888
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:438
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:453
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:528
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:711
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:800
+#: signbank/dictionary/templates/dictionary/update_lemma.html:238
 #: signbank/dictionary/templates/dictionary/update_video.html:78
 #: signbank/feedback/templates/feedback/recent_feedback.html:103
 #: signbank/feedback/templates/feedback/show_feedback_missing_signs.html:139
@@ -2420,21 +2569,23 @@ msgstr "Annuleer"
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:348
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:369
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:189
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:704
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1066
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1245
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1454
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1588
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1678
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1758
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2104
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2194
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2321
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2401
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2517
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:890
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1180
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1412
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1591
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1819
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1954
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2044
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2124
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2470
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2560
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2687
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2767
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2889
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:529
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:712
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:801
+#: signbank/dictionary/templates/dictionary/update_lemma.html:239
 #: signbank/feedback/templates/feedback/recent_feedback.html:104
 #: signbank/feedback/templates/feedback/show_feedback_missing_signs.html:140
 #: signbank/feedback/templates/feedback/show_feedback_morphemes.html:130
@@ -2551,13 +2702,21 @@ msgid "Quick Toggles"
 msgstr "Vlotte schakelaars"
 
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:451
-#: signbank/query_parameters.py:914
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:138
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:169
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:199
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:242
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:274
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:313
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:351
+#: signbank/query_parameters.py:926
 msgid "Annotation"
 msgstr "Annotatie"
 
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:496
 #: signbank/dictionary/templates/dictionary/admin_frequency_list.html:216
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1807
+#: signbank/dictionary/templates/dictionary/gloss.html:494
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2173
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:569
 msgid "Phonology"
 msgstr "Fonologie"
@@ -2620,14 +2779,6 @@ msgstr ""
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:32
 msgid "Machine Value"
 msgstr ""
-
-#: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:34
-#: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:35
-#: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:22
-#: signbank/dictionary/templates/dictionary/admin_handshape_list.html:356
-#: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:22
-msgid "Name"
-msgstr "Naam"
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:9
 msgid "Configure Handshapes"
@@ -2707,23 +2858,28 @@ msgid "Selected"
 msgstr "Geselecteerd"
 
 #: signbank/dictionary/templates/dictionary/admin_dataset_list.html:33
-msgid "Export Dataset"
-msgstr "Exporteer dataset"
+msgid "ECV File"
+msgstr "ECV-bestand"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:77
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:89
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:34
+#: signbank/dictionary/templates/dictionary/gloss_videos.html:233
+msgid "Download"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:78
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:90
 msgid "Request View Access"
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:85
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:86
 msgid "Motivation"
 msgstr "Motivatie"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:113
-msgid "ECV"
-msgstr "ECV"
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:126
+msgid "No ECV file found."
+msgstr "Geen ECV-bestand gevonden."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:124
+#: signbank/dictionary/templates/dictionary/admin_dataset_list.html:136
 #: signbank/dictionary/templates/dictionary/admin_dataset_select_list.html:90
 msgid "No datasets found."
 msgstr "Geen datasets gevonden."
@@ -2809,14 +2965,18 @@ msgstr "Corpus overzicht"
 msgid "Manage Media"
 msgstr "Beheer media"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:133
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:207
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:306
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:335
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:132
+msgid "Manage Video Storage"
+msgstr "Beheer video-opslag"
+
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:139
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:213
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:312
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:341
 msgid "Manage"
 msgstr "Beheer"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:144
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:150
 #, python-format
 msgid ""
 "\n"
@@ -2825,30 +2985,30 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:158
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:230
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:164
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:236
 msgid "No users found."
 msgstr "Geen gebruikers gevonden."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:169
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:189
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:241
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:261
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:175
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:195
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:247
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:267
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:102
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:175
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:247
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:181
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:253
 msgid "Grant"
 msgstr "Verleen toegang"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:195
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:267
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:201
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:273
 msgid "Revoke"
 msgstr "Toegang intrekken"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:217
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:223
 #, python-format
 msgid ""
 "\n"
@@ -2857,49 +3017,49 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:291
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:297
 #: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:41
 #: signbank/dictionary/templates/dictionary/edit_annotated_sentence.html:45
 msgid "Set"
 msgstr "Instellen"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:314
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:320
 msgid "No metadata CSV file found."
 msgstr "Geen metadata bestand gevonden."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:323
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:329
 msgid "Update CSV"
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:325
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:331
 msgid "Upload Metadata CSV"
 msgstr "Upload metadata CSV-bestand"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:329
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:335
 msgid "Upload CSV"
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:346
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:352
 msgid "No EAF files found."
 msgstr "Geen EAF-bestanden gevonden."
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:354
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:360
 msgid "Upload EAF"
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:357
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:363
 msgid "Folder"
 msgstr "Map"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:360
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:366
 msgid "Files"
 msgstr "Bestanden"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:363
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:369
 msgid "Upload EAF Files"
 msgstr "Upload EAF-bestanden"
 
-#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:376
+#: signbank/dictionary/templates/dictionary/admin_dataset_manager.html:382
 #: signbank/dictionary/templates/dictionary/dataset_field_choices.html:140
 msgid "You must be in group Dataset Manager to use this functionality."
 msgstr ""
@@ -2944,7 +3104,7 @@ msgstr "Beschikbare derivatieachtergronden"
 #: signbank/dictionary/templates/dictionary/admin_semanticfield_list.html:23
 #: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:53
 #: signbank/dictionary/templates/dictionary/semanticfield_detail.html:77
-#: signbank/query_parameters.py:925
+#: signbank/query_parameters.py:937
 msgid "Translations"
 msgstr "Mogelijke vertalingen"
 
@@ -2967,7 +3127,8 @@ msgstr "Veldnaam"
 #: signbank/dictionary/templates/dictionary/admin_frequency_graph.html:299
 #: signbank/dictionary/templates/dictionary/admin_frequency_list.html:206
 #: signbank/dictionary/templates/dictionary/admin_frequency_list.html:249
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:506
+#: signbank/dictionary/templates/dictionary/gloss.html:236
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:692
 #: signbank/dictionary/templates/dictionary/gloss_frequency.html:1347
 #: signbank/dictionary/templates/dictionary/gloss_revision_history.html:47
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:90
@@ -3004,7 +3165,8 @@ msgid "Sort by Frequency"
 msgstr "Sorteer op frequentie"
 
 #: signbank/dictionary/templates/dictionary/admin_frequency_list.html:226
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2016
+#: signbank/dictionary/templates/dictionary/gloss.html:579
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2382
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:598
 msgid "Semantics"
 msgstr "Semantiek"
@@ -3013,46 +3175,46 @@ msgstr "Semantiek"
 msgid "Signbank: Search Signs"
 msgstr "Signbank: Zoek gebaren"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:772
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:771
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:377
 msgid "Search by Morphology"
 msgstr "Zoek op Morfologie"
 
 #: signbank/dictionary/templates/dictionary/admin_gloss_list.html:784
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1644
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1651
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1711
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:729
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2010
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2017
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2077
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:732
 msgid "Morpheme Gloss"
 msgstr "Morfeem-Glos"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:871
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:872
 msgid "Search by Relation"
 msgstr "Zoek op Relaties"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:920
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:927
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:935
-#: signbank/query_parameters.py:549
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:921
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:928
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:936
+#: signbank/query_parameters.py:557
 msgid "Search Sign"
 msgstr "Zoek gebaar"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:922
-#: signbank/query_parameters.py:551
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:923
+#: signbank/query_parameters.py:559
 msgid "Search Sign or Morpheme"
 msgstr "Zoek gebaar of morfeem"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:929
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:930
 msgid "Sign or Morpheme"
 msgstr "Gebaar of morfeem"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:965
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:976
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:966
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:977
 msgid "Lemma View"
 msgstr "Lemmalijst"
 
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:967
-#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:978
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:968
+#: signbank/dictionary/templates/dictionary/admin_gloss_list.html:979
 msgid "List View"
 msgstr "Lijst"
 
@@ -3068,7 +3230,7 @@ msgstr "Signbank: Zoek handvormen"
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:63
 #: signbank/dictionary/templates/dictionary/dataset_media_manager.html:18
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:23
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:525
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:711
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:20
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:19
 #: signbank/dictionary/templates/dictionary/handshape_detail.html:73
@@ -3098,13 +3260,13 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:310
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:317
-#: signbank/query_parameters.py:554
+#: signbank/query_parameters.py:562
 msgid "Search Handshape"
 msgstr "Zoek handvorm"
 
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:312
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:319
-#: signbank/query_parameters.py:553
+#: signbank/query_parameters.py:561
 msgid "Search Sign by Handshape"
 msgstr "Zoek gebaar met handvorm"
 
@@ -3164,7 +3326,8 @@ msgstr "Label schakelaar"
 
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:218
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:310
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:499
+#: signbank/dictionary/templates/dictionary/gloss.html:228
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:685
 #: signbank/dictionary/templates/dictionary/gloss_frequency.html:1340
 #: signbank/dictionary/templates/dictionary/gloss_revision_history.html:40
 #: signbank/dictionary/templates/dictionary/gloss_videos.html:83
@@ -3198,7 +3361,8 @@ msgstr "Glos-details"
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:326
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:139
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:302
-#: signbank/dictionary/templates/dictionary/update_lemma.html:129
+#: signbank/dictionary/templates/dictionary/update_lemma.html:168
+#: signbank/dictionary/templates/dictionary/update_lemma.html:223
 msgid "Signbank ID"
 msgstr "Signbank-ID"
 
@@ -3223,9 +3387,10 @@ msgstr "voor deze glos"
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:608
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:535
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:219
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:464
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:471
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:477
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:648
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:655
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:661
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1116
 msgid "Dismiss"
 msgstr ""
 
@@ -3268,13 +3433,9 @@ msgid "Signbank: Lemmas"
 msgstr "Signbank: Lemmata"
 
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:176
-#: signbank/query_parameters.py:555
+#: signbank/query_parameters.py:563
 msgid "Search Lemma"
 msgstr "Zoek lemma"
-
-#: signbank/dictionary/templates/dictionary/admin_lemma_list.html:195
-msgid "Lemmas"
-msgstr "Lemmata"
 
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:218
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:356
@@ -3318,7 +3479,7 @@ msgid "Signbank: Minimal Pairs list"
 msgstr "Signbank: Lijst minimale paren"
 
 #: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:248
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1997
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2363
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:599
 msgid "Minimal Pairs"
 msgstr "Minimale paren"
@@ -3356,13 +3517,13 @@ msgid "Minimal Pair Gloss"
 msgstr "Andere glos"
 
 #: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:405
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2006
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2372
 #: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:8
 msgid "Source Sign Value"
 msgstr "Dit gebaar"
 
 #: signbank/dictionary/templates/dictionary/admin_minimalpairs_list.html:406
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2007
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2373
 #: signbank/dictionary/templates/dictionary/minimalpairs_gloss_table.html:9
 msgid "Contrasting Sign Value"
 msgstr "Ander gebaar"
@@ -3381,12 +3542,12 @@ msgid "Search by Basic Properties"
 msgstr "Zoek op basiseigenschappen"
 
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:467
-#: signbank/query_parameters.py:552
+#: signbank/query_parameters.py:560
 msgid "Search Morpheme"
 msgstr "Zoek morfeem"
 
 #: signbank/dictionary/templates/dictionary/admin_morpheme_list.html:564
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:931
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1279
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:439
 msgid "Create New"
 msgstr "Maak nieuw"
@@ -3422,13 +3583,13 @@ msgid "No active search or query parameters."
 msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:462
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:381
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:565
 msgid "Query Parameters"
 msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:467
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:397
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:431
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:581
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:615
 #: signbank/dictionary/templates/dictionary/gloss_revision_history.html:66
 #: signbank/dictionary/templates/dictionary/import_csv_update.html:303
 #: signbank/dictionary/templates/dictionary/import_csv_update_lemmas.html:145
@@ -3436,15 +3597,15 @@ msgid "Field"
 msgstr "Veld"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:468
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:399
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:433
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:583
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:617
 msgid "Value"
 msgstr "Waarde"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:495
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:498
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:469
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:476
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:653
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:660
 msgid "Run Query"
 msgstr "Voer query uit"
 
@@ -3477,6 +3638,64 @@ msgstr ""
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:603
 msgid "Publication Fields"
 msgstr "Publicatievelden"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:10
+msgid "Signbank: Recently Added Signs"
+msgstr "Signbank: Recent toegevoegd gebaren"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:61
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:10
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:15
+msgid "Recently Added Signs"
+msgstr "Recent toegevoegd gebaren"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:67
+msgid "Timeframe"
+msgstr "Tijdsbestek"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:81
+msgid "Sort Order of Timeline"
+msgstr "Sorteervolgorde tijdlijn"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:95
+msgid "Days Prior to Today"
+msgstr "Dagen vóór vandaag"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:109
+msgid "Timestamp on Gloss"
+msgstr "Tijdstempel op glos"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:142
+#: signbank/dictionary/templates/dictionary/admin_toggle_view.html:253
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2609
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:643
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:25
+msgid "Creator"
+msgstr "Toegevoegd door"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:144
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:148
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2608
+#: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:84
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:642
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:26
+msgid "Creation Date"
+msgstr "Aanmaakdatum"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:145
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:147
+msgid "Last Updated"
+msgstr "Laatst bijgewerkt"
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:195
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:65
+msgid "No recently added signs for the selected datasets"
+msgstr "Geen recent toegevoegd gebaren in de geselecteerde datasets."
+
+#: signbank/dictionary/templates/dictionary/admin_recently_added_glosses.html:195
+#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:65
+msgid "days"
+msgstr "dagen"
 
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:116
 msgid "No search history found."
@@ -3557,13 +3776,6 @@ msgstr ""
 "Voorafgaand nieuwe zoekopdrachten worden recent toegevoegd gebaren hieronder "
 "weergegeven."
 
-#: signbank/dictionary/templates/dictionary/admin_toggle_view.html:253
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2243
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:643
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:25
-msgid "Creator"
-msgstr "Toegevoegd door"
-
 #: signbank/dictionary/templates/dictionary/admin_toggle_view.html:256
 msgid "Semantic Fields"
 msgstr "Semantische velden"
@@ -3621,6 +3833,7 @@ msgstr "Dataset detailbeeld"
 
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:69
 #: signbank/dictionary/templates/dictionary/dataset_media_manager.html:81
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:97
 msgid "Dataset name"
 msgstr "Dataset-naam"
 
@@ -3628,6 +3841,7 @@ msgstr "Dataset-naam"
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:124
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:228
 #: signbank/dictionary/templates/dictionary/dataset_media_manager.html:82
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:98
 msgid "Acronym"
 msgstr "Acroniem"
 
@@ -3769,11 +3983,6 @@ msgid "The header row of the CSV file should be (using tab as separator):"
 msgstr ""
 "De koprij van het bestand zou zo eruit moeten zien (met tab als "
 "scheidingsteken):"
-
-#: signbank/dictionary/templates/dictionary/dataset_frequency.html:186
-#: signbank/gloss_update.py:1034 signbank/gloss_update.py:1134
-msgid "File"
-msgstr "Bestand"
 
 #: signbank/dictionary/templates/dictionary/dataset_frequency.html:193
 msgid "There are no EAF files for this dataset."
@@ -3960,6 +4169,7 @@ msgid "Manage Dataset Media"
 msgstr "Beheer dataset-media"
 
 #: signbank/dictionary/templates/dictionary/dataset_media_manager.html:83
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:99
 msgid "Number of glosses"
 msgstr "Aantal gebaren"
 
@@ -4012,6 +4222,92 @@ msgstr "Importeer de volgende 10"
 #: signbank/dictionary/templates/dictionary/dataset_media_manager.html:213
 msgid "Imported Videos"
 msgstr "Geïmporteerde video's"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:88
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:93
+msgid "Manage Dataset Video Storage"
+msgstr "Beheer dataset video-opslag"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:106
+msgid "Unlinked Gloss Video Files Available in File System"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:107
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:128
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:159
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:189
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:232
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:262
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:300
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:339
+msgid "results found"
+msgstr "gevonden resultaten"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:114
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:140
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:171
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:201
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:244
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:276
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:315
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:353
+msgid "Video Paths"
+msgstr "Bestandssysteempaden"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:127
+msgid "Glosses with Multiple Version 0 Videos"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:136
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:167
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:197
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:240
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:272
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:311
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:349
+#: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:82
+msgid "Gloss ID"
+msgstr "Glos-ID"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:158
+msgid "Glosses with Extra Characters in Video Filename"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:188
+msgid "Glosses with Wrong Folder for Video"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:202
+msgid "Exists"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:231
+msgid "Gloss Video Files with non-mp4 Extensions"
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:261
+msgid "Gloss Videos with Non-manual Elements"
+msgstr "Glos-video's met non-manuele elementen"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:299
+msgid "Gloss Perspective Videos"
+msgstr "Glos-video's met perspectief"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:338
+msgid "Gloss Videos"
+msgstr "Glos-video's"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:355
+msgid "Operations"
+msgstr "Operaties"
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:358
+msgid "Renumber backup files; match extension to video type."
+msgstr ""
+
+#: signbank/dictionary/templates/dictionary/dataset_video_storage.html:377
+msgid "Rename"
+msgstr "Hernoemen"
 
 #: signbank/dictionary/templates/dictionary/derivationhistory_detail.html:7
 msgid "Signbank: Derivation History Details"
@@ -4072,11 +4368,105 @@ msgid "Please choose a single dataset to use this functionality."
 msgstr ""
 "Kies alsjeblieft een enkel dataset om deze functionaliteit te gebruiken."
 
+#: signbank/dictionary/templates/dictionary/gloss.html:9
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:8
 #: signbank/dictionary/templates/dictionary/try.html:8
 #, python-format
 msgid "Sign for %(gloss)s"
 msgstr "Gebaar voor %(gloss)s"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:225
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:681
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1337
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:37
+#: signbank/dictionary/templates/dictionary/gloss_videos.html:80
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:289
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:64
+#: signbank/dictionary/templates/dictionary/word.html:79
+msgid "Public View"
+msgstr "Publieke Versie"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:240
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:696
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1351
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:51
+#: signbank/dictionary/templates/dictionary/gloss_videos.html:94
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:78
+#: signbank/dictionary/templates/dictionary/word.html:94
+msgid "Revision History"
+msgstr "Revisie-geschiedenis"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:243
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:699
+#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1354
+#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:54
+#: signbank/dictionary/templates/dictionary/gloss_videos.html:97
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:81
+#: signbank/dictionary/templates/dictionary/word.html:97
+msgid "Videos"
+msgstr "Video's"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:322
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1265
+#: signbank/dictionary/templates/dictionary/morpheme_detail.html:416
+msgid "Show Lemma Group"
+msgstr "Toon lemma-groep"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:398
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1789
+msgid "Videos with Non-manual Elements"
+msgstr "Video's met non-manuele elementen"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:436
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1916
+msgid "Morphology"
+msgstr "Morfologie"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:445
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2011
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2018
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2080
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:734
+msgid "Meaning in This Sign"
+msgstr "Betekenis in dit gebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:479
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2097
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2158
+msgid "Role in This Sign"
+msgstr "Rol in dit gebaar"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:604
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2436
+msgid "Relations to Other Signs"
+msgstr "Relaties met andere gebaren"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:626
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2740
+#: signbank/dictionary/templates/dictionary/gloss_videos.html:143
+#: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:145
+msgid "Example Sentences"
+msgstr "Voorbeeldzinnen"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:670
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2807
+msgid "Sentence context"
+msgstr "Voorbeeldzin context"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:678
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2815
+msgid "Sentence translation"
+msgstr "Vertaling voorbeeldzin"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:686
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2823
+msgid "Source"
+msgstr "Bron"
+
+#: signbank/dictionary/templates/dictionary/gloss.html:695
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2832
+msgid "Original video"
+msgstr ""
 
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:25
 msgid "Delete This Gloss"
@@ -4087,93 +4477,65 @@ msgstr "Verwijder deze glos"
 msgid "This idgloss already exists"
 msgstr "Deze idgloss bestaat al"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:354
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:538
 msgid "QUERY"
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:379
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:563
 msgid "Default Query Parameters"
 msgstr "Standaardqueryparameters"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:385
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:569
 msgid ""
 "No active query parameters were used in the search. Here are the non-empty "
 "fields of this gloss."
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:391
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:575
 msgid "No fields are filled in for this gloss."
 msgstr "Voor deze glos zijn geen velden ingevuld."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:496
-#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1337
-#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:37
-#: signbank/dictionary/templates/dictionary/gloss_videos.html:80
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:289
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:64
-#: signbank/dictionary/templates/dictionary/word.html:79
-msgid "Public View"
-msgstr "Publieke Versie"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:510
-#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1351
-#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:51
-#: signbank/dictionary/templates/dictionary/gloss_videos.html:94
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:78
-#: signbank/dictionary/templates/dictionary/word.html:94
-msgid "Revision History"
-msgstr "Revisie-geschiedenis"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:513
-#: signbank/dictionary/templates/dictionary/gloss_frequency.html:1354
-#: signbank/dictionary/templates/dictionary/gloss_revision_history.html:54
-#: signbank/dictionary/templates/dictionary/gloss_videos.html:97
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:81
-#: signbank/dictionary/templates/dictionary/word.html:97
-msgid "Videos"
-msgstr "Video's"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:528
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:714
 msgid "Copy"
 msgstr "Kopieer"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:534
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:720
 msgid "Copy Gloss"
 msgstr "Kopieer glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:538
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:724
 msgid ""
 "This gloss is already a duplicate. Please modify the annotation fields "
 "before creating a new duplicate."
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:540
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:726
 msgid "This will create a new gloss with identical phonology."
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:547
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:629
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:733
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:815
 msgid "Source Dataset"
 msgstr "Bron dataset"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:551
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:633
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:737
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:819
 msgid "Target Dataset"
 msgstr "Doel dataset"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:574
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:760
 msgid "Confirm Copy Create"
 msgstr "Bevestig kopie-creëren"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:586
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:772
 msgid "Move"
 msgstr "Verplaats"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:592
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:778
 msgid "Move Gloss"
 msgstr "Verplaats glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:600
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:786
 msgid ""
 "\n"
 "                        <p>This command will change the dataset of the gloss "
@@ -4191,331 +4553,309 @@ msgid ""
 "                        "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:610
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:796
 msgid "This gloss is related to other glosses:"
 msgstr "Deze glos is gerelateerd aan andere glossen:"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:619
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:805
 msgid "Related Glosses"
 msgstr "Gerelateerd glossen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:655
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:841
 msgid "Confirm Move"
 msgstr "Bevestig verplaatsen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:674
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:860
+#: signbank/dictionary/templates/dictionary/update_lemma.html:221
 msgid "Delete This Sign"
 msgstr "Verwijder dit gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:678
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:864
 #: signbank/feedback/templates/feedback/missingsign.html:50
 #: signbank/feedback/templates/feedback/show_feedback_signs.html:100
 msgid "Sign"
 msgstr "Gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:684
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:870
 msgid "This sign is related to other signs:"
 msgstr "Dit gebaar is gerelateerd aan andere gebaren:"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:696
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:882
+#: signbank/dictionary/templates/dictionary/update_lemma.html:231
 msgid ""
 "This action will delete this sign and all associated records. It cannot be "
 "undone."
-msgstr ""
-"Je verwijdert zo deze glos. Het kan niet ongedaan gemaakt worden."
+msgstr "Je verwijdert zo deze glos. Het kan niet ongedaan gemaakt worden."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:744
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:960
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:340
 msgid "Upload New Video"
 msgstr "Nieuwe video uploaden"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:839
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1055
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:377
 msgid "Upload New Citation Form Image"
 msgstr "Upload een nieuwe foto"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:867
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1083
 msgid "Create Citation Form Image from Current Video"
-msgstr ""
+msgstr "Creër stilstaand beeld van houdige video"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:876
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1084
+#: signbank/dictionary/views.py:2546 signbank/dictionary/views.py:2595
+#: signbank/dictionary/views.py:2608 signbank/dictionary/views.py:2621
+msgid "Create"
+msgstr "Voeg toe"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1090
+msgid "Choose Still Image"
+msgstr "Kies stilstaand beeld"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1097
+msgid "Choose a Still Image"
+msgstr "Kies een stilstaand beeld"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1115
+msgid "Choose Image"
+msgstr "Kies afbeelding"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1126
 msgid "Delete Media"
 msgstr "Verwijder media"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:894
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:897
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1145
+msgid "Upload Perspective Videos"
+msgstr "Nieuwe video's met perspectief uploaden"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1168
+msgid "Delete Perspective Video"
+msgstr "Verwijder video met perspectief"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1171
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1810
+msgid "Are you sure? This cannot be undone."
+msgstr "Weet je het zeker? Het kan niet ongedaan gemaakt worden."
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1212
+msgid "Upload New Perspective Video"
+msgstr "Nieuwe video met perspectief uploaden"
+
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1242
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1245
 msgid "Delete Sign"
 msgstr "Verwijder gebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:917
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:416
-msgid "Show Lemma Group"
-msgstr "Toon lemma-groep"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:927
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:943
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1275
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1291
 msgid "Edit Lemma"
 msgstr "Bewerk lemma"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:929
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1277
 msgid "Choose Other"
 msgstr "Kies andere"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:966
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1314
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:437
 msgid "Set Lemma"
-msgstr ""
+msgstr "Lemma instellen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:981
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1329
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:452
 msgid "Add Lemma"
 msgstr "Voeg lemma toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1055
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1401
 msgid "Delete this Sense"
 msgstr "Verwijder dit betekenis"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1077
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1423
 msgid "Edit this sense"
 msgstr "Bewerk dit betekenis"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1113
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1459
 msgid "Update sense"
 msgstr "Update betekenis"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1128
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1474
 #: signbank/dictionary/templates/dictionary/try.html:173
 msgid "Similar senses"
 msgstr "Vergelijkbare betekenissen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1169
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1515
 #: signbank/dictionary/templates/dictionary/try.html:214
 msgid "Adopt"
-msgstr ""
+msgstr "Aannemen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1176
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1522
 #: signbank/dictionary/templates/dictionary/try.html:221
 msgid "Close"
-msgstr ""
+msgstr "Sluit"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1234
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1580
 msgid "Delete this Example Sentence"
 msgstr "Verwijder dit voorbeeldzin"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1257
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1603
 msgid "Edit an example sentence"
 msgstr "Bewerk voorbeeldzin"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1283
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1629
 msgid "Confirm edit"
 msgstr "Bevestig bewerking"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1320
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1325
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1666
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1671
 msgid "Add an example sentence"
 msgstr "Voeg een voorbeeldzin toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1347
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1391
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1693
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1737
 msgid "Confirm add"
 msgstr "Bevestig toevoegen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1364
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1369
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1710
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1715
 msgid "Add a sense"
 msgstr "Voeg een betekenis toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1424
-msgid "Videos with Non-manual Elements"
-msgstr "Video's met non-manuele elementen"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1442
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1807
 msgid "Delete NME Video"
 msgstr "Verwijder NME video"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1445
-msgid "Are you sure? This cannot be undone."
-msgstr "Weet je het zeker? Het kan niet ongedaan gemaakt worden."
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1520
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1885
 msgid "Add descriptions for the video:"
 msgstr "Voeg beschrijvingen voor de video toe:"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1550
-msgid "Morphology"
-msgstr "Morfologie"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1561
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1927
 msgid "Compound Part"
 msgstr "Samenstelling-deel"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1562
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1928
 msgid "Component Sign"
 msgstr "Deelgebaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1576
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1942
 msgid "Delete This Compound Part"
 msgstr "Verwijder dit deel van de samenstelling"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1605
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1971
 msgid "If this is a compound, use [Edit] to define its components"
 msgstr ""
 "Als dit een compound is, kun je de delen specificeren door op [Bewerk] te "
 "klikken"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1626
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:1992
 msgid "Add Component"
 msgstr "Voeg deel toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1639
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2005
 msgid "There are no morphemes in the dataset of this gloss."
 msgstr "Er zitten geen morfemen in de dataset voor deze glos."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1645
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1652
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1714
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:731
-msgid "Meaning in This Sign"
-msgstr "Betekenis in dit gebaar"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1667
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2033
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:111
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:499
 msgid "Delete This Morpheme"
 msgstr "Verwijder dit morfeem"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1715
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2081
 msgid "Add Morpheme"
 msgstr "Voeg morfeem toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1730
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1789
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2096
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2155
 msgid "Blend Gloss"
 msgstr "Blend-glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1731
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1792
-msgid "Role in This Sign"
-msgstr "Rol in dit gebaar"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1746
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2112
 msgid "Delete This Blend"
 msgstr "Verwijder deze blend"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1793
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2159
 msgid "Add Blend"
 msgstr "Blend toevoegen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1964
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2330
 msgid "Identical phonology but not marked as homonym"
 msgstr "Identieke fonologie maar niet gemarkeerd als homoniem"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:1981
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2347
 msgid "Marked as homonym but different phonology"
 msgstr "Gemarkeerd als homoniem maar verschillende fonologie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2070
-msgid "Relations to Other Signs"
-msgstr "Relaties met andere gebaren"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2092
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2182
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2458
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2548
 msgid "Delete This Relation"
 msgstr "Verwijder deze relatie"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2154
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:752
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2520
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:755
 msgid "Relations to Foreign Signs"
 msgstr "Relaties met gebaren uit andere talen"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2167
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:753
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2533
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:756
 msgid "Loan"
 msgstr "Leenwoord"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2224
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2590
 msgid "Add Relation to Foreign Sign"
 msgstr "Voeg relatie toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2237
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2603
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:636
 msgid "Publication Status"
 msgstr "Publicatiestatus"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2242
-#: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:84
-#: signbank/dictionary/templates/dictionary/morpheme_detail.html:642
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:26
-msgid "Creation Date"
-msgstr "Aanmaakdatum"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2309
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2675
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:700
 msgid "Delete This Note"
 msgstr "Verwijder deze aantekening"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2313
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2679
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:704
 msgid "This action will delete this note. It cannot be undone."
 msgstr ""
 "Je verwijdert zo deze aantekening. Het kan niet ongedaan gemaakt worden."
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2359
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2725
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:751
 msgid "Save New Note"
 msgstr "Bewaar nieuwe aantekening"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2374
-#: signbank/dictionary/templates/dictionary/gloss_videos.html:143
-#: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:145
-msgid "Example Sentences"
-msgstr "Voorbeeldzinnen"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2378
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2744
 msgid "Add annotated media"
 msgstr "Voeg media toe"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2441
-msgid "Sentence context"
-msgstr "Voorbeeldzin context"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2449
-msgid "Sentence translation"
-msgstr "Vertaling voorbeeldzin"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2457
-msgid "Source"
-msgstr "Bron"
-
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2489
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2861
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:772
 msgid "Image/Video"
 msgstr "Afbeelding/video"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2490
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2862
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:773
 msgid "File Type"
 msgstr "Bestandstype"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2492
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2553
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2864
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2925
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:775
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:837
 msgid "Alternative Gloss"
 msgstr "Alternatieve glos"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2505
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2877
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:789
 msgid "Delete This Media"
 msgstr "Verwijder dit bestand"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2558
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2930
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:110
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:842
 msgid "Save"
 msgstr "Bewaar"
 
-#: signbank/dictionary/templates/dictionary/gloss_detail.html:2577
+#: signbank/dictionary/templates/dictionary/gloss_detail.html:2949
 msgid "Provide Feedback About This Sign"
 msgstr "Geef feedback over dit gebaar"
 
@@ -4604,10 +4944,6 @@ msgstr "Er is geen citation form image voor deze glos."
 msgid "Your browser does not support this format."
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/gloss_videos.html:233
-msgid "Download"
-msgstr ""
-
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:7
 msgid "Signbank: Glosses Without Lemma"
 msgstr "Signbank: Glossen zonder lemmata"
@@ -4621,10 +4957,6 @@ msgid "The following glosses do not have a lemma or dataset."
 msgstr ""
 
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:82
-msgid "Gloss ID"
-msgstr "Glos-ID"
-
-#: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:82
 msgid "Dataset: Translation Languages"
 msgstr "Dataset: Mogelijke vertaaltalen"
 
@@ -4633,7 +4965,6 @@ msgid "Annotations"
 msgstr "Annotaties"
 
 #: signbank/dictionary/templates/dictionary/glosses_with_no_lemma.html:84
-#: signbank/dictionary/templates/dictionary/import_media.html:41
 msgid "Status"
 msgstr ""
 
@@ -4647,12 +4978,12 @@ msgstr "Geen glossen zonder lemmata gevonden."
 
 #: signbank/dictionary/templates/dictionary/glosstags.html:22
 #: signbank/dictionary/templates/dictionary/morphemetags.html:22
-#: signbank/dictionary/views.py:2618
+#: signbank/dictionary/views.py:2579
 msgid "delete this tag"
 msgstr "verwijder dit label"
 
 #: signbank/dictionary/templates/dictionary/glosstags.html:39
-#: signbank/dictionary/views.py:2622
+#: signbank/dictionary/views.py:2583
 msgid "Add Tag"
 msgstr "Voeg label toe"
 
@@ -4735,7 +5066,6 @@ msgstr "Sjabloon"
 
 #: signbank/dictionary/templates/dictionary/import_csv_create.html:114
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:128
-#: signbank/dictionary/templates/dictionary/import_media.html:59
 msgid "Errors"
 msgstr "Foutmeldingen"
 
@@ -5042,27 +5372,6 @@ msgid ""
 "                    "
 msgstr ""
 
-#: signbank/dictionary/templates/dictionary/import_media.html:9
-msgid "Signbank: Import Media"
-msgstr ""
-
-#: signbank/dictionary/templates/dictionary/import_media.html:14
-msgid "Imported Media"
-msgstr ""
-
-#: signbank/dictionary/templates/dictionary/import_media.html:19
-msgid "No media found to import."
-msgstr ""
-
-#: signbank/dictionary/templates/dictionary/import_media.html:31
-msgid "Empty Folder"
-msgstr "Lege map"
-
-#: signbank/dictionary/templates/dictionary/import_media.html:40
-#: signbank/dictionary/templates/dictionary/unused_videos.html:23
-msgid "Filename"
-msgstr "Bestandsnaam"
-
 #. Translators: Welcome message
 #: signbank/dictionary/templates/dictionary/index.html:7
 #, python-format
@@ -5086,7 +5395,15 @@ msgstr "Lemma-groep"
 
 #: signbank/dictionary/templates/dictionary/lemma_frequency.html:104
 msgid "No lemma group for this gloss."
-msgstr ""
+msgstr "Geen lemma groep voor deze glos."
+
+#: signbank/dictionary/templates/dictionary/missingvideo.html:9
+msgid "Missing Videos"
+msgstr "Ontbrekende video's"
+
+#: signbank/dictionary/templates/dictionary/missingvideo.html:16
+msgid "Video Files without GlossVideo objects"
+msgstr "Video-bestanden zonder GlossVideo objecten"
 
 #: signbank/dictionary/templates/dictionary/morpheme_detail.html:8
 #, python-format
@@ -5150,19 +5467,6 @@ msgstr "Geef feedback over dit morfeem"
 msgid "Add morpheme Tag"
 msgstr "Voeg morfeem-label toe"
 
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:10
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:15
-msgid "Recently Added Signs"
-msgstr "Recent toegevoegd gebaren"
-
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:65
-msgid "No recently added signs for the selected datasets"
-msgstr "Geen recent toegevoegd gebaren in de geselecteerde datasets."
-
-#: signbank/dictionary/templates/dictionary/recently_added_glosses.html:65
-msgid "days"
-msgstr "dagen"
-
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:9
 #, python-format
 msgid "Relations for %(gloss)s"
@@ -5189,12 +5493,12 @@ msgid "Hypernyms"
 msgstr "Hyperoniemen"
 
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:444
-#: signbank/query_parameters.py:547 signbank/query_parameters.py:881
+#: signbank/query_parameters.py:555 signbank/query_parameters.py:892
 msgid "Handshape Paradigm"
 msgstr "Handvorm paradigma"
 
 #: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:497
-#: signbank/query_parameters.py:546 signbank/query_parameters.py:880
+#: signbank/query_parameters.py:554 signbank/query_parameters.py:891
 msgid "See Also"
 msgstr "Zie ook"
 
@@ -5202,19 +5506,15 @@ msgstr "Zie ook"
 msgid "Compounds"
 msgstr "Samenstellingen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:611
-msgid "Component Gloss"
-msgstr "Deelgebaar"
-
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:638
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:641
 msgid "Appears in Compounds"
 msgstr "Komt voor in samenstellingen"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:669
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:672
 msgid "Component Glosses"
 msgstr "Deelgebaren"
 
-#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:756
+#: signbank/dictionary/templates/dictionary/related_signs_detail_view.html:759
 msgid "Foreign Translation Equivalents"
 msgstr "Mogelijke vreemde vertalingen"
 
@@ -5315,6 +5615,50 @@ msgstr "Zinnen"
 msgid "#"
 msgstr "#"
 
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:9
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:9
+msgid "Signbank API: Update Gloss"
+msgstr "Signbank: API: Bewerk glos"
+
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:116
+#: signbank/dictionary/templates/dictionary/virtual_machine.html:103
+#: signbank/dictionary/templates/dictionary/virtual_machine_api.html:95
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:116
+msgid "Gloss Fields"
+msgstr "Glos velden"
+
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:117
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:117
+msgid ""
+"This template is for testing the gloss update API while logged in using the "
+"same url as the API."
+msgstr ""
+"Deze sjabloon biedt het bewerken van glossen toe met dezelfde url als de API."
+
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:118
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:118
+msgid ""
+"It is intended for checking the multilingual translations of field choices "
+"and values."
+msgstr "Men kan hier experimenteren met meertalige velden en veldwaarden."
+
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:119
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:119
+msgid "It makes use of the csrf token in the javascript AJAX setup."
+msgstr ""
+"De sjabloon maakt gebruik van de CSRF-token in de javascript-code en AJAX "
+"setup."
+
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:165
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:165
+msgid "Update Gloss"
+msgstr "Bewerk glos"
+
+#: signbank/dictionary/templates/dictionary/test_api_update_gloss_vm.html:171
+#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:171
+msgid "Updated Gloss"
+msgstr "Bewerkte glos"
+
 #: signbank/dictionary/templates/dictionary/unassigned_glosses.html:7
 msgid "Signbank: Unassigned Glosses"
 msgstr "Signbank: Niet-toegewezen glossen"
@@ -5360,25 +5704,29 @@ msgstr "Aantal ontkoppelde videobestanden"
 msgid "Folder (Gloss Prefix)"
 msgstr "Map (Glos-voorvoegsel)"
 
+#: signbank/dictionary/templates/dictionary/unused_videos.html:23
+msgid "Filename"
+msgstr "Bestandsnaam"
+
 #: signbank/dictionary/templates/dictionary/update_lemma.html:7
 msgid "Signbank: Update Lemma"
 msgstr "Signbank: Update lemma"
 
-#: signbank/dictionary/templates/dictionary/update_lemma.html:95
+#: signbank/dictionary/templates/dictionary/update_lemma.html:131
 msgid "Update Lemma"
 msgstr "Update lemma"
 
-#: signbank/dictionary/templates/dictionary/update_lemma.html:99
-#: signbank/dictionary/templates/dictionary/update_lemma.html:101
-#: signbank/dictionary/templates/dictionary/update_lemma.html:103
+#: signbank/dictionary/templates/dictionary/update_lemma.html:135
+#: signbank/dictionary/templates/dictionary/update_lemma.html:137
+#: signbank/dictionary/templates/dictionary/update_lemma.html:139
 msgid "Return to Lemma List"
 msgstr "Terug naar lemmata-lijst"
 
-#: signbank/dictionary/templates/dictionary/update_lemma.html:106
+#: signbank/dictionary/templates/dictionary/update_lemma.html:142
 msgid "Return to Gloss Details"
 msgstr "Terug naar glos-details"
 
-#: signbank/dictionary/templates/dictionary/update_lemma.html:157
+#: signbank/dictionary/templates/dictionary/update_lemma.html:206
 msgid "Restore Gloss"
 msgstr "Herstel glos"
 
@@ -5433,12 +5781,6 @@ msgstr "Upload video"
 msgid "Signbank API: Create Gloss"
 msgstr "Signbank: API: Maak glos aan"
 
-#: signbank/dictionary/templates/dictionary/virtual_machine.html:103
-#: signbank/dictionary/templates/dictionary/virtual_machine_api.html:95
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:116
-msgid "Gloss Fields"
-msgstr "Glos velden"
-
 #: signbank/dictionary/templates/dictionary/virtual_machine.html:147
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:154
 msgid "Create Gloss"
@@ -5448,37 +5790,6 @@ msgstr "Maak glos aan"
 #: signbank/dictionary/templates/dictionary/virtual_machine_api.html:160
 msgid "Created Gloss"
 msgstr "Nieuwe glos"
-
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:9
-msgid "Signbank API: Update Gloss"
-msgstr "Signbank: API: Bewerk glos"
-
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:117
-msgid ""
-"This template is for testing the gloss update API while logged in using the "
-"same url as the API."
-msgstr ""
-"Deze sjabloon biedt het bewerken van glossen toe met dezelfde url als de API."
-
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:118
-msgid ""
-"It is intended for checking the multilingual translations of field choices "
-"and values."
-msgstr "Men kan hier experimenteren met meertalige velden en veldwaarden."
-
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:119
-msgid "It makes use of the csrf token in the javascript AJAX setup."
-msgstr ""
-"De sjabloon maakt gebruik van de CSRF-token in de javascript-code en AJAX "
-"setup."
-
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:165
-msgid "Update Gloss"
-msgstr "Bewerk glos"
-
-#: signbank/dictionary/templates/dictionary/virtual_machine_gloss_update_api.html:171
-msgid "Updated Gloss"
-msgstr "Bewerkte glos"
 
 #: signbank/dictionary/templates/dictionary/warning.html:8
 msgid "Click here to go back."
@@ -5502,358 +5813,328 @@ msgstr "Dialecten"
 msgid "Note(s)"
 msgstr "Aantekening(en)"
 
-#: signbank/dictionary/update.py:85 signbank/dictionary/update.py:104
-#: signbank/dictionary/update.py:2330
+#: signbank/dictionary/update.py:88 signbank/dictionary/update.py:107
+#: signbank/dictionary/update.py:2364
 msgid "You are not authorized to change the selected dataset."
 msgstr "Je hebt niet genoeg rechten om de geselecteerde dataset te wijzigen."
 
-#: signbank/dictionary/update.py:94
+#: signbank/dictionary/update.py:97
 msgid "The given Lemma Idgloss is a string, not a Lemma."
 msgstr ""
 
-#: signbank/dictionary/update.py:98 signbank/dictionary/update.py:2323
+#: signbank/dictionary/update.py:101 signbank/dictionary/update.py:2357
 msgid "The given Lemma Idgloss ID is unknown."
 msgstr ""
 
-#: signbank/dictionary/update.py:108 signbank/dictionary/update.py:2334
+#: signbank/dictionary/update.py:111 signbank/dictionary/update.py:2368
 msgid "Please provide a dataset."
 msgstr "Specificeer hier een dataset"
 
-#: signbank/dictionary/update.py:120 signbank/dictionary/update.py:2348
+#: signbank/dictionary/update.py:123 signbank/dictionary/update.py:2382
 msgid "Annotation ID Gloss not unique."
 msgstr "Annotatie-ID-Glos is niet uniek"
 
-#: signbank/dictionary/update.py:124
+#: signbank/dictionary/update.py:127
 msgid "The add gloss form is not valid."
 msgstr ""
 
-#: signbank/dictionary/update.py:127
+#: signbank/dictionary/update.py:130
 msgid "The new lemma form is not valid."
 msgstr ""
 
-#: signbank/dictionary/update.py:130
+#: signbank/dictionary/update.py:133
 msgid "Please select or create a lemma."
 msgstr ""
 
-#: signbank/dictionary/update.py:214
+#: signbank/dictionary/update.py:217
 msgid "This example sentence was not changed."
 msgstr ""
 
-#: signbank/dictionary/update.py:275
+#: signbank/dictionary/update.py:278
 msgid "No input sentence given."
 msgstr ""
 
-#: signbank/dictionary/update.py:339 signbank/dictionary/update.py:361
+#: signbank/dictionary/update.py:342 signbank/dictionary/update.py:364
 msgid "Could not sort this sense."
 msgstr ""
 
-#: signbank/dictionary/update.py:390
+#: signbank/dictionary/update.py:393
 msgid "Could not sort this examplesentence."
 msgstr ""
 
-#: signbank/dictionary/update.py:424
+#: signbank/dictionary/update.py:427
 msgid "Sense Update Not Allowed"
 msgstr ""
 
-#: signbank/dictionary/update.py:441
+#: signbank/dictionary/update.py:444
 msgid "No keywords given for edited sense."
 msgstr ""
 
-#: signbank/dictionary/update.py:453
+#: signbank/dictionary/update.py:456
 msgid "Sense did not change."
 msgstr ""
 
-#: signbank/dictionary/update.py:459
+#: signbank/dictionary/update.py:462
 msgid "GlossSense not found for gloss."
 msgstr ""
 
-#: signbank/dictionary/update.py:462
+#: signbank/dictionary/update.py:465
 msgid "GlossSense duplicate found for gloss."
 msgstr ""
 
-#: signbank/dictionary/update.py:470 signbank/dictionary/update.py:606
+#: signbank/dictionary/update.py:473 signbank/dictionary/update.py:609
 msgid "This sense was already in this gloss."
 msgstr ""
 
-#: signbank/dictionary/update.py:569
+#: signbank/dictionary/update.py:572
 msgid "Given sense was updated."
 msgstr "Betekenis bijgewerkt"
 
-#: signbank/dictionary/update.py:580
+#: signbank/dictionary/update.py:583
 msgid "Sense Creation Not Allowed"
 msgstr ""
 
-#: signbank/dictionary/update.py:600
+#: signbank/dictionary/update.py:603
 msgid "No keywords given for new sense."
 msgstr ""
 
-#: signbank/dictionary/update.py:660
+#: signbank/dictionary/update.py:663
 msgid "Sense Deletion Not Allowed"
 msgstr ""
 
-#: signbank/dictionary/update.py:762
+#: signbank/dictionary/update.py:765
 msgid ""
 "GUARDED_GLOSS_DELETE is set to True. The gloss has relations to other "
 "glosses and was not deleted."
 msgstr ""
 
-#: signbank/dictionary/update.py:933
+#: signbank/dictionary/update.py:940
 msgid "The dataset of the gloss is not the same as that of the lemma."
 msgstr ""
 
-#: signbank/dictionary/update.py:935 signbank/dictionary/update.py:2562
+#: signbank/dictionary/update.py:942 signbank/dictionary/update.py:2596
 msgid "The specified lemma does not exist."
 msgstr ""
 
-#: signbank/dictionary/update.py:1745
+#: signbank/dictionary/update.py:1775
 msgid ""
 "Edit Simultaneuous Morphology: The dataset of this gloss has no morphemes."
 msgstr ""
 
-#: signbank/dictionary/update.py:1748
+#: signbank/dictionary/update.py:1778
 msgid "Edit Simultaneuous Morphology: No morpheme selected."
 msgstr "Bewerk Simultane morfologie: Geen morfeem geselecteerd."
 
-#: signbank/dictionary/update.py:1762
+#: signbank/dictionary/update.py:1792
 msgid "Simultaneuous morphology: no morpheme found with identifier {}."
 msgstr ""
 
-#: signbank/dictionary/update.py:2046
+#: signbank/dictionary/update.py:2080
 msgid "Annotated Sentence Deletion Not Allowed"
 msgstr ""
 
-#: signbank/dictionary/update.py:2083
+#: signbank/dictionary/update.py:2116
 msgid "Upload other media failed: The othermedia folder is missing."
 msgstr "Upload andere media niet gelukt: Het systeemmap othermedia ontbreekt."
 
-#: signbank/dictionary/update.py:2103 signbank/dictionary/update.py:2184
+#: signbank/dictionary/update.py:2136 signbank/dictionary/update.py:2217
 msgid "Upload other media failed: The file has an unknown type."
 msgstr "Upload andere media niet gelukt: Het bestand heeft een onbekend type."
 
-#: signbank/dictionary/update.py:2111
+#: signbank/dictionary/update.py:2144
 msgid "Upload other media failed: The file has no extension."
 msgstr ""
 "Upload andere media niet gelukt: : Het bestand heeft geen bestandsextensie."
 
-#: signbank/dictionary/update.py:2165
+#: signbank/dictionary/update.py:2198
 msgid ""
 "The other media file could not be uploaded. Please use a different filename."
 msgstr ""
 
-#: signbank/dictionary/update.py:2203
+#: signbank/dictionary/update.py:2236
 msgid ""
 "Upload other media failed: The Quicktime file could not be converted to MP4."
 msgstr ""
 
-#: signbank/dictionary/update.py:2229
+#: signbank/dictionary/update.py:2262
 msgid "Upload other media failed: The file could not be converted to H264."
 msgstr ""
 
-#: signbank/dictionary/update.py:2237
+#: signbank/dictionary/update.py:2270
 msgid "Upload other media failed: The file extension does not match its type."
 msgstr ""
 
-#: signbank/dictionary/update.py:2428
+#: signbank/dictionary/update.py:2462
 msgid ""
 "GUARDED_MORPHEME_DELETE is set to True or the morpheme has relations to "
 "other glosses and was not deleted."
 msgstr ""
 
-#: signbank/dictionary/update.py:2560
+#: signbank/dictionary/update.py:2594
 msgid "The dataset of the morpheme is not the same as that of the lemma."
 msgstr "De dataset van de morfeem komt niet overeen met die van de lemma."
 
-#: signbank/dictionary/update.py:2930
+#: signbank/dictionary/update.py:2964
 msgid "You must be in group Dataset Manager to modify dataset details."
 msgstr "Je moet in groep Dataset Manager zijn om deze dataset te wijzigen."
 
-#: signbank/dictionary/update.py:3189 signbank/dictionary/update.py:3240
+#: signbank/dictionary/update.py:3225 signbank/dictionary/update.py:3276
 msgid "No acronym for dataset."
 msgstr "Geen acroniem voor dataset."
 
-#: signbank/dictionary/update.py:3197 signbank/dictionary/update.py:3248
+#: signbank/dictionary/update.py:3233 signbank/dictionary/update.py:3284
 msgid "Dataset does not exist."
 msgstr "Dataset bestaat niet."
 
-#: signbank/dictionary/update.py:3203
+#: signbank/dictionary/update.py:3239
 msgid "You are not authorized to remove eaf files."
 msgstr "Je hebt niet genoeg rechten om EAF-bestanden te verwijderen."
 
-#: signbank/dictionary/update.py:3223
+#: signbank/dictionary/update.py:3259
 msgid "No eaf files found."
 msgstr "Geen EAF-bestanden gevonden."
 
-#: signbank/dictionary/update.py:3254
+#: signbank/dictionary/update.py:3290
 msgid "You are not authorized to upload eaf files."
 msgstr "Je hebt niet genoeg rechten om EAF-bestanden te uploaden."
 
-#: signbank/dictionary/update.py:3343
+#: signbank/dictionary/update.py:3379
 msgid "Non-EAF file(s) ignored: "
 msgstr ""
 
-#: signbank/dictionary/update.py:3347
+#: signbank/dictionary/update.py:3383
 msgid "File(s) encountered twice: "
 msgstr ""
 
-#: signbank/dictionary/update.py:3351
+#: signbank/dictionary/update.py:3387
 msgid "Already imported to different folder: "
 msgstr ""
 
-#: signbank/dictionary/update.py:3483
+#: signbank/dictionary/update.py:3519
 msgid "You do not have permission to change glosses."
 msgstr "Gebruiker heeft geen rechten om gebaren te wijzigen."
 
-#: signbank/dictionary/update.py:3509
+#: signbank/dictionary/update.py:3546
 msgid "You do not have change permission for"
 msgstr ""
 
-#: signbank/dictionary/update.py:3517
+#: signbank/dictionary/update.py:3554
 msgid "Error assigning lemma to gloss."
 msgstr ""
 
-#: signbank/dictionary/views.py:98
+#: signbank/dictionary/views.py:102
 msgid "You are not allowed to see this sign."
 msgstr "Je hebt niet genoeg rechten om dit gebaar te bekijken."
 
-#: signbank/dictionary/views.py:196
+#: signbank/dictionary/views.py:200
 msgid "You are not allowed to see this morpheme."
 msgstr "Je hebt niet genoeg rechten om dit morfeem te bekijken."
 
-#: signbank/dictionary/views.py:357
-msgid "Warning: Duplicate gloss found."
-msgstr "Waarschuwing: Duplicaat glos gevonden."
-
-#: signbank/dictionary/views.py:360
-msgid "Fail: Gloss Not Found"
-msgstr "Fout: Glos niet gevonden"
-
-#: signbank/dictionary/views.py:370
-msgid "Permission denied"
-msgstr "Geen toestemming"
-
-#: signbank/dictionary/views.py:378
-msgid "Success (Image File Overwritten)"
-msgstr "Succes (Beeldbestand overschreven)"
-
-#: signbank/dictionary/views.py:380 signbank/dictionary/views.py:391
-#: signbank/manage_videos.py:204
-msgid "Success"
-msgstr "Succes"
-
-#: signbank/dictionary/views.py:389
-msgid "Success (Video File Overwritten)"
-msgstr "Succes (Videobestand overschreven)"
-
-#: signbank/dictionary/views.py:455
+#: signbank/dictionary/views.py:344
 msgid "You do not have permission to use the try command."
 msgstr ""
 
-#: signbank/dictionary/views.py:609 signbank/dictionary/views.py:1029
-#: signbank/dictionary/views.py:2866
+#: signbank/dictionary/views.py:498 signbank/dictionary/views.py:918
+#: signbank/dictionary/views.py:2827
 msgid "Unrecognised format in selected CSV file."
 msgstr ""
 
-#: signbank/dictionary/views.py:635 signbank/dictionary/views.py:1092
-#: signbank/dictionary/views.py:1620 signbank/dictionary/views.py:2891
+#: signbank/dictionary/views.py:524 signbank/dictionary/views.py:981
+#: signbank/dictionary/views.py:1509 signbank/dictionary/views.py:2852
 msgid "The delimiter is not comma, tab, or semicolon."
 msgstr ""
 
-#: signbank/dictionary/views.py:637 signbank/dictionary/views.py:1094
-#: signbank/dictionary/views.py:1622 signbank/dictionary/views.py:2893
+#: signbank/dictionary/views.py:526 signbank/dictionary/views.py:983
+#: signbank/dictionary/views.py:1511 signbank/dictionary/views.py:2854
 msgid "The header row of the csv file looks like this: "
 msgstr "De koprij van het bestand zou zo eruit moeten zien: "
 
-#: signbank/dictionary/views.py:639 signbank/dictionary/views.py:1096
-#: signbank/dictionary/views.py:1624 signbank/dictionary/views.py:2895
+#: signbank/dictionary/views.py:528 signbank/dictionary/views.py:985
+#: signbank/dictionary/views.py:1513 signbank/dictionary/views.py:2856
 msgid "Some required column headers are missing: "
 msgstr ""
 
-#: signbank/dictionary/views.py:652 signbank/dictionary/views.py:1111
+#: signbank/dictionary/views.py:541 signbank/dictionary/views.py:1000
 msgid "Empty Column Header Found."
 msgstr "Lege kolomkop gevonden."
 
-#: signbank/dictionary/views.py:656 signbank/dictionary/views.py:1115
+#: signbank/dictionary/views.py:545 signbank/dictionary/views.py:1004
 msgid "Duplicate Column Header Found."
 msgstr "Duplicaat kolomkop gevonden."
 
-#: signbank/dictionary/views.py:660
+#: signbank/dictionary/views.py:549
 msgid "Signbank ID column found."
 msgstr "Signbank-ID kolom gevonden."
 
-#: signbank/dictionary/views.py:664 signbank/dictionary/views.py:1123
+#: signbank/dictionary/views.py:553 signbank/dictionary/views.py:1012
 msgid "The Dataset column is required."
 msgstr "De kolom 'Dataset' is verplicht."
 
-#: signbank/dictionary/views.py:1119
+#: signbank/dictionary/views.py:1008
 msgid "The Signbank ID column is required."
 msgstr "De kolom 'Signbank ID' is verplicht."
 
-#: signbank/dictionary/views.py:1252
+#: signbank/dictionary/views.py:1141
 msgid ""
 "Attempt to update Lemma translations. Use Import CSV Lemma Update instead."
 msgstr ""
 
-#: signbank/dictionary/views.py:1319
+#: signbank/dictionary/views.py:1208
 msgid "Attempt to update Lemma translations. Use Import CSV Lemma Update."
 msgstr ""
 
-#: signbank/dictionary/views.py:1554
+#: signbank/dictionary/views.py:1443
 msgid "Please select a single dataset for which you have change permission."
 msgstr ""
 
-#: signbank/dictionary/views.py:1572
+#: signbank/dictionary/views.py:1461
 msgid "You do not have change permission for the chosen dataset."
 msgstr "Gebruiker heeft geen rechten om de geselecteerde dataset te wijzigen."
 
-#: signbank/dictionary/views.py:1596
+#: signbank/dictionary/views.py:1485
 msgid ""
 "Unrecognised text encoding. Please export your file to UTF-8 format using e."
 "g. LibreOffice."
 msgstr ""
 
-#: signbank/dictionary/views.py:1915 signbank/dictionary/views.py:2041
+#: signbank/dictionary/views.py:1856 signbank/dictionary/views.py:1983
 msgid "File extension not supported! Please convert to png or jpg"
 msgstr ""
 
-#: signbank/dictionary/views.py:1923 signbank/dictionary/views.py:2048
+#: signbank/dictionary/views.py:1864 signbank/dictionary/views.py:1990
 msgid "Uploaded file too large!"
 msgstr ""
 
-#: signbank/dictionary/views.py:2075
+#: signbank/dictionary/views.py:2017
 msgid "Error uploading handshape image. Please consult the administrator."
 msgstr ""
 
-#: signbank/dictionary/views.py:2581
+#: signbank/dictionary/views.py:2542
 msgid "NME Video Description"
 msgstr "NME video beschrijving"
 
-#: signbank/dictionary/views.py:2585 signbank/dictionary/views.py:2587
-#: signbank/dictionary/views.py:2589
+#: signbank/dictionary/views.py:2546 signbank/dictionary/views.py:2548
+#: signbank/dictionary/views.py:2550 signbank/video/admin_update.py:99
 msgid "NME Video"
 msgstr "NME video"
 
-#: signbank/dictionary/views.py:2585 signbank/dictionary/views.py:2634
-#: signbank/dictionary/views.py:2647 signbank/dictionary/views.py:2660
-msgid "Create"
-msgstr "Voeg toe"
-
-#: signbank/dictionary/views.py:2607
+#: signbank/dictionary/views.py:2568
 msgid "Deleted"
 msgstr "Verwijderd"
 
-#: signbank/dictionary/views.py:2609
+#: signbank/dictionary/views.py:2570
 msgid "Restored"
 msgstr "Hersteld"
 
-#: signbank/dictionary/views.py:2909
+#: signbank/dictionary/views.py:2870
 msgid "Extra columns were found: "
 msgstr "Extra kolommen gevonden: "
 
-#: signbank/dictionary/views.py:3098 signbank/dictionary/views.py:3124
+#: signbank/dictionary/views.py:3059 signbank/dictionary/views.py:3085
 msgid "You do not have permission to use the test command."
 msgstr "Gebruiker heeft geen rechten om deze pagina te zien."
 
-#: signbank/dictionary/views.py:3134
+#: signbank/dictionary/views.py:3095
 msgid "The gloss does not exist in the dataset."
 msgstr "Aangevraagd glos bestaat niet in de dataset."
 
@@ -6144,7 +6425,7 @@ msgstr "Glossen bijgewerkt"
 msgid "No annotations"
 msgstr "Geen annotaties"
 
-#: signbank/gloss_morphology_update.py:46 signbank/gloss_update.py:126
+#: signbank/gloss_morphology_update.py:46 signbank/gloss_update.py:128
 msgid "Field update not available"
 msgstr "Veldupdate niet beschikbaar"
 
@@ -6152,119 +6433,111 @@ msgstr "Veldupdate niet beschikbaar"
 msgid "You must be logged in to use this functionality."
 msgstr "Je moet ingelogd zijn om deze functionaliteit te gebruiken."
 
-#: signbank/gloss_morphology_update.py:177 signbank/gloss_update.py:558
-#: signbank/gloss_update.py:694 signbank/gloss_update.py:774
-#: signbank/gloss_update.py:948 signbank/gloss_update.py:1091
-#: signbank/gloss_update.py:1175
+#: signbank/gloss_morphology_update.py:177 signbank/gloss_update.py:606
+#: signbank/gloss_update.py:735 signbank/gloss_update.py:815
+#: signbank/gloss_update.py:989 signbank/gloss_update.py:1122
+#: signbank/gloss_update.py:1206
 msgid "No change permission for dataset."
 msgstr "Geen toestemming om dataset te bewerken."
 
-#: signbank/gloss_morphology_update.py:187 signbank/gloss_update.py:568
-#: signbank/gloss_update.py:704 signbank/gloss_update.py:784
-#: signbank/gloss_update.py:958 signbank/gloss_update.py:1101
-#: signbank/gloss_update.py:1185
+#: signbank/gloss_morphology_update.py:187 signbank/gloss_update.py:616
+#: signbank/gloss_update.py:745 signbank/gloss_update.py:825
+#: signbank/gloss_update.py:999 signbank/gloss_update.py:1132
+#: signbank/gloss_update.py:1216
 msgid "Gloss ID must be a number."
 msgstr "'%(value)s' waarde moet een getal zijn."
 
-#: signbank/gloss_morphology_update.py:195 signbank/gloss_update.py:576
-#: signbank/gloss_update.py:712 signbank/gloss_update.py:966
-#: signbank/gloss_update.py:1109 signbank/gloss_update.py:1193
-#: signbank/manage_videos.py:187
+#: signbank/gloss_morphology_update.py:195 signbank/gloss_update.py:624
+#: signbank/gloss_update.py:753 signbank/gloss_update.py:1007
+#: signbank/gloss_update.py:1140 signbank/gloss_update.py:1224
+#: signbank/manage_videos.py:181
 msgid "Gloss not found."
 msgstr "Glos niet gevonden."
 
-#: signbank/gloss_morphology_update.py:201 signbank/gloss_update.py:582
-#: signbank/gloss_update.py:718 signbank/gloss_update.py:798
-#: signbank/gloss_update.py:972 signbank/gloss_update.py:1115
-#: signbank/gloss_update.py:1199
+#: signbank/gloss_morphology_update.py:201 signbank/gloss_update.py:630
+#: signbank/gloss_update.py:759 signbank/gloss_update.py:839
+#: signbank/gloss_update.py:1013 signbank/gloss_update.py:1146
+#: signbank/gloss_update.py:1230
 msgid "Gloss does not have a lemma."
 msgstr "Glos heeft geen lemma."
 
-#: signbank/gloss_morphology_update.py:207 signbank/gloss_update.py:588
-#: signbank/gloss_update.py:724 signbank/gloss_update.py:804
-#: signbank/gloss_update.py:978 signbank/gloss_update.py:1121
-#: signbank/gloss_update.py:1205
+#: signbank/gloss_morphology_update.py:207 signbank/gloss_update.py:636
+#: signbank/gloss_update.py:765 signbank/gloss_update.py:845
+#: signbank/gloss_update.py:1019 signbank/gloss_update.py:1152
+#: signbank/gloss_update.py:1236
 msgid "Gloss not found in the dataset."
 msgstr "Glos niet gevonden in de dataset."
 
-#: signbank/gloss_update.py:316 signbank/gloss_update.py:321
-#: signbank/gloss_update.py:324 signbank/gloss_update.py:328
-#: signbank/gloss_update.py:332
+#: signbank/gloss_update.py:328
+msgid "API UPDATE NOT AVAILABLE: The gloss has senses with example sentences."
+msgstr ""
+
+#: signbank/gloss_update.py:339 signbank/gloss_update.py:344
+#: signbank/gloss_update.py:347 signbank/gloss_update.py:351
+#: signbank/gloss_update.py:355
 msgid "NOT FOUND: "
 msgstr "NIET GEVONDEN: "
 
-#: signbank/gloss_update.py:639
+#: signbank/gloss_update.py:680
 msgid "Gloss operation not confirmed"
 msgstr ""
 
-#: signbank/gloss_update.py:792
+#: signbank/gloss_update.py:833
 msgid "Gloss not found in archive."
 msgstr "Glos niet gevonden in het archief."
 
-#: signbank/gloss_update.py:994 signbank/gloss_update.py:1002
-#: signbank/gloss_update.py:1221 signbank/gloss_update.py:1229
+#: signbank/gloss_update.py:1035 signbank/gloss_update.py:1043
+#: signbank/gloss_update.py:1252 signbank/gloss_update.py:1260
 msgid "NME Video ID"
 msgstr "NME video ID"
 
-#: signbank/gloss_update.py:994 signbank/gloss_update.py:1221
+#: signbank/gloss_update.py:1035 signbank/gloss_update.py:1252
 msgid "Video ID must be a number."
 msgstr "Video ID moet een getal zijn."
 
-#: signbank/gloss_update.py:1002 signbank/gloss_update.py:1229
+#: signbank/gloss_update.py:1043 signbank/gloss_update.py:1260
 msgid "NME Video not found."
 msgstr "NME video niet gevonden."
 
-#: signbank/gloss_update.py:1136
+#: signbank/gloss_update.py:1167
 msgid "Missing File argument."
 msgstr "Bestand ontbreekt."
 
-#: signbank/manage_videos.py:54
+#: signbank/manage_videos.py:53
 msgid "You must be in group Dataset Manager to upload a zip video archive."
 msgstr "Je moet in groep Dataset Manager zijn om een zip-archief te uploaden."
 
-#: signbank/manage_videos.py:78
+#: signbank/manage_videos.py:77
 msgid "No change dataset permission."
 msgstr "Geen verander-dataset toestemming."
 
-#: signbank/manage_videos.py:84
+#: signbank/manage_videos.py:83
 msgid "Upload zip archive: The folder VIDEOS_TO_IMPORT_FOLDER is missing."
 msgstr "Zip-archief uploaden: De systeemmap VIDEOS_TO_IMPORT_FOLDER ontbreekt."
 
-#: signbank/manage_videos.py:93
+#: signbank/manage_videos.py:92
 msgid "Upload zip archive: The file has an unknown type."
 msgstr "Zip-archief uploaden: Het bestand heeft een onbekend type."
 
-#: signbank/manage_videos.py:98
+#: signbank/manage_videos.py:97
 msgid "Upload zip archive: The file is not a zip file."
 msgstr "Zip-archief uploaden: Het bestand heeft geen zip-formaat."
 
-#: signbank/manage_videos.py:106
+#: signbank/manage_videos.py:105
 msgid "Upload zip archive: The file has no extension."
 msgstr "Zip-archief uploaden: Het bestand heeft geen bestandsextensie."
 
-#: signbank/manage_videos.py:123
+#: signbank/manage_videos.py:122
 msgid "The zip archive has the wrong structure. It should be: "
 msgstr "Het zip-archief heeft een verkeerde structuur: Dat moet als volgt: "
 
-#: signbank/manage_videos.py:131
+#: signbank/manage_videos.py:130
 msgid "Upload zipped videos media was successful."
 msgstr "Het uploaden van het zip-archief was succesvol."
 
-#: signbank/manage_videos.py:213
-msgid "Failure."
-msgstr "Mislukking."
-
-#: signbank/manage_videos.py:214
-msgid "Error saving video file."
-msgstr "Fout bij opslaan videobestand."
-
-#: signbank/manage_videos.py:222
-msgid "Wrong video format."
-msgstr "Verkeerd videoformaat."
-
-#: signbank/manage_videos.py:223
-msgid "Video file is not h264."
-msgstr "Videoformaat is geen h264"
+#: signbank/manage_videos.py:195
+msgid "Success"
+msgstr "Succes"
 
 #: signbank/pages/admin.py:16
 msgid ""
@@ -6345,43 +6618,43 @@ msgstr "pagina's"
 msgid "title"
 msgstr "titel"
 
-#: signbank/query_parameters.py:477
+#: signbank/query_parameters.py:485
 msgid "Search Type"
 msgstr "Zoektype"
 
-#: signbank/query_parameters.py:540 signbank/query_parameters.py:874
+#: signbank/query_parameters.py:548 signbank/query_parameters.py:885
 msgid "Homonym"
 msgstr "Homoniem"
 
-#: signbank/query_parameters.py:541 signbank/query_parameters.py:875
+#: signbank/query_parameters.py:549 signbank/query_parameters.py:886
 msgid "Synonym"
 msgstr "Synoniem"
 
-#: signbank/query_parameters.py:542 signbank/query_parameters.py:876
+#: signbank/query_parameters.py:550 signbank/query_parameters.py:887
 msgid "Variant"
 msgstr "Variant"
 
-#: signbank/query_parameters.py:543 signbank/query_parameters.py:877
+#: signbank/query_parameters.py:551 signbank/query_parameters.py:888
 msgid "Antonym"
 msgstr "Antoniem"
 
-#: signbank/query_parameters.py:544 signbank/query_parameters.py:878
+#: signbank/query_parameters.py:552 signbank/query_parameters.py:889
 msgid "Hyponym"
 msgstr "Hyponiem"
 
-#: signbank/query_parameters.py:545 signbank/query_parameters.py:879
+#: signbank/query_parameters.py:553 signbank/query_parameters.py:890
 msgid "Hypernym"
 msgstr "Hyperoniem"
 
-#: signbank/query_parameters.py:556
+#: signbank/query_parameters.py:564
 msgid "Annotated Gloss Sentence"
 msgstr "Voorbeeldzin"
 
-#: signbank/query_parameters.py:941
+#: signbank/query_parameters.py:953
 msgid "Sentence"
 msgstr "Zin"
 
-#: signbank/settings/server_specific/default.py:68
+#: signbank/settings/server_specific/default.py:69
 #: signbank/settings/server_specific/global_sb_local.py:28
 #: signbank/settings/server_specific/global_sb_new_aj.py:14
 #: signbank/settings/server_specific/server_specific.py:28
@@ -6412,27 +6685,43 @@ msgstr "Hebreeuws"
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: signbank/video/admin.py:32
+#: signbank/video/admin.py:32 signbank/video/admin_update.py:37
 msgid "File System Group"
 msgstr ""
 
-#: signbank/video/admin.py:63
+#: signbank/video/admin.py:63 signbank/video/admin_update.py:68
 msgid "File Exists"
 msgstr ""
 
-#: signbank/video/admin.py:193
+#: signbank/video/admin.py:203 signbank/video/admin_update.py:371
 msgid "Actor"
 msgstr ""
 
-#: signbank/video/models.py:854
+#: signbank/video/admin_update.py:114
+msgid "Perspective Video"
+msgstr "Video met perspectief"
+
+#: signbank/video/admin_update.py:129
+msgid "MP4 File"
+msgstr "MP4-bestand"
+
+#: signbank/video/forms.py:32
+msgid "Video Perspective"
+msgstr "Video-perspectief"
+
+#: signbank/video/models.py:890
 msgid "NME Gloss Video"
 msgstr "NME glos-video"
 
-#: signbank/video/views.py:89
+#: signbank/video/models.py:987
+msgid "Gloss Video Perspective"
+msgstr "Glos-video met perspectief"
+
+#: signbank/video/views.py:99
 msgid "Annotated sentence upload went wrong. Please try again."
 msgstr ""
 
-#: signbank/video/views.py:139
+#: signbank/video/views.py:200
 msgid "Invalid file. Please try again."
 msgstr ""
 
@@ -6683,11 +6972,54 @@ msgstr "vind alle strings in dit veld"
 msgid "use backslash to find <br/>special characters in field"
 msgstr "gebruik backslash om <br/>speciale karakters te zoeken"
 
+#~ msgid ""
+#~ "Please refine your query to retrieve fewer than 100 glosses to use this "
+#~ "functionality."
+#~ msgstr ""
+#~ "Verfijn uw zoekopdracht tot minder dan 100 glossen om deze "
+#~ "functionaliteit te gebruiken."
+
+#~ msgid "Export Dataset"
+#~ msgstr "Exporteer dataset"
+
+#~ msgid "ECV"
+#~ msgstr "ECV"
+
+#~ msgid "Empty Folder"
+#~ msgstr "Lege map"
+
+#~ msgid "Component Gloss"
+#~ msgstr "Deelgebaar"
+
+#~ msgid "Warning: Duplicate gloss found."
+#~ msgstr "Waarschuwing: Duplicaat glos gevonden."
+
+#~ msgid "Fail: Gloss Not Found"
+#~ msgstr "Fout: Glos niet gevonden"
+
+#~ msgid "Permission denied"
+#~ msgstr "Geen toestemming"
+
+#~ msgid "Success (Image File Overwritten)"
+#~ msgstr "Succes (Beeldbestand overschreven)"
+
+#~ msgid "Success (Video File Overwritten)"
+#~ msgstr "Succes (Videobestand overschreven)"
+
+#~ msgid "Failure."
+#~ msgstr "Mislukking."
+
+#~ msgid "Error saving video file."
+#~ msgstr "Fout bij opslaan videobestand."
+
+#~ msgid "Wrong video format."
+#~ msgstr "Verkeerd videoformaat."
+
+#~ msgid "Video file is not h264."
+#~ msgstr "Videoformaat is geen h264"
+
 #~ msgid "User not found in request."
 #~ msgstr "Gebruiker ontbreekt van de AJAX-request."
-
-#~ msgid "View dataset"
-#~ msgstr "Toon dataset"
 
 #~ msgid "Number of Annotations"
 #~ msgstr "Aantal annotaties"
@@ -7650,9 +7982,6 @@ msgstr "gebruik backslash om <br/>speciale karakters te zoeken"
 #~ msgstr ""
 #~ "Houdt \"Control\", of \"Command\" op een Mac, ingedrukt om meer dan een "
 #~ "te selecteren."
-
-#~ msgid "name"
-#~ msgstr "naam"
 
 #~ msgid "\"Hide Empty Frequencies\""
 #~ msgstr "Verberg lege frequenties"

--- a/conf/locale/nl/LC_MESSAGES/django.po
+++ b/conf/locale/nl/LC_MESSAGES/django.po
@@ -1138,7 +1138,7 @@ msgstr "Lemma-ID-Glos is niet uniek voor die taal"
 
 #: signbank/dictionary/adminviews.py:6408
 msgid "The specified gloss does not exist."
-msgstr ""
+msgstr "De opgegeven glos bestaat niet."
 
 #: signbank/dictionary/adminviews.py:6427
 msgid "Lemma ID Gloss not unique for language."
@@ -1150,11 +1150,11 @@ msgstr "De invoerformulier bevat fouten."
 
 #: signbank/dictionary/adminviews.py:6588
 msgid "The changes to the lemma have been saved."
-msgstr ""
+msgstr "De wijzigingen in het lemma zijn opgeslagen."
 
 #: signbank/dictionary/adminviews.py:6595
 msgid "There must be at least one translation for this lemma."
-msgstr ""
+msgstr "Er moet minstens één vertaling zijn voor het lemma."
 
 #: signbank/dictionary/adminviews.py:6619
 msgid "The requested lemma does not exist."
@@ -1166,11 +1166,11 @@ msgstr "Aangevraagd lemma heeft geen dataset."
 
 #: signbank/dictionary/adminviews.py:6634
 msgid "The lemma you are trying to view is not in your selected datasets."
-msgstr ""
+msgstr "Het lemma dat u probeert te bekijken, bevindt zich niet in uw geselecteerde datasets."
 
 #: signbank/dictionary/adminviews.py:6639
 msgid "The lemma you are trying to view is not in a dataset you can view."
-msgstr ""
+msgstr "Het lemma dat u probeert te bekijken, bevindt zich niet in een dataset die u kunt bekijken.."
 
 #: signbank/dictionary/adminviews.py:6654
 msgid "There are glosses using this lemma."
@@ -1501,11 +1501,11 @@ msgstr "Rol"
 
 #: signbank/dictionary/forms.py:642
 msgid "Please choose a type description when uploading other media."
-msgstr ""
+msgstr "Kies een soort beschrijving bij het uploaden van media."
 
 #: signbank/dictionary/forms.py:649
 msgid "Please choose a video or image file to upload."
-msgstr ""
+msgstr "Kies een video- of beeldbestand te uploaden"
 
 #: signbank/dictionary/forms.py:756
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:363
@@ -1599,11 +1599,11 @@ msgstr "Laatste update"
 
 #: signbank/dictionary/forms.py:1220
 msgid "The Field Choice Category is required"
-msgstr ""
+msgstr "De categorie Veldkeuze is verplicht"
 
 #: signbank/dictionary/forms.py:1230
 msgid "The Name fields for all languages are required"
-msgstr ""
+msgstr "De velden Naam zijn voor alle talen verplicht"
 
 #: signbank/dictionary/forms.py:1237 signbank/dictionary/forms.py:1247
 msgid "The combination "
@@ -1630,7 +1630,7 @@ msgstr "Taal"
 #: signbank/dictionary/forms.py:1479 signbank/dictionary/forms.py:1484
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:128
 msgid "Parameters"
-msgstr ""
+msgstr "Parameters"
 
 #: signbank/dictionary/forms.py:1493
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:143
@@ -1664,7 +1664,7 @@ msgstr "Betekenis index"
 #: signbank/dictionary/models.py:253 signbank/dictionary/models.py:265
 #: signbank/dictionary/models.py:296
 msgid "Machine value"
-msgstr ""
+msgstr "Machinewaarde"
 
 #: signbank/dictionary/models.py:308
 msgid "Finger selection"
@@ -1921,7 +1921,7 @@ msgstr ""
 #: signbank/dictionary/models.py:1064
 #: signbank/dictionary/templates/dictionary/import_csv_create_sentences.html:141
 msgid "Sense Number"
-msgstr ""
+msgstr "Betekenisnummer"
 
 #: signbank/dictionary/models.py:1072
 msgid "Senses in this Gloss"
@@ -2106,7 +2106,7 @@ msgstr "Omschrijving"
 
 #: signbank/dictionary/models.py:2852
 msgid "What order to display this sense within the gloss."
-msgstr ""
+msgstr "In welke volgorde moet deze betekenis in de gloss worden weergegeven?"
 
 #: signbank/dictionary/models.py:2857
 msgid "Gloss sense"
@@ -2150,11 +2150,11 @@ msgstr "Lemma-ID-Glos vertaling"
 
 #: signbank/dictionary/models.py:3710
 msgid "Multiple Select"
-msgstr ""
+msgstr "Meerdere selecteren"
 
 #: signbank/dictionary/models.py:3711
 msgid "Is this a multiselect parameter?"
-msgstr ""
+msgstr "Is dit een multiselect-parameter?"
 
 #: signbank/dictionary/models.py:3853
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:355
@@ -2491,7 +2491,7 @@ msgstr "Aantal gebaren"
 #: signbank/dictionary/views.py:2550 signbank/dictionary/views.py:2599
 #: signbank/dictionary/views.py:2612 signbank/dictionary/views.py:2625
 msgid "Update"
-msgstr ""
+msgstr "Werk bij"
 
 #: signbank/dictionary/templates/dictionary/admin_annotatedsentence_list.html:216
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:270
@@ -2748,7 +2748,7 @@ msgstr "Vergelijkbare glossen"
 
 #: signbank/dictionary/templates/dictionary/admin_batch_edit_view.html:982
 msgid "QUERY EXACT"
-msgstr ""
+msgstr "EXACTE VRAAG"
 
 #: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:8
 msgid "Configure Derivation History"
@@ -2756,7 +2756,7 @@ msgstr "Derivatieachtergrond"
 
 #: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:17
 msgid "Derivation History is not supported by your Signbank configuration."
-msgstr ""
+msgstr "Derivatieachtergrond wordt niet ondersteund door uw Signbank-configuratie."
 
 #: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:19
 msgid "You do not have permission to configure Derivation Histories."
@@ -2764,7 +2764,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:21
 msgid "No choices found for Derivation History in FieldChoice."
-msgstr ""
+msgstr "Geen keuzes gevonden voor Derivatieachtergrond in FieldChoice."
 
 #: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:24
 msgid "Derivation History has already been configured."
@@ -2779,7 +2779,7 @@ msgstr ""
 #: signbank/dictionary/templates/dictionary/admin_configure_derivationhistory.html:31
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:32
 msgid "Machine Value"
-msgstr ""
+msgstr "Machinewaarde"
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:9
 msgid "Configure Handshapes"
@@ -2787,7 +2787,7 @@ msgstr "Configureer handvormen"
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:18
 msgid "Handshapes are not supported by your Signbank configuration."
-msgstr ""
+msgstr "Handvormen wordt niet ondersteund door uw Signbank-configuratie."
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:20
 msgid "You do not have permission to configure Handshapes."
@@ -2795,11 +2795,11 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:22
 msgid "No choices found for Handshape in FieldChoice."
-msgstr ""
+msgstr "Geen keuzes gevonden voor Handvorm in FieldChoice."
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:25
 msgid "Handshapes are already configured."
-msgstr ""
+msgstr "Handvormen zijn al geconfigureerd."
 
 #: signbank/dictionary/templates/dictionary/admin_configure_handshapes.html:27
 msgid ""
@@ -3095,7 +3095,7 @@ msgstr "Auteursrechten"
 
 #: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:9
 msgid "Signbank: Available Derivation Histories"
-msgstr ""
+msgstr "Signbank: Beschikbare derivatieachtergronden"
 
 #: signbank/dictionary/templates/dictionary/admin_derivationhistory_list.html:15
 msgid "Available Derivation Histories"
@@ -3257,7 +3257,7 @@ msgstr "Handvorm-naam"
 
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:157
 msgid "FINGER SELECTION"
-msgstr ""
+msgstr "VINGERSELECTIE"
 
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:310
 #: signbank/dictionary/templates/dictionary/admin_handshape_list.html:317
@@ -3369,7 +3369,7 @@ msgstr "Signbank-ID"
 
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:345
 msgid "You are in Keywords Mapping View."
-msgstr ""
+msgstr "U bevindt zich in de weergave Trefwoordentoewijzin."
 
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:346
 msgid "If you wish to edit the gloss or add example sentences, switch to"
@@ -3393,7 +3393,7 @@ msgstr "voor deze glos"
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:661
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:1116
 msgid "Dismiss"
-msgstr ""
+msgstr "Sluiten"
 
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:370
 msgid "Gloss Sense Translations"
@@ -3427,7 +3427,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_keyword_list.html:563
 msgid "Regroup Kewords"
-msgstr ""
+msgstr "Hergroepeer trefwoorden"
 
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:8
 msgid "Signbank: Lemmas"
@@ -3465,11 +3465,11 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:360
 msgid "You have chosen to delete"
-msgstr ""
+msgstr "U hebt ervoor gekozen om"
 
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:360
 msgid "lemmas."
-msgstr ""
+msgstr "lemmata te verwijderen."
 
 #: signbank/dictionary/templates/dictionary/admin_lemma_list.html:380
 msgid "No lemmas found. Please enter a query."
@@ -3581,12 +3581,12 @@ msgstr "Zoek-geschiedenis"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:459
 msgid "No active search or query parameters."
-msgstr ""
+msgstr "Geen actieve zoek- of queryparameters."
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:462
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:565
 msgid "Query Parameters"
-msgstr ""
+msgstr "Queryparameters"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:467
 #: signbank/dictionary/templates/dictionary/gloss_detail.html:581
@@ -3618,7 +3618,7 @@ msgstr "Bewaar query"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:525
 msgid "Some parameters are not yet available for saving:"
-msgstr ""
+msgstr "Sommige parameters zijn nog niet beschikbaar voor opslag:"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:542
 msgid "Glosses Matching Query"
@@ -3626,7 +3626,7 @@ msgstr "Glossen die overeenkomen met Query"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:544
 msgid "Columns can be hidden to focus on relevant results."
-msgstr ""
+msgstr "Kolommen kunnen worden verborgen om de focus te leggen op relevante resultaten."
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:581
 msgid "Gloss List Fields"
@@ -3634,7 +3634,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:592
 msgid "Query Parameter Fields"
-msgstr ""
+msgstr "Queryparameter velden"
 
 #: signbank/dictionary/templates/dictionary/admin_query_list.html:603
 msgid "Publication Fields"
@@ -3731,7 +3731,7 @@ msgstr "Bewerk deze query"
 
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:205
 msgid "Update the description of this query."
-msgstr ""
+msgstr "Werk de beschrijving van deze query bij."
 
 #: signbank/dictionary/templates/dictionary/admin_search_history.html:210
 msgid "Query Name"
@@ -3873,7 +3873,7 @@ msgstr "Standaard taal"
 
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:129
 msgid "Conditions for data citation and usage"
-msgstr ""
+msgstr "Voorwaarden voor het citeren en gebruiken van data."
 
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:131
 msgid "Conditions of use by others"
@@ -3891,7 +3891,7 @@ msgstr ""
 
 #: signbank/dictionary/templates/dictionary/dataset_detail.html:150
 msgid "To view this dataset, please create an account or login."
-msgstr ""
+msgstr "Om deze dataset te bekijken, moet u een account aanmaken of inloggen."
 
 #: signbank/dictionary/templates/dictionary/dataset_field_choice_colors.html:271
 msgid "Signbank: Manage Field Choice Colors"
@@ -4231,7 +4231,7 @@ msgstr "Beheer dataset video-opslag"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:106
 msgid "Unlinked Gloss Video Files Available in File System"
-msgstr ""
+msgstr "Niet-gekoppelde glos-videobestanden beschikbaar in bestandssysteem"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:107
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:128

--- a/conf/locale/nl/LC_MESSAGES/django.po
+++ b/conf/locale/nl/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-13 12:47+0100\n"
+"POT-Creation-Date: 2025-03-14 11:15+0100\n"
 "PO-Revision-Date: 2018-03-08 18:54+0100\n"
 "Last-Translator: susanodd\n"
 "Language-Team: Dutch <LL@li.org>\n"
@@ -501,8 +501,8 @@ msgstr "Gebruiker"
 #: signbank/gloss_update.py:815 signbank/gloss_update.py:982
 #: signbank/gloss_update.py:989 signbank/gloss_update.py:1115
 #: signbank/gloss_update.py:1122 signbank/gloss_update.py:1199
-#: signbank/gloss_update.py:1206 signbank/video/admin.py:15
-#: signbank/video/admin.py:186 signbank/video/admin.py:228
+#: signbank/gloss_update.py:1206 signbank/video/admin.py:26
+#: signbank/video/admin.py:553 signbank/video/admin.py:595
 #: signbank/video/admin_update.py:20 signbank/video/admin_update.py:354
 #: signbank/video/admin_update.py:396
 msgid "Dataset"
@@ -606,7 +606,8 @@ msgstr " Hij behoort tot de dataset "
 #: signbank/dictionary/adminviews.py:1772
 #: signbank/dictionary/adminviews.py:3111
 msgid "The gloss you are trying to view is not in a dataset you can view."
-msgstr "De aangevraagde glos bevindt zich niet in een dataset die u kunt bekijken."
+msgstr ""
+"De aangevraagde glos bevindt zich niet in een dataset die u kunt bekijken."
 
 #: signbank/dictionary/adminviews.py:1569
 #: signbank/dictionary/adminviews.py:4752
@@ -882,7 +883,7 @@ msgstr ""
 #: signbank/dictionary/adminviews.py:4962
 #: signbank/dictionary/adminviews.py:5002
 msgid "No dataset with that acronym found."
-msgstr ""
+msgstr "Geen dataset met dat acroniem gevonden."
 
 #: signbank/dictionary/adminviews.py:4931
 msgid "No permission to import speakers for this dataset."
@@ -916,19 +917,19 @@ msgstr "Corpus met succes bijgewerkt."
 
 #: signbank/dictionary/adminviews.py:5107
 msgid "The requested morpheme does not exist."
-msgstr ""
+msgstr "Aangevraagd morfeem bestaat niet."
 
 #: signbank/dictionary/adminviews.py:5111
 msgid "Requested morpheme has no lemma or dataset."
-msgstr ""
+msgstr "Aangevraagd morfeem heeft geen lemma nog dataset."
 
 #: signbank/dictionary/adminviews.py:5125
 msgid "The morpheme you are trying to view is not in your selected datasets."
-msgstr ""
+msgstr "De aangevraagde morfeem bevindt zich niet in de geselecteerde datasets."
 
 #: signbank/dictionary/adminviews.py:5130
 msgid "The morpheme you are trying to view is not in a dataset you can view."
-msgstr ""
+msgstr "De aangevraagde morfeem bevindt zich niet in een dataset die u kunt bekijken."
 
 #: signbank/dictionary/adminviews.py:5770
 #: signbank/dictionary/adminviews.py:5784
@@ -1117,11 +1118,11 @@ msgstr "Type relatie"
 
 #: signbank/dictionary/adminviews.py:6282
 msgid "You have no permission to delete lemmas."
-msgstr ""
+msgstr "Je hebt geen toestemming om lemma's te verwijderen."
 
 #: signbank/dictionary/adminviews.py:6287
 msgid "Incorrect deletion code."
-msgstr ""
+msgstr "Onjuiste verwijderingscode."
 
 #: signbank/dictionary/adminviews.py:6293
 #: signbank/dictionary/adminviews.py:6306
@@ -1133,7 +1134,7 @@ msgstr ""
 #: signbank/dictionary/adminviews.py:6371
 #: signbank/dictionary/adminviews.py:6563
 msgid "Lemma ID Gloss is not unique for that language."
-msgstr ""
+msgstr "Lemma-ID-Glos is niet uniek voor die taal"
 
 #: signbank/dictionary/adminviews.py:6408
 msgid "The specified gloss does not exist."
@@ -1145,7 +1146,7 @@ msgstr "Lemma-ID-Glos is niet uniek."
 
 #: signbank/dictionary/adminviews.py:6440
 msgid "The form contains errors."
-msgstr ""
+msgstr "De invoerformulier bevat fouten."
 
 #: signbank/dictionary/adminviews.py:6588
 msgid "The changes to the lemma have been saved."
@@ -1157,11 +1158,11 @@ msgstr ""
 
 #: signbank/dictionary/adminviews.py:6619
 msgid "The requested lemma does not exist."
-msgstr ""
+msgstr "Aangevraagd lemma bestaat niet."
 
 #: signbank/dictionary/adminviews.py:6623
 msgid "Requested lemma has no dataset."
-msgstr ""
+msgstr "Aangevraagd lemma heeft geen dataset."
 
 #: signbank/dictionary/adminviews.py:6634
 msgid "The lemma you are trying to view is not in your selected datasets."
@@ -1173,7 +1174,7 @@ msgstr ""
 
 #: signbank/dictionary/adminviews.py:6654
 msgid "There are glosses using this lemma."
-msgstr ""
+msgstr "Er zijn glossen die dit lemma gebruiken."
 
 #: signbank/dictionary/adminviews.py:6678
 #: signbank/dictionary/adminviews.py:6716
@@ -2299,7 +2300,7 @@ msgstr "Voeg nieuw lemma toe"
 
 #: signbank/dictionary/templates/dictionary/add_gloss.html:147
 msgid "Type in the initial letters to see if the lemma already exists."
-msgstr "Typ de eerste letters van de lemma om te checken of die al bestaat."
+msgstr "Typ de eerste letters van het lemma om te checken of het al bestaat."
 
 #: signbank/dictionary/templates/dictionary/add_gloss.html:176
 msgid "Copy Annotation Fields to Lemma Translations"
@@ -4256,7 +4257,7 @@ msgstr "Bestandssysteempaden"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:127
 msgid "Glosses with Multiple Version 0 Videos"
-msgstr ""
+msgstr "Glossen met meerdere versie 0 videobestanden"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:136
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:167
@@ -4271,22 +4272,22 @@ msgstr "Glos-ID"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:158
 msgid "Glosses with Extra Characters in Video Filename"
-msgstr ""
+msgstr "Glossen met extra tekens in video bestandsnaam"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:188
 msgid "Glosses with Wrong Folder for Video"
-msgstr ""
+msgstr "Glossen met verkeerde map voor video"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:202
 msgid "Exists"
-msgstr ""
+msgstr "Bestaat"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:231
 msgid "Gloss Video Files with non-mp4 Extensions"
-msgstr ""
+msgstr "Glos-video's zonder mp4-extensie"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:261
-msgid "Gloss Videos with Non-manual Elements"
+msgid "Gloss NME Videos"
 msgstr "Glos-video's met non-manuele elementen"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:299
@@ -4303,7 +4304,7 @@ msgstr "Operaties"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:358
 msgid "Renumber backup files; match extension to video type."
-msgstr ""
+msgstr "Back-upbestanden opnieuw nummeren; overeenkomen met de video-extensie"
 
 #: signbank/dictionary/templates/dictionary/dataset_video_storage.html:377
 msgid "Rename"
@@ -5914,7 +5915,7 @@ msgstr ""
 
 #: signbank/dictionary/update.py:942 signbank/dictionary/update.py:2596
 msgid "The specified lemma does not exist."
-msgstr ""
+msgstr "bestaat niet."
 
 #: signbank/dictionary/update.py:1775
 msgid ""
@@ -5972,7 +5973,7 @@ msgstr ""
 
 #: signbank/dictionary/update.py:2594
 msgid "The dataset of the morpheme is not the same as that of the lemma."
-msgstr "De dataset van de morfeem komt niet overeen met die van de lemma."
+msgstr "De dataset van de morfeem komt niet overeen met die van het lemma."
 
 #: signbank/dictionary/update.py:2964
 msgid "You must be in group Dataset Manager to modify dataset details."
@@ -6008,7 +6009,7 @@ msgstr ""
 
 #: signbank/dictionary/update.py:3387
 msgid "Already imported to different folder: "
-msgstr ""
+msgstr "Al geïmporteerd naar een andere map: "
 
 #: signbank/dictionary/update.py:3519
 msgid "You do not have permission to change glosses."
@@ -6016,11 +6017,11 @@ msgstr "Gebruiker heeft geen rechten om gebaren te wijzigen."
 
 #: signbank/dictionary/update.py:3546
 msgid "You do not have change permission for"
-msgstr ""
+msgstr "U hebt geen wijzigingsrechten voor"
 
 #: signbank/dictionary/update.py:3554
 msgid "Error assigning lemma to gloss."
-msgstr ""
+msgstr "Fout bij het toewijzen van lemma aan glos."
 
 #: signbank/dictionary/views.py:102
 msgid "You are not allowed to see this sign."
@@ -6037,12 +6038,12 @@ msgstr ""
 #: signbank/dictionary/views.py:498 signbank/dictionary/views.py:918
 #: signbank/dictionary/views.py:2827
 msgid "Unrecognised format in selected CSV file."
-msgstr ""
+msgstr "Onbekend formaat in geselecteerd CSV-bestand."
 
 #: signbank/dictionary/views.py:524 signbank/dictionary/views.py:981
 #: signbank/dictionary/views.py:1509 signbank/dictionary/views.py:2852
 msgid "The delimiter is not comma, tab, or semicolon."
-msgstr ""
+msgstr "Het scheidingsteken is geen komma, tab of puntkomma."
 
 #: signbank/dictionary/views.py:526 signbank/dictionary/views.py:983
 #: signbank/dictionary/views.py:1511 signbank/dictionary/views.py:2854
@@ -6052,7 +6053,7 @@ msgstr "De koprij van het bestand zou zo eruit moeten zien: "
 #: signbank/dictionary/views.py:528 signbank/dictionary/views.py:985
 #: signbank/dictionary/views.py:1513 signbank/dictionary/views.py:2856
 msgid "Some required column headers are missing: "
-msgstr ""
+msgstr "Sommige vereiste kolomkoppen ontbreken: "
 
 #: signbank/dictionary/views.py:541 signbank/dictionary/views.py:1000
 msgid "Empty Column Header Found."
@@ -6077,15 +6078,15 @@ msgstr "De kolom 'Signbank ID' is verplicht."
 #: signbank/dictionary/views.py:1141
 msgid ""
 "Attempt to update Lemma translations. Use Import CSV Lemma Update instead."
-msgstr ""
+msgstr "Poging om Lemma bij te werken. Gebruik in plaats daarvan: Import CSV Update Lemma."
 
 #: signbank/dictionary/views.py:1208
 msgid "Attempt to update Lemma translations. Use Import CSV Lemma Update."
-msgstr ""
+msgstr "Poging om Lemma bij te werken. Gebruik in plaats daarvan: Import CSV Update Lemma."
 
 #: signbank/dictionary/views.py:1443
 msgid "Please select a single dataset for which you have change permission."
-msgstr ""
+msgstr "Selecteer een enkele dataset waarvoor u wijzigingsrechten hebt."
 
 #: signbank/dictionary/views.py:1461
 msgid "You do not have change permission for the chosen dataset."
@@ -6099,11 +6100,11 @@ msgstr ""
 
 #: signbank/dictionary/views.py:1856 signbank/dictionary/views.py:1983
 msgid "File extension not supported! Please convert to png or jpg"
-msgstr ""
+msgstr "Bestandsextensie niet ondersteund! Converteer het bestand naar png of jpg"
 
 #: signbank/dictionary/views.py:1864 signbank/dictionary/views.py:1990
 msgid "Uploaded file too large!"
-msgstr ""
+msgstr "Geüploade bestand te groot!"
 
 #: signbank/dictionary/views.py:2017
 msgid "Error uploading handshape image. Please consult the administrator."
@@ -6114,7 +6115,8 @@ msgid "NME Video Description"
 msgstr "NME video beschrijving"
 
 #: signbank/dictionary/views.py:2546 signbank/dictionary/views.py:2548
-#: signbank/dictionary/views.py:2550 signbank/video/admin_update.py:99
+#: signbank/dictionary/views.py:2550 signbank/video/admin.py:163
+#: signbank/video/admin_update.py:99
 msgid "NME Video"
 msgstr "NME video"
 
@@ -6140,7 +6142,7 @@ msgstr "Aangevraagd glos bestaat niet in de dataset."
 
 #: signbank/feedback/models.py:114
 msgid "Comment or new keywords"
-msgstr ""
+msgstr "Commentaar of nieuwe trefwoorden"
 
 #: signbank/feedback/models.py:123
 msgid "Sign Meaning"
@@ -6187,11 +6189,11 @@ msgstr ""
 
 #: signbank/feedback/templates/feedback/generalfeedback.html:30
 msgid "General comments, suggestions, or anything you feel like telling us."
-msgstr ""
+msgstr "Algemene opmerkingen, suggesties, alles wat je ons wilt vertellen."
 
 #: signbank/feedback/templates/feedback/generalfeedback.html:36
 msgid " Upload your feedback as a video."
-msgstr ""
+msgstr " Upload uw feedback als video."
 
 #: signbank/feedback/templates/feedback/generalfeedback.html:39
 msgid ""
@@ -6238,7 +6240,7 @@ msgstr ""
 
 #: signbank/feedback/templates/feedback/index.html:34
 msgid "We thank you in advance for your contribution and cooperation."
-msgstr ""
+msgstr "Wij danken u bij voorbaat voor uw bijdrage en medewerking."
 
 #: signbank/feedback/templates/feedback/index.html:39
 #, python-format
@@ -6654,7 +6656,7 @@ msgstr "Voorbeeldzin"
 msgid "Sentence"
 msgstr "Zin"
 
-#: signbank/settings/server_specific/default.py:69
+#: signbank/settings/server_specific/default.py:70
 #: signbank/settings/server_specific/global_sb_local.py:28
 #: signbank/settings/server_specific/global_sb_new_aj.py:14
 #: signbank/settings/server_specific/server_specific.py:28
@@ -6685,35 +6687,43 @@ msgstr "Hebreeuws"
 msgid "Arabic"
 msgstr "Arabisch"
 
-#: signbank/video/admin.py:32 signbank/video/admin_update.py:37
+#: signbank/video/admin.py:48 signbank/video/admin_update.py:37
 msgid "File System Group"
-msgstr ""
+msgstr "Bestandssysteemgroep"
 
-#: signbank/video/admin.py:63 signbank/video/admin_update.py:68
+#: signbank/video/admin.py:82 signbank/video/admin_update.py:68
 msgid "File Exists"
-msgstr ""
+msgstr "Bestand bestaat"
 
-#: signbank/video/admin.py:203 signbank/video/admin_update.py:371
-msgid "Actor"
-msgstr ""
+#: signbank/video/admin.py:118
+msgid "Filename Correct"
+msgstr "Bestandsnaam klopt"
 
-#: signbank/video/admin_update.py:114
+#: signbank/video/admin.py:186 signbank/video/admin_update.py:114
 msgid "Perspective Video"
 msgstr "Video met perspectief"
 
-#: signbank/video/admin_update.py:129
+#: signbank/video/admin.py:209 signbank/video/admin_update.py:129
 msgid "MP4 File"
 msgstr "MP4-bestand"
+
+#: signbank/video/admin.py:244
+msgid "Backup Video"
+msgstr "Back-upvideo"
+
+#: signbank/video/admin.py:570 signbank/video/admin_update.py:371
+msgid "Actor"
+msgstr ""
 
 #: signbank/video/forms.py:32
 msgid "Video Perspective"
 msgstr "Video-perspectief"
 
-#: signbank/video/models.py:890
+#: signbank/video/models.py:929
 msgid "NME Gloss Video"
 msgstr "NME glos-video"
 
-#: signbank/video/models.py:987
+#: signbank/video/models.py:1040
 msgid "Gloss Video Perspective"
 msgstr "Glos-video met perspectief"
 
@@ -6971,6 +6981,9 @@ msgstr "vind alle strings in dit veld"
 #: templates/global-templates/tooltip.html:25
 msgid "use backslash to find <br/>special characters in field"
 msgstr "gebruik backslash om <br/>speciale karakters te zoeken"
+
+#~ msgid "Gloss Videos with Non-manual Elements"
+#~ msgstr "Glos-video's met non-manuele elementen"
 
 #~ msgid ""
 #~ "Please refine your query to retrieve fewer than 100 glosses to use this "

--- a/signbank/api_interface.py
+++ b/signbank/api_interface.py
@@ -1,42 +1,16 @@
-import json
-import urllib.request
-import tempfile
-import shutil
-import os
+
 import stat
-import zipfile
 import sys
 
 from urllib.parse import quote
-from urllib.error import URLError
-from requests.exceptions import InvalidURL
 from guardian.shortcuts import get_objects_for_user, get_user_perms
-from tagging.models import Tag, TaggedItem
-
-from django.shortcuts import get_object_or_404
-from django.contrib.auth.models import Group, User
-from django.contrib.auth.decorators import permission_required
-from django.views.decorators.csrf import csrf_exempt
-from django.utils.translation import override, gettext_lazy as _, activate
-from django.http import HttpResponse, HttpResponseRedirect, HttpResponseForbidden, HttpResponseBadRequest, JsonResponse, StreamingHttpResponse
-from django.urls import reverse, reverse_lazy
-
-from django.core.exceptions import ObjectDoesNotExist
-from django.core.files.base import ContentFile, File
-
-from django.db import DatabaseError, IntegrityError
-from django.db.transaction import TransactionManagementError
-from django.db.models import FileField
 
 import signbank.tools
-from signbank.dictionary.models import *
-from signbank.dictionary.forms import *
-from signbank.settings.server_specific import LANGUAGES, LEFT_DOUBLE_QUOTE_PATTERNS, RIGHT_DOUBLE_QUOTE_PATTERNS, VIDEOS_TO_IMPORT_FOLDER
 from signbank.api_token import put_api_user_in_request
-from signbank.abstract_machine import get_interface_language_api, get_human_readable_value_dict
-from signbank.video.convertvideo import probe_format
-from signbank.video.models import GlossVideo, GlossVideoHistory
+from signbank.abstract_machine import get_interface_language_api
 from signbank.zip_interface import *
+from django.utils.translation import activate, gettext
+import zipfile
 
 
 def check_api_dataset_manager_permissions(request, datasetid):
@@ -266,7 +240,6 @@ def get_gloss_data_json(request, datasetid, glossid):
 @put_api_user_in_request
 def get_annotated_sentences_of_gloss_json(request, datasetid, glossid):
 
-    from django.utils.translation import gettext_lazy as _, activate, gettext
     interface_language_code = request.headers.get('Accept-Language', 'en')
     if interface_language_code not in settings.MODELTRANSLATION_LANGUAGES:
         interface_language_code = 'en'

--- a/signbank/registration/locale/nl/LC_MESSAGES/django.po
+++ b/signbank/registration/locale/nl/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-08 15:18+0100\n"
+"POT-Creation-Date: 2025-03-13 12:47+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,216 +17,216 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: forms.py:51
+#: signbank/registration/forms.py:51
 msgid "Username"
 msgstr ""
 
-#: forms.py:54
+#: signbank/registration/forms.py:54
 msgid "First Name"
 msgstr ""
 
-#: forms.py:57
+#: signbank/registration/forms.py:57
 msgid "Last Name"
 msgstr ""
 
-#: forms.py:59
+#: signbank/registration/forms.py:59
 msgid "Your Email Address"
 msgstr ""
 
-#: forms.py:61 forms.py:231
+#: signbank/registration/forms.py:61 signbank/registration/forms.py:231
 msgid "Password"
 msgstr ""
 
-#: forms.py:63
+#: signbank/registration/forms.py:63
 msgid "Password (again)"
 msgstr ""
 
-#: forms.py:77
+#: signbank/registration/forms.py:77
 msgid "Requested Datasets"
 msgstr ""
 
-#: forms.py:82
+#: signbank/registration/forms.py:82
 msgid "Motivation"
 msgstr ""
 
-#: forms.py:89
+#: signbank/registration/forms.py:89
 msgid ""
 "Please explain why you would like to get access to this dataset. What are "
 "the purposes for which you wish to use it?"
 msgstr ""
 
-#: forms.py:106
+#: signbank/registration/forms.py:106
 msgid "Usernames should not have special characters."
 msgstr ""
 
-#: forms.py:111
+#: signbank/registration/forms.py:111
 msgid "This username is already taken. Please choose another."
 msgstr ""
 
-#: forms.py:121
+#: signbank/registration/forms.py:121
 msgid "You must type the same password each time"
 msgstr ""
 
-#: forms.py:130
+#: signbank/registration/forms.py:130
 msgid "Please provide motivation for your request"
 msgstr ""
 
-#: forms.py:139
+#: signbank/registration/forms.py:139
 msgid "Please consider the Terms of Service."
 msgstr ""
 
-#: forms.py:180
+#: signbank/registration/forms.py:180
 msgid "I have read and agree to the Terms of Service"
 msgstr ""
 
-#: forms.py:189
+#: signbank/registration/forms.py:189
 msgid "You must agree to the terms to register"
 msgstr ""
 
-#: forms.py:208
+#: signbank/registration/forms.py:208
 msgid ""
 "This email address is already in use. Please supply a different email "
 "address."
 msgstr ""
 
-#: forms.py:230
+#: signbank/registration/forms.py:230
 msgid "Email"
 msgstr ""
 
-#: forms.py:251
+#: signbank/registration/forms.py:251
 msgid ""
 "Please enter a correct email and password. Note that password is case-"
 "sensitive."
 msgstr ""
 
-#: forms.py:253
+#: signbank/registration/forms.py:253
 msgid "This account is inactive."
 msgstr ""
 
-#: forms.py:258
+#: signbank/registration/forms.py:258
 msgid ""
 "Your Web browser doesn't appear to have cookies enabled. Cookies are "
 "required for logging in."
 msgstr ""
 
-#: models.py:206
+#: signbank/registration/models.py:206
 msgid "user"
 msgstr ""
 
-#: models.py:207
+#: signbank/registration/models.py:207
 msgid "activation key"
 msgstr ""
 
-#: models.py:212
+#: signbank/registration/models.py:212
 msgid "registration profile"
 msgstr ""
 
-#: models.py:213
+#: signbank/registration/models.py:213
 msgid "registration profiles"
 msgstr ""
 
-#: templates/registration/registration_complete.html:8
+#: signbank/registration/templates/registration/registration_complete.html:8
 msgid "Signbank Registration"
 msgstr ""
 
-#: templates/registration/registration_complete.html:9
+#: signbank/registration/templates/registration/registration_complete.html:9
 msgid "The following user registration request has been accepted:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:11
+#: signbank/registration/templates/registration/registration_complete.html:11
 msgid "Username:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:12
+#: signbank/registration/templates/registration/registration_complete.html:12
 msgid "First name:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:13
+#: signbank/registration/templates/registration/registration_complete.html:13
 msgid "Last name:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:14
+#: signbank/registration/templates/registration/registration_complete.html:14
 msgid "E-mail:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:15
+#: signbank/registration/templates/registration/registration_complete.html:15
 msgid "Requested datasets:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:22
+#: signbank/registration/templates/registration/registration_complete.html:22
 msgid "Groups:"
 msgstr ""
 
-#: templates/registration/registration_complete.html:31
+#: signbank/registration/templates/registration/registration_complete.html:31
 msgid ""
 "An email has been sent to your nominated address. Please check your email "
 "for details of how to complete the registration process."
 msgstr ""
 
-#: templates/registration/registration_form.html:54
+#: signbank/registration/templates/registration/registration_form.html:54
 msgid "Registration"
 msgstr ""
 
-#: templates/user_profile.html:54
+#: signbank/registration/templates/user_profile.html:54
 msgid "User Profile"
 msgstr ""
 
-#: templates/user_profile.html:60
+#: signbank/registration/templates/user_profile.html:60
 msgid "View Permission for Public Signs in Datasets"
 msgstr ""
 
-#: templates/user_profile.html:78
+#: signbank/registration/templates/user_profile.html:78
 msgid "Selected Datasets"
 msgstr ""
 
-#: templates/user_profile.html:79
+#: signbank/registration/templates/user_profile.html:79
 msgid "View Permission"
 msgstr ""
 
-#: templates/user_profile.html:80
+#: signbank/registration/templates/user_profile.html:80
 msgid "Change Permission"
 msgstr ""
 
-#: templates/user_profile.html:90
+#: signbank/registration/templates/user_profile.html:90
 msgid "days remaining"
 msgstr ""
 
-#: templates/user_profile.html:121
+#: signbank/registration/templates/user_profile.html:121
 msgid "Extend Expiry"
 msgstr ""
 
-#: templates/user_profile.html:130
+#: signbank/registration/templates/user_profile.html:130
 msgid "Affiliation"
 msgstr "Affiliatie"
 
-#: templates/user_profile.html:144
+#: signbank/registration/templates/user_profile.html:144
 msgid "Signbank API Tokens"
 msgstr "Signbank API-tokens"
 
-#: templates/user_profile.html:149
+#: signbank/registration/templates/user_profile.html:149
 msgid "A Signbank API Token was created on"
 msgstr "Een Signbank API-token is aangemaakt op"
 
-#: templates/user_profile.html:159
+#: signbank/registration/templates/user_profile.html:159
 msgid "Generate Signbank API Token"
 msgstr "Maak een Signbank API-token aan"
 
-#: templates/user_profile.html:176
+#: signbank/registration/templates/user_profile.html:176
 msgid "Recently Saved Queries"
 msgstr "Bewaarde zoekopdrachten"
 
-#: templates/user_profile.html:181
+#: signbank/registration/templates/user_profile.html:181
 msgid "Search History"
 msgstr "Zoek-geschiedenis"
 
-#: views.py:212
+#: signbank/registration/views.py:212
 msgid "Error processing your request."
 msgstr ""
 
-#: views.py:255
+#: signbank/registration/views.py:255
 msgid "This account has expired. Please contact w.stoop@let.ru.nl."
 msgstr ""
 
-#: views.py:274
+#: signbank/registration/views.py:274
 msgid "The username or password is incorrect."
 msgstr ""


### PR DESCRIPTION

- Side effect (this issue makes changes of other issue): File api_interface.py (See changed files)

I needed to reorder the import of `gettext` because it wasn't being recognised as imported by PyCharm type-checking.
I also removed the greyed out imports that are not used according to PyCharm. The import of `zipfile` also needed to be moved below other imports for it to be "not grey".

- How to translate "you" ?

Both forms are used in the translations. (Most of the time because it's catch phrases used in computer jargon.) Since there are thousands of translations, I'm just going to leave it as is.