### PR TITLE
#1406: Gloss Videos List View, Search Form, template

### DIFF
--- a/signbank/dataset_operations.py
+++ b/signbank/dataset_operations.py
@@ -1,7 +1,7 @@
 import os.path
 from django.contrib.auth.decorators import permission_required
 from signbank.dictionary.models import *
-from signbank.video.models import GlossVideo, GlossVideoNME, GlossVideoPerspective
+from signbank.video.models import GlossVideo, GlossVideoNME, GlossVideoPerspective, filename_matches_backup_video
 from signbank.video.convertvideo import video_file_type_extension
 from signbank.tools import get_two_letter_dir
 import re
@@ -71,14 +71,15 @@ def rename_backup_videos(gloss):
     for inx, glossvideo in enumerate(glossvideos, 1):
         video_file_full_path = os.path.join(WRITABLE_FOLDER, str(glossvideo.videofile))
         video_extension = video_file_type_extension(video_file_full_path)
-        desired_filename_without_extension = f'{idgloss}-{glossid}{video_extension}'
+        # keep this a normal string concatenation, not an f-string
+        desired_filename_without_extension = idgloss + '-' + glossid + video_extension
         _, bak = os.path.splitext(glossvideo.videofile.name)
         desired_extension = '.bak' + str(glossvideo.id)
         desired_filename = desired_filename_without_extension + desired_extension
         desired_relative_path = os.path.join(settings.GLOSS_VIDEO_DIRECTORY,
                                              dataset_dir, two_letter_dir, desired_filename)
         current_relative_path = str(glossvideo.videofile)
-        if current_relative_path == desired_relative_path:
+        if filename_matches_backup_video(current_relative_path):
             continue
         source = os.path.join(settings.WRITABLE_FOLDER, current_relative_path)
         destination = os.path.join(WRITABLE_FOLDER, desired_relative_path)
@@ -173,7 +174,8 @@ def rename_gloss_video(gloss):
     dataset_dir = gloss.lemma.dataset.acronym
     video_file_full_path = os.path.join(WRITABLE_FOLDER, str(glossvideo.videofile))
     video_extension = video_file_type_extension(video_file_full_path)
-    desired_filename = f'{idgloss}-{glossid}{video_extension}'
+    # keep this a normal string concatenation, not an f-string
+    desired_filename = idgloss + '-' + glossid + video_extension
     desired_relative_path = os.path.join(settings.GLOSS_VIDEO_DIRECTORY,
                                          dataset_dir, two_letter_dir, desired_filename)
     current_relative_path = str(glossvideo.videofile)

--- a/signbank/dataset_operations.py
+++ b/signbank/dataset_operations.py
@@ -356,7 +356,7 @@ def update_gloss_video_backups(request, glossid):
 
     glossvideos = GlossVideo.objects.filter(gloss=gloss,
                                             glossvideonme=None,
-                                            glossvideoperspective=None).order_by('version')
+                                            glossvideoperspective=None, version__gt=0).order_by('version')
     list_videos = ', '.join([str(gv.version) + ': ' + str(gv.videofile) for gv in glossvideos])
 
     return JsonResponse({'videos': list_videos})

--- a/signbank/dictionary/dataset_views.py
+++ b/signbank/dictionary/dataset_views.py
@@ -244,6 +244,5 @@ class GlossVideoListView(ListView):
             if display_glossvideos or display_glossbackupvideos or display_perspvideos or display_nmevideos or display_wrong_videos:
                 gloss_videos.append((gloss, num_backup_videos, display_glossvideos,
                                      display_glossbackupvideos, display_perspvideos, display_nmevideos, display_wrong_videos))
-
         return (gloss_videos, count_video_objects,
                 count_glossvideos, count_glossbackupvideos, count_glossperspvideos, count_glossnmevideos, count_wrong_filename)

--- a/signbank/dictionary/dataset_views.py
+++ b/signbank/dictionary/dataset_views.py
@@ -4,8 +4,9 @@ from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 from django.core.paginator import Paginator
 from django.views.generic.edit import CreateView, DeleteView, UpdateView
+from signbank.video.models import GlossVideo
 from signbank.dictionary.models import Dataset, Gloss, AnnotationIdglossTranslation
-
+from signbank.dictionary.forms import GlossVideoSearchForm
 from signbank.dataset_operations import (find_unlinked_video_files_for_dataset, gloss_annotations_check, gloss_videos_check, gloss_video_filename_check, gloss_subclass_videos_check)
 from signbank.tools import get_dataset_languages
 from signbank.settings.server_specific import *
@@ -16,6 +17,7 @@ from django.contrib import messages
 from django.shortcuts import *
 from django.conf import settings
 from django.utils.translation import override, gettext, gettext_lazy as _, activate
+from signbank.query_parameters import set_up_language_fields
 
 
 class DatasetConstraintsView(DetailView):
@@ -82,3 +84,71 @@ class DatasetConstraintsView(DetailView):
 
         return context
 
+
+class GlossVideoListView(ListView):
+    model = GlossVideo
+    template_name = 'dictionary/admin_dataset_videos_list.html'
+    dataset = None
+    search_form = GlossVideoSearchForm()
+
+
+    def get_context_data(self, **kwargs):
+        # Call the base implementation first to get a context
+
+        if 'pk' in kwargs:
+            self.dataset = get_object_or_404(Dataset, pk=kwargs['pk'])
+        context = super(GlossVideoListView, self).get_context_data(**kwargs)
+
+        context['dataset'] = self.dataset
+        selected_datasets = get_selected_datasets(self.request)
+        dataset_languages = get_dataset_languages(selected_datasets)
+        context['dataset_languages'] = dataset_languages
+        context['default_language'] = self.dataset.default_language if self.dataset else ''
+
+        context['SHOW_DATASET_INTERFACE_OPTIONS'] = getattr(settings, 'SHOW_DATASET_INTERFACE_OPTIONS', False)
+        context['USE_REGULAR_EXPRESSIONS'] = getattr(settings, 'USE_REGULAR_EXPRESSIONS', False)
+
+        glosses = Gloss.objects.filter(lemma__dataset=self.dataset, morpheme=None)
+        nr_of_glosses = glosses.count()
+        context['nr_of_glosses'] = nr_of_glosses
+
+        context['gloss_videos'] = self.get_query_set()
+        context['searchform'] = self.search_form
+
+        return context
+
+    def get_query_set(self):
+        get = self.request.GET
+
+        selected_datasets = get_selected_datasets(self.request)
+        if not self.dataset:
+            self.dataset = selected_datasets.first()
+        default_language = self.dataset.default_language
+
+        if not self.search_form.is_bound:
+            # if the search_form is not bound, then
+            # this is the first time the get_queryset function is called for this view
+            # it has already been initialised with the __init__ method, but
+            # the language fields are dynamic and are not inside the form yet
+            # they depend on the selected datasets which are inside the request, which
+            # is not available to the __init__ method
+            set_up_language_fields(GlossVideo, self, self.search_form)
+
+        gloss_videos = []
+
+        all_glosses = Gloss.objects.filter(lemma__dataset=self.dataset,
+                                           lemma__lemmaidglosstranslation__language=default_language).order_by(
+            'lemma__lemmaidglosstranslation__text').distinct()
+
+        for gloss in all_glosses:
+
+            glossvideos = GlossVideo.objects.filter(gloss=gloss,
+                gloss__lemma__dataset__in=selected_datasets).order_by('gloss__annotationidglosstranslation__text', 'version')
+
+            num_videos = glossvideos.count()
+
+            if num_videos > 0:
+                list_videos = ', '.join([str(gv.version)+': '+str(gv.videofile) for gv in glossvideos])
+                gloss_videos.append((gloss, num_videos, list_videos))
+
+        return gloss_videos

--- a/signbank/dictionary/dataset_views.py
+++ b/signbank/dictionary/dataset_views.py
@@ -255,9 +255,6 @@ class GlossVideoListView(ListView):
             if list_glossvideos or list_glossbackupvideos or list_perspvideos or list_nmevideos:
                 gloss_videos.append((gloss, num_backup_videos, list_glossvideos, list_glossbackupvideos, list_perspvideos, list_nmevideos))
 
-        # save the query parameters to a session variable
-        self.request.session['query_parameters'] = json.dumps(query_parameters)
-        self.request.session.modified = True
         self.query_parameters = query_parameters
 
         return gloss_videos, count_glossvideos, count_glossbackupvideos, count_glossperspvideos, count_glossnmevideos

--- a/signbank/dictionary/dataset_views.py
+++ b/signbank/dictionary/dataset_views.py
@@ -126,13 +126,6 @@ class GlossVideoListView(ListView):
 
         context['searchform'] = self.search_form
 
-        context['language_query_keys'] = [language.language_code_2char for language in dataset_languages]
-
-        # data structures to store the query parameters in order to keep them in the form
-        context['query_parameters'] = json.dumps(self.query_parameters)
-        query_parameters_keys = list(self.query_parameters.keys())
-        context['query_parameters_keys'] = json.dumps(query_parameters_keys)
-
         (gloss_videos, count_glossvideos,
          count_glossbackupvideos, count_glossperspvideos, count_glossnmevideos) = self.get_query_set()
         context['gloss_videos'] = gloss_videos
@@ -140,6 +133,16 @@ class GlossVideoListView(ListView):
         context['count_glossbackupvideos'] = count_glossbackupvideos
         context['count_glossperspvideos'] = count_glossperspvideos
         context['count_glossnmevideos'] = count_glossnmevideos
+
+        # data structures to store the query parameters in order to keep them in the form
+        prefixes = [GlossVideoSearchForm.gloss_search_field_prefix, GlossVideoSearchForm.lemma_search_field_prefix,
+                    GlossVideoSearchForm.keyword_search_field_prefix]
+        context['language_query_keys'] = json.dumps([prefix + language.language_code_2char
+                                                     for language in dataset_languages for prefix in prefixes])
+        context['select_query_keys'] = json.dumps(['isNormalVideo', 'isNMEVideo', 'isPerspectiveVideo', 'isBackup'])
+        context['query_parameters'] = json.dumps(self.query_parameters)
+        query_parameters_keys = list(self.query_parameters.keys())
+        context['query_parameters_keys'] = json.dumps(query_parameters_keys)
 
         return context
 
@@ -255,6 +258,7 @@ class GlossVideoListView(ListView):
             if list_glossvideos or list_glossbackupvideos or list_perspvideos or list_nmevideos:
                 gloss_videos.append((gloss, num_backup_videos, list_glossvideos, list_glossbackupvideos, list_perspvideos, list_nmevideos))
 
+        # the active query parameters are passed to the context via self
         self.query_parameters = query_parameters
 
         return gloss_videos, count_glossvideos, count_glossbackupvideos, count_glossperspvideos, count_glossnmevideos

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -6,6 +6,7 @@ from django.utils.translation import override, gettext_lazy as _, get_language
 from django.db import OperationalError, ProgrammingError
 from django.db.transaction import atomic
 from signbank.video.fields import VideoUploadToFLVField
+from signbank.video.models import GlossVideo
 from signbank.dictionary.models import (Dialect, Gloss, Morpheme, Definition, Relation, RelationToForeignSign,
                                         MorphologyDefinition, OtherMedia, Handshape, SemanticField, DerivationHistory,
                                         AnnotationIdglossTranslation, Dataset, FieldChoice, LemmaIdgloss, AnnotatedSentence,
@@ -1624,3 +1625,37 @@ class AnnotatedGlossForm(forms.ModelForm):
         super(AnnotatedGlossForm, self).__init__(*args, **kwargs)
 
         self.fields['isRepresentative'].choices = [('0', '-'), ('yes', _('Yes')), ('no', _('No'))]
+
+
+class GlossVideoSearchForm(forms.ModelForm):
+
+    isPerspectiveVideo = forms.ChoiceField(label=_('Is Perspective Video'),
+                                           choices=[(0, '-')],
+                                           widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    isNMEVideo = forms.ChoiceField(label=_('Is NME Video'),
+                                    choices=[(0, '-')],
+                                    widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    correctFilename = forms.ChoiceField(label=_('Correct Filename'),
+                                        choices=[(0, '-')],
+                                        widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+
+    gloss_search_field_prefix = "glosssearch_"
+    keyword_search_field_prefix = "keyword_"
+    lemma_search_field_prefix = "lemma_"
+
+    class Meta:
+
+        ATTRS_FOR_FORMS = {'class': 'form-control'}
+
+        model = GlossVideo
+
+        fields = ['gloss', 'videofile', 'version']
+
+    def __init__(self, *args, **kwargs):
+        super(GlossVideoSearchForm, self).__init__(*args, **kwargs)
+
+        # language fields will be set up elsewhere
+        # field choice choices will be set up elsewhere
+
+        for boolean_field in ['isPerspectiveVideo', 'isNMEVideo', 'correctFilename']:
+            self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -1629,7 +1629,7 @@ class AnnotatedGlossForm(forms.ModelForm):
 
 class GlossVideoSearchForm(forms.ModelForm):
 
-    isNormalVideo = forms.ChoiceField(label=_('Is Primary Video'),
+    isPrimaryVideo = forms.ChoiceField(label=_('Is Primary Video'),
                                       choices=[(0, '-')],
                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     isPerspectiveVideo = forms.ChoiceField(label=_('Is Perspective Video'),
@@ -1662,5 +1662,5 @@ class GlossVideoSearchForm(forms.ModelForm):
 
         # language fields will be set up elsewhere
 
-        for boolean_field in ['isNormalVideo', 'isPerspectiveVideo', 'isNMEVideo', 'isBackup', 'correctFilename']:
+        for boolean_field in ['isPrimaryVideo', 'isPerspectiveVideo', 'isNMEVideo', 'isBackup', 'correctFilename']:
             self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -1629,12 +1629,18 @@ class AnnotatedGlossForm(forms.ModelForm):
 
 class GlossVideoSearchForm(forms.ModelForm):
 
+    isNormalVideo = forms.ChoiceField(label=_('Is Normal Video'),
+                                      choices=[(0, '-')],
+                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     isPerspectiveVideo = forms.ChoiceField(label=_('Is Perspective Video'),
                                            choices=[(0, '-')],
                                            widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    isNMEVideo = forms.ChoiceField(label=_('Is NME Video'),
-                                    choices=[(0, '-')],
-                                    widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    isNMEVideo = forms.ChoiceField(label=_('Is NME or Perspective NME Video'),
+                                   choices=[(0, '-')],
+                                   widget=forms.Select(attrs=ATTRS_FOR_FORMS))
+    isBackup = forms.ChoiceField(label=_('Is Backup Video'),
+                                 choices=[(0, '-')],
+                                 widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     correctFilename = forms.ChoiceField(label=_('Correct Filename'),
                                         choices=[(0, '-')],
                                         widget=forms.Select(attrs=ATTRS_FOR_FORMS))
@@ -1655,7 +1661,6 @@ class GlossVideoSearchForm(forms.ModelForm):
         super(GlossVideoSearchForm, self).__init__(*args, **kwargs)
 
         # language fields will be set up elsewhere
-        # field choice choices will be set up elsewhere
 
-        for boolean_field in ['isPerspectiveVideo', 'isNMEVideo', 'correctFilename']:
+        for boolean_field in ['isNormalVideo', 'isPerspectiveVideo', 'isNMEVideo', 'isBackup', 'correctFilename']:
             self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -1641,7 +1641,7 @@ class GlossVideoSearchForm(forms.ModelForm):
     isBackup = forms.ChoiceField(label=_('Is Backup Video'),
                                  choices=[(0, '-')],
                                  widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-    correctFilename = forms.ChoiceField(label=_('Correct Filename'),
+    wrongFilename = forms.ChoiceField(label=_('Wrong Filename'),
                                         choices=[(0, '-')],
                                         widget=forms.Select(attrs=ATTRS_FOR_FORMS))
 
@@ -1662,5 +1662,5 @@ class GlossVideoSearchForm(forms.ModelForm):
 
         # language fields will be set up elsewhere
 
-        for boolean_field in ['isPrimaryVideo', 'isPerspectiveVideo', 'isNMEVideo', 'isBackup', 'correctFilename']:
+        for boolean_field in ['isPrimaryVideo', 'isPerspectiveVideo', 'isNMEVideo', 'isBackup', 'wrongFilename']:
             self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -1629,7 +1629,7 @@ class AnnotatedGlossForm(forms.ModelForm):
 
 class GlossVideoSearchForm(forms.ModelForm):
 
-    isNormalVideo = forms.ChoiceField(label=_('Is Normal Video'),
+    isNormalVideo = forms.ChoiceField(label=_('Is Primary Video'),
                                       choices=[(0, '-')],
                                       widget=forms.Select(attrs=ATTRS_FOR_FORMS))
     isPerspectiveVideo = forms.ChoiceField(label=_('Is Perspective Video'),

--- a/signbank/dictionary/templates/dictionary/admin_dataset_manager.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_manager.html
@@ -128,7 +128,7 @@ tr > td > form > input[type="submit"] {
                     </tr>
                     <tr>
                         <td>
-                            <a href="{{PREFIX_URL}}/datasets/checks/{{dataset.id}}" >
+                            <a href="{{PREFIX_URL}}/datasets/glossvideos/{{dataset.id}}" >
                                 <button id='manage_video_storage' class='btn btn-primary' name='manage_media'>{% trans "Manage Video Storage" %}</button></a>
                         </td>
                     </tr>

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -1,0 +1,247 @@
+{% extends 'baselayout.html' %}
+{% load i18n %}
+{% load stylesheet %}
+{% load annotation_idgloss_translation %}
+{% load has_group %}
+{% load bootstrap3 %}
+
+{% load guardian_tags %}
+{% load annotation_idgloss_translation %}
+
+{% block bootstrap3_title %}
+{% blocktrans %}Signbank: Manage Dataset Video Storage{% endblocktrans %}
+{% endblock %}
+
+{% block extrahead %}
+{% endblock %}
+
+{% block extrajs %}
+<script type='text/javascript'>
+var url = '{{PREFIX_URL}}';
+var csrf_token = '{{csrf_token}}';
+
+function update_gloss_video_backups(el) {
+    var glossid = $(el).attr('data-glossid');
+    var lookup = "#videos_"+glossid;
+    $.ajax({
+        url : url + "/dictionary/update_gloss_video_backups/"+glossid+ "/",
+        datatype: "json",
+        data: {
+            'csrfmiddlewaretoken': csrf_token
+        },
+        type: "POST",
+        async: true,
+        success : function(result) {
+            console.log(result);
+            if ($.isEmptyObject(result)) {
+                return;
+            };
+            var videos = result.videos;
+            $(lookup).html('');
+            $(lookup).append(videos);
+        }
+    });
+};
+</script>
+
+<style>
+list {
+    overflow-y: scroll;
+    overflow-x: hidden;
+    scrollbar-width: thin;
+}
+dl:after {
+    content: none;
+}
+dl {
+    margin-bottom: 0px;
+}
+dt {
+    margin-left: 0px;
+}
+dd {
+    margin-left: 0px;
+}
+
+.list-group-item {
+    padding: 0px 8px;
+}
+.list-group-item:hover {
+
+}
+.list-group-item.active {
+    background-color: inherit;
+    color: inherit;
+}
+.list-group-item.active:hover {
+    color: white;
+    background-color: DodgerBlue;
+}
+.list-group-item-contents {
+    background-color: inherit;
+    color: inherit;
+}
+.row.list-group-item.list-group-item-contents:hover {
+    background-color: DodgerBlue;
+    color: white;
+}
+.table-condensed {
+    border-collapse: collapse;
+}
+</style>
+{% endblock %}
+
+
+{% block content %}
+<div>
+<h3>{% trans "Manage Dataset Video Storage" %}</h3>
+<div id='searchform_outer' class='well well-light'>
+<form name='adminsearch' class="search-form search-form-light" id='adminsearch' method='get' action='{{PREFIX_URL}}/analysis/minimalpairs/'>
+<div class="panel panel-default panel-light">
+    <div class="panel-heading panel-light" data-toggle="collapse" data-target="#query-area">{% trans "Construct Filter" %}
+    </div>
+        <div id='query-area' class='collapse {% if request.GET|length == 0 and not show_all %} in {% endif %}'>
+        <div id='searchformwell' class='well well-light search-results-collapsable'>
+
+        <div class="hidden">
+            <input name='sortOrder' class='form-control' value='' >
+            <input name='search_type' class='form-control' value='filter'>
+        </div>
+
+        <div class="panel panel-default panel-light">
+              <div class="panel-heading panel-light" data-toggle="collapse" data-target="#ann_search">{% trans "Filter Gloss Video by Annotation" %}
+                {% if USE_REGULAR_EXPRESSIONS %}
+                <span class="hasTooltip">
+                <span id="tooltip" class="glyphicon glyphicon-question-sign" aria-hidden="true" data-toggle="tooltip" data-placement="bottom" data-html="true"
+                  title=""></span>
+				{% include "tooltip.html" with include_tags=True %}
+                </span>
+                {% endif %}
+              </div>
+        <div id='ann_search' class='collapse'>
+        <table class='table' id='searchfields'>
+            {% for dataset_lang in dataset_languages %}
+            <tr>
+                {% with searchform|get_annotation_search_field_for_language:dataset_lang as search_field %}
+                <td class='td td-light'>
+                    <div class='input-group input-group-light'>
+                    <label class='input-group-addon' for='id_annotation_idgloss_{{ dataset_lang.language_code_2char }}'>
+                        {{search_field.label}}
+                    </label>
+                    <input id='glosssearch_{{ dataset_lang.language_code_2char }}' type='text'
+                           name='glosssearch_{{ dataset_lang.language_code_2char }}' class='form-control' value="{{search_field.value}}">
+                    </div>
+                </td>
+                {% endwith %}
+
+                {% with searchform|get_lemma_form_field_for_language:dataset_lang as lemma_field %}
+                <td class='td td-light'><div class='input-group input-group-light'>
+                    <label class='input-group-addon' for='id_lemma_{{ dataset_lang.language_code_2char }}'>
+                        {{lemma_field.label}}
+                    </label>
+                    <input id='lemma_{{ dataset_lang.language_code_2char }}' type='text'
+                           name='lemma_{{ dataset_lang.language_code_2char }}' class='form-control' value='{{lemma_field.value}}'></div>
+                </td>
+                {% endwith %}
+
+                {% with searchform|get_senses_form_field_for_language:dataset_lang as keyword_field %}
+                <td class='td td-light'><div class='input-group input-group-light'>
+                    <label class='input-group-addon' for='id_keyword_{{ dataset_lang.language_code_2char }}'>{{keyword_field.label}}</label>
+                    <input id='keyword_{{ dataset_lang.language_code_2char }}' type='text'
+                           name='keyword_{{ dataset_lang.language_code_2char }}' class='form-control' value='{{keyword_field.value}}'></div>
+                </td>
+                {% endwith %}
+            </tr>
+            {% endfor %}
+        </table>
+        </div>
+        </div>
+        </div>
+
+       </div>
+    </div>
+<div class='btn-group' style="margin-bottom: 20px">
+<button class='btn btn-primary' type='submit'
+       id='minimal_pairs_search_button'
+       onclick="do_adminsearch(this);"
+       value='minimal_pairs'>{% trans "Apply Filter and Show Results" %}</button>
+<input type='hidden' id='do_minimal_pairs_search' name='search_minimal_pairs' value="">
+<button class='btn btn-primary' type='submit'
+       id='show_all_minimal_pairs_button'
+       onclick="do_show_all(this);"
+       value='minimal_pairs'>{% trans "Show All Gloss Videos" %}</button>
+<input type='hidden' id='show_all_minimal_pairs' name='show_all_minimal_pairs' value="">
+
+<input class='btn btn-primary' type='submit' onclick="clearForm();"
+       value='{% trans "Reset" %}'>
+<input type='hidden' id="reset" name="reset" value="">
+</div>
+</div>
+</form>
+</div>
+{% url 'dictionary:protected_media' '' as protected_media_url %}
+
+<table class='table table-condensed table-condensed-light'>
+<tr><th style="width:300px;">{% trans "Dataset name" %}</th><td style="width:1200px;">{{dataset.name}}</td></tr>
+<tr><th>{% trans "Acronym" %}</th><td>{{dataset.acronym}}</td></tr>
+<tr><th>{% trans "Number of glosses" %}</th><td>{{nr_of_glosses}} total</td></tr>
+</table>
+<br>
+
+<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
+     data-target='#toggle_gloss_videos'>{% trans "Gloss Videos" %}
+    <span>({{gloss_videos|length}} {% trans "results found" %})</span>
+</div>
+<div id='toggle_gloss_videos' class="panel-collapse collapse" style="width:auto;">
+<div class="panel-body" style="display:inline-block;border-color:transparent;">
+    {% if gloss_videos %}
+    <table class='table table-condensed table-condensed-light'>
+    <tr>
+        <td class="list-group-hover" style="padding: 0;">
+        <dl class="row list-group-item active"  style="padding: 0;">
+            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
+            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
+            {% for language in dataset_languages %}
+            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
+            {% endfor %}
+            <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
+            <dt class="col-sm-2" style="width:300px;">
+                <span class="hasTooltip">{% trans "Operations" %}
+                    <span id="tooltipops" class="glyphicon glyphicon-question-sign" aria-hidden="true" data-container="body"
+                          data-toggle="tooltip" data-placement="top" data-html="true" title=""></span>
+                    <span class="isTooltip">{% trans "Renumber backup files; match extension to video type." %}</span>
+                </span>
+            </dt>
+        </dl>
+        <list id="document_tuples" style="height:280px; display:block;">
+              {% for gloss, num_videos, videos in gloss_videos %}
+                  <dl id="gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
+                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
+                      {% for language in dataset_languages %}
+                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
+                      {% endfor %}
+                      <dd class="col-sm-2" style="width:400px;" id='videos_{{gloss.id}}'>{{videos}}</dd>
+                      <dd class="col-sm-2" style="width:300px;">
+                            <div class='btn-group' >
+                                {% if num_videos > 1 %}
+                                <button id="update_gloss_video_backups_{{gloss.id}}" class="btn btn-success"
+                                        onclick='update_gloss_video_backups(this)'
+                                        style="padding-top: 0; padding-bottom: 0; margin-top: 0;"
+                                        data-glossid='{{gloss.id}}'>{% trans "Rename" %}</button>
+                                {% endif %}
+                            </div>
+                      </dd>
+                  </dl>
+             {% endfor %}
+        </list>
+        </td>
+        </tr>
+    </table>
+    {% endif %}
+</div>
+</div>
+</div>
+<br>
+
+{% endblock %}

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -295,6 +295,47 @@ dd {
 <br>
 
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
+     data-target='#toggle_normal_gloss_videos'>{% trans "Gloss Primary Video Objects" %}
+    <span>({{count_glossvideos}} {% trans "results found" %})</span>
+</div>
+<div id='toggle_normal_gloss_videos' class="panel-collapse collapse" style="width:auto;">
+<div class="panel-body" style="display:inline-block;border-color:transparent;">
+    {% if count_glossvideos %}
+    <table class='table table-condensed table-condensed-light'>
+    <tr>
+        <td class="list-group-hover" style="padding: 0;">
+        <dl class="row list-group-item active"  style="padding: 0;">
+            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
+            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
+            {% for language in dataset_languages %}
+            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
+            {% endfor %}
+            <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
+        </dl>
+        <list id="document_tuples" style="height:280px; display:block;">
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
+                  {% if videos %}
+                  <dl id="primary_gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
+                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
+                      {% for language in dataset_languages %}
+                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
+                      {% endfor %}
+                      <dd class="col-sm-2" style="width:400px;" id='normal_videos_{{gloss.id}}'>{{videos}}</dd>
+                  </dl>
+                  {% endif %}
+             {% endfor %}
+        </list>
+        </td>
+        </tr>
+    </table>
+    {% endif %}
+</div>
+</div>
+</div>
+<br>
+
+<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
      data-target='#toggle_persp_videos'>{% trans "Gloss Perspective Video Objects" %}
     <span>({{count_glossperspvideos}} {% trans "results found" %})</span>
 </div>
@@ -433,46 +474,6 @@ dd {
         </tr>
     </table>
     {% endif %}
-</div>
-</div>
-<br>
-<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_normal_gloss_videos'>{% trans "Gloss Primary Video Objects" %}
-    <span>({{count_glossvideos}} {% trans "results found" %})</span>
-</div>
-<div id='toggle_normal_gloss_videos' class="panel-collapse collapse" style="width:auto;">
-<div class="panel-body" style="display:inline-block;border-color:transparent;">
-    {% if count_glossvideos %}
-    <table class='table table-condensed table-condensed-light'>
-    <tr>
-        <td class="list-group-hover" style="padding: 0;">
-        <dl class="row list-group-item active"  style="padding: 0;">
-            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
-            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
-            {% for language in dataset_languages %}
-            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
-            {% endfor %}
-            <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
-        </dl>
-        <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
-                  {% if videos %}
-                  <dl id="primary_gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
-                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
-                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
-                      {% for language in dataset_languages %}
-                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
-                      {% endfor %}
-                      <dd class="col-sm-2" style="width:400px;" id='normal_videos_{{gloss.id}}'>{{videos}}</dd>
-                  </dl>
-                  {% endif %}
-             {% endfor %}
-        </list>
-        </td>
-        </tr>
-    </table>
-    {% endif %}
-</div>
 </div>
 </div>
 <br>

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -47,6 +47,28 @@ function update_gloss_video_backups(el) {
     });
 };
 
+function move_gloss_video_backups_to_trash(el) {
+    var glossid = $(el).attr('data-glossid');
+    var lookup = "#gloss_videos_"+glossid;
+    $.ajax({
+        url : url + "/dictionary/move_gloss_video_backups_to_trash/"+glossid+ "/",
+        datatype: "json",
+        data: {
+            'csrfmiddlewaretoken': csrf_token
+        },
+        type: "POST",
+        async: true,
+        success : function(result) {
+            console.log(result);
+            if ($.isEmptyObject(result)) {
+                return;
+            };
+            var videos = result.videos;
+            $(lookup).html('');
+        }
+    });
+};
+
 $(document).ready(function() {
 
     $('[data-toggle="tooltip"]').tooltip();
@@ -185,7 +207,7 @@ dd {
                 </span>
                 {% endif %}
               </div>
-        <div id='ann_search' class='collapse'>
+        <div id='ann_search' class='collapse in'>
         <table class='table' id='searchfields'>
             {% for dataset_lang in dataset_languages %}
             <tr>
@@ -241,9 +263,9 @@ dd {
                 <td class='td td-light' style="width:200px;"><label>{{searchform.isBackup.label}}</label></td>
                 <td class='td td-light' style="width:100px;">{{ searchform.isBackup }}</td>
             </tr>
-            <tr id='video_icorrectFilename'>
-                <td class='td td-light' style="width:200px;"><label>{{searchform.correctFilename.label}}</label></td>
-                <td class='td td-light' style="width:100px;">{{ searchform.correctFilename }}</td>
+            <tr id='video_wrongFilename'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.wrongFilename.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.wrongFilename }}</td>
             </tr>
         </table>
         </div>
@@ -291,7 +313,7 @@ dd {
             <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
                   {% if perspvideos %}
                   <dl id="gloss_persp_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
@@ -331,7 +353,8 @@ dd {
             <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
+                  {% if nmevideos %}
                   <dl id="gloss_nme_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
                       <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
@@ -340,6 +363,7 @@ dd {
                       {% endfor %}
                       <dd class="col-sm-2" style="width:600px;" id='nme_videos_{{gloss.id}}'>{{nmevideos}}</dd>
                   </dl>
+                  {% endif %}
              {% endfor %}
         </list>
         </td>
@@ -377,7 +401,7 @@ dd {
             </dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
                   {% if glossbackupvideos %}
                   <dl id="gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
@@ -394,6 +418,10 @@ dd {
                                         onclick='update_gloss_video_backups(this)'
                                         style="padding-top: 0; padding-bottom: 0; margin-top: 0;"
                                         data-glossid='{{gloss.id}}'>{% trans "Rename" %}</button>
+                                <button id="move_gloss_video_backups_to_trash_{{gloss.id}}" class="btn btn-success"
+                                        onclick='move_gloss_video_backups_to_trash(this)'
+                                        style="padding-top: 0; padding-bottom: 0; margin-top: 0;"
+                                        data-glossid='{{gloss.id}}'>{% trans "Move to Trash" %}</button>
                                 {% endif %}
                             </div>
                       </dd>
@@ -427,9 +455,9 @@ dd {
             <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
                   {% if videos %}
-                  <dl id="normal_gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                  <dl id="primary_gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
                       <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
                       {% for language in dataset_languages %}
@@ -445,6 +473,45 @@ dd {
     </table>
     {% endif %}
 </div>
+</div>
+</div>
+<br>
+<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
+     data-target='#toggle_wrong_videos'>{% trans "Gloss Video Objects with Wrong Filename" %}
+    <span>({{count_wrong_filename}} {% trans "results found" %})</span>
+</div>
+<div id='toggle_wrong_videos' class="panel-collapse collapse">
+<div class="panel-body" style="display:inline-block;border-color:transparent;">
+    {% if count_wrong_filename %}
+    <table class='table table-condensed table-condensed-light' style="width:100%;">
+    <tr>
+        <td class="list-group-hover" style="padding: 0;">
+        <dl class="row list-group-item active"  style="padding: 0;">
+            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
+            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
+            {% for language in dataset_languages %}
+            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
+            {% endfor %}
+            <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
+        </dl>
+        <list id="document_tuples" style="height:280px; display:block;">
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos, wrongvideos in gloss_videos %}
+                  {% if wrongvideos %}
+                  <dl id="gloss_wrong_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
+                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
+                      {% for language in dataset_languages %}
+                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
+                      {% endfor %}
+                      <dd class="col-sm-2" style="width:600px;" id='wrong_videos_{{gloss.id}}'>{{wrongvideos}}</dd>
+                  </dl>
+                  {% endif %}
+             {% endfor %}
+        </list>
+        </td>
+        </tr>
+    </table>
+    {% endif %}
 </div>
 </div>
 <br>

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -266,12 +266,13 @@ dd {
 <table class='table table-condensed table-condensed-light'>
 <tr><th style="width:300px;">{% trans "Dataset name" %}</th><td style="width:1200px;">{{dataset.name}}</td></tr>
 <tr><th>{% trans "Acronym" %}</th><td>{{dataset.acronym}}</td></tr>
-<tr><th>{% trans "Number of glosses" %}</th><td>{{nr_of_glosses}} total</td></tr>
+<tr><th>{% trans "Number of glosses" %}</th><td>{{nr_of_glosses}}</td></tr>
+<tr><th>{% trans "Number of video objects matching query" %}</th><td>{{count_glosses}}</td></tr>
 </table>
 <br>
 
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_persp_videos'>{% trans "Gloss Perspective Videos" %}
+     data-target='#toggle_persp_videos'>{% trans "Gloss Perspective Video Objects" %}
     <span>({{count_glossperspvideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_persp_videos' class="panel-collapse collapse">
@@ -311,7 +312,7 @@ dd {
 <br>
 
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_nme_videos'>{% trans "Gloss NME Videos" %}
+     data-target='#toggle_nme_videos'>{% trans "Gloss NME Video Objects" %}
     <span>({{count_glossnmevideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_nme_videos' class="panel-collapse collapse">
@@ -349,7 +350,7 @@ dd {
 <br>
 
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_gloss_videos'>{% trans "Gloss Backup Videos" %}
+     data-target='#toggle_gloss_videos'>{% trans "Gloss Backup Video Objects" %}
     <span>({{count_glossbackupvideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_gloss_videos' class="panel-collapse collapse" style="width:auto;">
@@ -405,7 +406,7 @@ dd {
 </div>
 <br>
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_normal_gloss_videos'>{% trans "Gloss Videos" %}
+     data-target='#toggle_normal_gloss_videos'>{% trans "Gloss Primary Video Objects" %}
     <span>({{count_glossvideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_normal_gloss_videos' class="panel-collapse collapse" style="width:auto;">

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -19,6 +19,8 @@
 <script type='text/javascript'>
 var url = '{{PREFIX_URL}}';
 var csrf_token = '{{csrf_token}}';
+var query_parameters_keys = {{query_parameters_keys|safe}};
+var query_parameters_dict = {{query_parameters|safe}};
 
 function update_gloss_video_backups(el) {
     var glossid = $(el).attr('data-glossid');
@@ -42,8 +44,54 @@ function update_gloss_video_backups(el) {
         }
     });
 };
-</script>
 
+$(document).ready(function() {
+
+    $('[data-toggle="tooltip"]').tooltip();
+
+     // initialize language-based query fields
+     for (var i = 0; i < language_query_keys.length; i++) {
+        var this_var = language_query_keys[i];
+        if (query_parameters_keys.includes(this_var)) {
+            var $language_search = $("input[name='"+this_var+"']");
+            var query_initial = query_parameters_dict[this_var];
+            $language_search.val(query_initial);
+        };
+    }
+
+});
+</script>
+<script type='text/javascript'>
+function clearForm() {
+
+      $('input').each(function() {
+        var this_field = $(this).attr('name');
+        if (this_field == undefined) { return; };
+        if (this_field == 'morpheme') { $(this).attr('value', ""); return; };
+        var this_type = $(this).attr('type');
+        if (this_type == 'hidden' || this_type == 'submit' || this_type == 'radio' || this_type == 'button') { return; };
+        if (this_type == 'date') {
+            $(this).attr('value', "");
+        } else {
+            $(this).val('');
+        };
+      });
+      $('select').each(function() {
+        var this_field = $(this).attr('name');
+        if (this_field == undefined) { return; };
+        var this_type = $(this).attr('type');
+        if (this_type == 'hidden') { return; };
+        if (this_field.endsWith('[]')) {
+            return;
+        } else {
+            $(this).find('option').each(function () {
+                $(this).removeAttr("selected");
+            });;
+        };
+      });
+}
+</script>
+</script>
 <style>
 list {
     overflow-y: scroll;
@@ -205,13 +253,12 @@ dd {
 
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
      data-target='#toggle_persp_videos'>{% trans "Gloss Perspective Videos" %}
-<!--    <span>({{gloss_perspective_videos|length}} {% trans "results found" %})</span>-->
+    <span>({{count_glossperspvideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_persp_videos' class="panel-collapse collapse">
 <div class="panel-body" style="display:inline-block;border-color:transparent;">
-    {% if gloss_videos %}
+    {% if count_glossperspvideos %}
     <table class='table table-condensed table-condensed-light' style="width:100%;">
-
     <tr>
         <td class="list-group-hover" style="padding: 0;">
         <dl class="row list-group-item active"  style="padding: 0;">
@@ -243,13 +290,52 @@ dd {
 </div>
 </div>
 <br>
+
+<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
+     data-target='#toggle_nme_videos'>{% trans "Gloss NME Videos" %}
+    <span>({{count_glossnmevideos}} {% trans "results found" %})</span>
+</div>
+<div id='toggle_nme_videos' class="panel-collapse collapse">
+<div class="panel-body" style="display:inline-block;border-color:transparent;">
+    {% if count_glossnmevideos %}
+    <table class='table table-condensed table-condensed-light' style="width:100%;">
+    <tr>
+        <td class="list-group-hover" style="padding: 0;">
+        <dl class="row list-group-item active"  style="padding: 0;">
+            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
+            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
+            {% for language in dataset_languages %}
+            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
+            {% endfor %}
+            <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
+        </dl>
+        <list id="document_tuples" style="height:280px; display:block;">
+              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+                  <dl id="gloss_nme_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
+                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
+                      {% for language in dataset_languages %}
+                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
+                      {% endfor %}
+                      <dd class="col-sm-2" style="width:600px;" id='nme_videos_{{gloss.id}}'>{{nmevideos}}</dd>
+                  </dl>
+             {% endfor %}
+        </list>
+        </td>
+        </tr>
+    </table>
+    {% endif %}
+</div>
+</div>
+<br>
+
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
      data-target='#toggle_gloss_videos'>{% trans "Gloss Backup Videos" %}
-<!--    <span>({{gloss_videos|length}} {% trans "results found" %})</span>-->
+    <span>({{count_glossbackupvideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_gloss_videos' class="panel-collapse collapse" style="width:auto;">
 <div class="panel-body" style="display:inline-block;border-color:transparent;">
-    {% if gloss_videos %}
+    {% if count_glossbackupvideos %}
     <table class='table table-condensed table-condensed-light'>
     <tr>
         <td class="list-group-hover" style="padding: 0;">
@@ -298,15 +384,14 @@ dd {
     {% endif %}
 </div>
 </div>
-</div>
 <br>
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_normal_gloss_videos'>{% trans "Normal Gloss Videos" %}
-<!--    <span>({{gloss_videos|length}} {% trans "results found" %})</span>-->
+     data-target='#toggle_normal_gloss_videos'>{% trans "Gloss Videos" %}
+    <span>({{count_glossvideos}} {% trans "results found" %})</span>
 </div>
 <div id='toggle_normal_gloss_videos' class="panel-collapse collapse" style="width:auto;">
 <div class="panel-body" style="display:inline-block;border-color:transparent;">
-    {% if gloss_videos %}
+    {% if count_glossvideos %}
     <table class='table table-condensed table-condensed-light'>
     <tr>
         <td class="list-group-hover" style="padding: 0;">

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -21,6 +21,8 @@ var url = '{{PREFIX_URL}}';
 var csrf_token = '{{csrf_token}}';
 var query_parameters_keys = {{query_parameters_keys|safe}};
 var query_parameters_dict = {{query_parameters|safe}};
+var language_query_keys = {{language_query_keys|safe}};
+var select_query_keys = {{select_query_keys|safe}};
 
 function update_gloss_video_backups(el) {
     var glossid = $(el).attr('data-glossid');
@@ -58,6 +60,15 @@ $(document).ready(function() {
             $language_search.val(query_initial);
         };
     }
+     // initialize Boolean select query fields
+     for (var i = 0; i < select_query_keys.length; i++) {
+        var this_var = select_query_keys[i];
+        if (query_parameters_keys.includes(this_var)) {
+            var this_id = '#id_' + select_query_keys[i];
+            var query_initial = query_parameters_dict[this_var];
+            $(this_id).val(query_initial);
+        };
+    }
 
 });
 </script>
@@ -89,6 +100,18 @@ function clearForm() {
             });;
         };
       });
+}
+/**
+ * @returns {void}
+ */
+function do_adminsearch(el) {
+ var sSearchType = $(el).attr('value');
+  switch(sSearchType) {
+    case "sign":
+        $("#adminsearch").attr('action', '{{PREFIX_URL}}/datasets/glossvideos/{{datasetid}}');
+        break;
+  }
+  document.getElementById('adminsearch').submit();
 }
 </script>
 </script>
@@ -228,13 +251,9 @@ dd {
     </div>
 <div class='btn-group' style="margin-bottom: 20px">
 <button class='btn btn-primary' type='submit'
-       id='minimal_pairs_search_button'
+       id='glossvideos_search_button'
        onclick="do_adminsearch(this);"
-       value='minimal_pairs'>{% trans "Apply Filter and Show Results" %}</button>
-<button class='btn btn-primary' type='submit'
-       id='show_all_minimal_pairs_button'
-       onclick="do_show_all(this);"
-       value='minimal_pairs'>{% trans "Show All Gloss Videos" %}</button>
+       value='apply_filter'>{% trans "Apply Filter and Show Results" %}</button>
 
 <input class='btn btn-primary' type='submit' onclick="clearForm();"
        value='{% trans "Reset" %}'>

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -78,7 +78,6 @@ function clearForm() {
       $('input').each(function() {
         var this_field = $(this).attr('name');
         if (this_field == undefined) { return; };
-        if (this_field == 'morpheme') { $(this).attr('value', ""); return; };
         var this_type = $(this).attr('type');
         if (this_type == 'hidden' || this_type == 'submit' || this_type == 'radio' || this_type == 'button') { return; };
         if (this_type == 'date') {
@@ -95,9 +94,11 @@ function clearForm() {
         if (this_field.endsWith('[]')) {
             return;
         } else {
+            console.log('options');
+            $(this).val('');
             $(this).find('option').each(function () {
                 $(this).removeAttr("selected");
-            });;
+            });
         };
       });
 }
@@ -224,9 +225,9 @@ dd {
         </div>
         <div>
         <table class='table table-condensed table-condensed-light' style="width:33%;">
-            <tr id='video_isNormalVideo'>
-                <td class='td td-light' style="width:200px;"><label>{{searchform.isNormalVideo.label}}</label></td>
-                <td class='td td-light' style="width:100px;">{{ searchform.isNormalVideo }}</td>
+            <tr id='video_isPrimaryVideo'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.isPrimaryVideo.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.isPrimaryVideo }}</td>
             </tr>
             <tr id='video_isPerspectiveVideo'>
                 <td class='td td-light' style="width:200px;"><label>{{searchform.isPerspectiveVideo.label}}</label></td>
@@ -267,7 +268,7 @@ dd {
 <tr><th style="width:300px;">{% trans "Dataset name" %}</th><td style="width:1200px;">{{dataset.name}}</td></tr>
 <tr><th>{% trans "Acronym" %}</th><td>{{dataset.acronym}}</td></tr>
 <tr><th>{% trans "Number of glosses" %}</th><td>{{nr_of_glosses}}</td></tr>
-<tr><th>{% trans "Number of video objects matching query" %}</th><td>{{count_glosses}}</td></tr>
+<tr><th>{% trans "Number of video objects matching query" %}</th><td>{{count_video_objects}}</td></tr>
 </table>
 <br>
 
@@ -290,7 +291,7 @@ dd {
             <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
                   {% if perspvideos %}
                   <dl id="gloss_persp_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
@@ -330,7 +331,7 @@ dd {
             <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
                   <dl id="gloss_nme_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
                       <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
@@ -365,6 +366,7 @@ dd {
             {% for language in dataset_languages %}
             <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
             {% endfor %}
+            <dt class="col-sm-2" style="width:150px;">{% trans "# Backups" %}</dt>
             <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
             <dt class="col-sm-2" style="width:300px;">
                 <span class="hasTooltip">{% trans "Operations" %}
@@ -375,7 +377,7 @@ dd {
             </dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
                   {% if glossbackupvideos %}
                   <dl id="gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
@@ -383,10 +385,11 @@ dd {
                       {% for language in dataset_languages %}
                         <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
                       {% endfor %}
+                      <dd class="col-sm-2" style="width:150px;">{{num_backup_videos}}</dd>
                       <dd class="col-sm-2" style="width:400px;" id='videos_{{gloss.id}}'>{{glossbackupvideos}}</dd>
                       <dd class="col-sm-2" style="width:300px;">
                             <div class='btn-group' >
-                                {% if num_videos > 1 %}
+                                {% if num_backup_videos > 0 %}
                                 <button id="update_gloss_video_backups_{{gloss.id}}" class="btn btn-success"
                                         onclick='update_gloss_video_backups(this)'
                                         style="padding-top: 0; padding-bottom: 0; margin-top: 0;"
@@ -424,7 +427,7 @@ dd {
             <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+              {% for gloss, num_backup_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
                   {% if videos %}
                   <dl id="normal_gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>

--- a/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
+++ b/signbank/dictionary/templates/dictionary/admin_dataset_videos_list.html
@@ -96,17 +96,12 @@ dd {
 <div>
 <h3>{% trans "Manage Dataset Video Storage" %}</h3>
 <div id='searchform_outer' class='well well-light'>
-<form name='adminsearch' class="search-form search-form-light" id='adminsearch' method='get' action='{{PREFIX_URL}}/analysis/minimalpairs/'>
+<form name='adminsearch' class="search-form search-form-light" id='adminsearch' method='get' action='{{PREFIX_URL}}/datasets/glossvideos/{{datasetid}}'>
 <div class="panel panel-default panel-light">
     <div class="panel-heading panel-light" data-toggle="collapse" data-target="#query-area">{% trans "Construct Filter" %}
     </div>
         <div id='query-area' class='collapse {% if request.GET|length == 0 and not show_all %} in {% endif %}'>
         <div id='searchformwell' class='well well-light search-results-collapsable'>
-
-        <div class="hidden">
-            <input name='sortOrder' class='form-control' value='' >
-            <input name='search_type' class='form-control' value='filter'>
-        </div>
 
         <div class="panel panel-default panel-light">
               <div class="panel-heading panel-light" data-toggle="collapse" data-target="#ann_search">{% trans "Filter Gloss Video by Annotation" %}
@@ -156,8 +151,31 @@ dd {
         </table>
         </div>
         </div>
+        <div>
+        <table class='table table-condensed table-condensed-light' style="width:33%;">
+            <tr id='video_isNormalVideo'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.isNormalVideo.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.isNormalVideo }}</td>
+            </tr>
+            <tr id='video_isPerspectiveVideo'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.isPerspectiveVideo.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.isPerspectiveVideo }}</td>
+            </tr>
+            <tr id='video_isNMEVideo'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.isNMEVideo.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.isNMEVideo }}</td>
+            </tr>
+            <tr id='video_isBackup'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.isBackup.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.isBackup }}</td>
+            </tr>
+            <tr id='video_icorrectFilename'>
+                <td class='td td-light' style="width:200px;"><label>{{searchform.correctFilename.label}}</label></td>
+                <td class='td td-light' style="width:100px;">{{ searchform.correctFilename }}</td>
+            </tr>
+        </table>
         </div>
-
+        </div>
        </div>
     </div>
 <div class='btn-group' style="margin-bottom: 20px">
@@ -165,17 +183,14 @@ dd {
        id='minimal_pairs_search_button'
        onclick="do_adminsearch(this);"
        value='minimal_pairs'>{% trans "Apply Filter and Show Results" %}</button>
-<input type='hidden' id='do_minimal_pairs_search' name='search_minimal_pairs' value="">
 <button class='btn btn-primary' type='submit'
        id='show_all_minimal_pairs_button'
        onclick="do_show_all(this);"
        value='minimal_pairs'>{% trans "Show All Gloss Videos" %}</button>
-<input type='hidden' id='show_all_minimal_pairs' name='show_all_minimal_pairs' value="">
 
 <input class='btn btn-primary' type='submit' onclick="clearForm();"
        value='{% trans "Reset" %}'>
 <input type='hidden' id="reset" name="reset" value="">
-</div>
 </div>
 </form>
 </div>
@@ -189,8 +204,48 @@ dd {
 <br>
 
 <div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
-     data-target='#toggle_gloss_videos'>{% trans "Gloss Videos" %}
-    <span>({{gloss_videos|length}} {% trans "results found" %})</span>
+     data-target='#toggle_persp_videos'>{% trans "Gloss Perspective Videos" %}
+<!--    <span>({{gloss_perspective_videos|length}} {% trans "results found" %})</span>-->
+</div>
+<div id='toggle_persp_videos' class="panel-collapse collapse">
+<div class="panel-body" style="display:inline-block;border-color:transparent;">
+    {% if gloss_videos %}
+    <table class='table table-condensed table-condensed-light' style="width:100%;">
+
+    <tr>
+        <td class="list-group-hover" style="padding: 0;">
+        <dl class="row list-group-item active"  style="padding: 0;">
+            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
+            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
+            {% for language in dataset_languages %}
+            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
+            {% endfor %}
+            <dt class="col-sm-2" style="width:600px;">{% trans "Video Paths" %}</dt>
+        </dl>
+        <list id="document_tuples" style="height:280px; display:block;">
+              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+                  {% if perspvideos %}
+                  <dl id="gloss_persp_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
+                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
+                      {% for language in dataset_languages %}
+                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
+                      {% endfor %}
+                      <dd class="col-sm-2" style="width:600px;" id='persp_videos_{{gloss.id}}'>{{perspvideos}}</dd>
+                  </dl>
+                  {% endif %}
+             {% endfor %}
+        </list>
+        </td>
+        </tr>
+    </table>
+    {% endif %}
+</div>
+</div>
+<br>
+<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
+     data-target='#toggle_gloss_videos'>{% trans "Gloss Backup Videos" %}
+<!--    <span>({{gloss_videos|length}} {% trans "results found" %})</span>-->
 </div>
 <div id='toggle_gloss_videos' class="panel-collapse collapse" style="width:auto;">
 <div class="panel-body" style="display:inline-block;border-color:transparent;">
@@ -214,14 +269,15 @@ dd {
             </dt>
         </dl>
         <list id="document_tuples" style="height:280px; display:block;">
-              {% for gloss, num_videos, videos in gloss_videos %}
+              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+                  {% if glossbackupvideos %}
                   <dl id="gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
                       <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
                       <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
                       {% for language in dataset_languages %}
                         <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
                       {% endfor %}
-                      <dd class="col-sm-2" style="width:400px;" id='videos_{{gloss.id}}'>{{videos}}</dd>
+                      <dd class="col-sm-2" style="width:400px;" id='videos_{{gloss.id}}'>{{glossbackupvideos}}</dd>
                       <dd class="col-sm-2" style="width:300px;">
                             <div class='btn-group' >
                                 {% if num_videos > 1 %}
@@ -233,6 +289,7 @@ dd {
                             </div>
                       </dd>
                   </dl>
+                  {% endif %}
              {% endfor %}
         </list>
         </td>
@@ -243,5 +300,44 @@ dd {
 </div>
 </div>
 <br>
-
+<div class='panel-heading panel-light' data-toggle='collapse' data-parent='#video_storage_toggles'
+     data-target='#toggle_normal_gloss_videos'>{% trans "Normal Gloss Videos" %}
+<!--    <span>({{gloss_videos|length}} {% trans "results found" %})</span>-->
+</div>
+<div id='toggle_normal_gloss_videos' class="panel-collapse collapse" style="width:auto;">
+<div class="panel-body" style="display:inline-block;border-color:transparent;">
+    {% if gloss_videos %}
+    <table class='table table-condensed table-condensed-light'>
+    <tr>
+        <td class="list-group-hover" style="padding: 0;">
+        <dl class="row list-group-item active"  style="padding: 0;">
+            <dt class="col-sm-2" style="width:300px;">{% trans "Lemma" %} ({{default_language.name}})</dt>
+            <dt class="col-sm-2" style="width:150px;">{% trans "Gloss ID" %}</dt>
+            {% for language in dataset_languages %}
+            <dt class="col-sm-2" style="width:300px;">{% trans "Annotation" %} ({{language.name}})</dt>
+            {% endfor %}
+            <dt class="col-sm-2" style="width:400px;">{% trans "Video Paths" %}</dt>
+        </dl>
+        <list id="document_tuples" style="height:280px; display:block;">
+              {% for gloss, num_videos, videos, glossbackupvideos, perspvideos, nmevideos in gloss_videos %}
+                  {% if videos %}
+                  <dl id="normal_gloss_videos_{{gloss.id}}" class="row list-group-item list-group-item-contents" style="padding: 0;">
+                      <dd class="col-sm-2" style="width:300px;">{{gloss.idgloss}}</dd>
+                      <dd class="col-sm-2" style="width:150px;">{{gloss.id}}</dd>
+                      {% for language in dataset_languages %}
+                        <dd class="col-sm-2" style="width:300px;">{{gloss|get_annotation_idgloss_translation_no_default:language}}</dd>
+                      {% endfor %}
+                      <dd class="col-sm-2" style="width:400px;" id='normal_videos_{{gloss.id}}'>{{videos}}</dd>
+                  </dl>
+                  {% endif %}
+             {% endfor %}
+        </list>
+        </td>
+        </tr>
+    </table>
+    {% endif %}
+</div>
+</div>
+</div>
+<br>
 {% endblock %}

--- a/signbank/dictionary/urls.py
+++ b/signbank/dictionary/urls.py
@@ -263,6 +263,8 @@ urlpatterns = [
 
     re_path(r'update_gloss_video_backups/(?P<glossid>\d+)/$',
             permission_required('dictionary.change_gloss')(signbank.dataset_operations.update_gloss_video_backups)),
+    re_path(r'move_gloss_video_backups_to_trash/(?P<glossid>\d+)/$',
+            permission_required('dictionary.change_gloss')(signbank.dataset_operations.move_gloss_video_backups_to_trash)),
 
     re_path(r'info/$', signbank.dictionary.views.info),
     re_path(r'protected_media/(?P<filename>.*)$', signbank.dictionary.views.protected_media, name='protected_media'),

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -5,7 +5,7 @@ from django.utils.encoding import smart_str
 from signbank.settings.server_specific import *
 from datetime import datetime
 
-DEBUG = True
+DEBUG = False
 
 PROJECT_DIR = os.path.dirname(BASE_DIR)
 

--- a/signbank/settings/base.py
+++ b/signbank/settings/base.py
@@ -5,7 +5,7 @@ from django.utils.encoding import smart_str
 from signbank.settings.server_specific import *
 from datetime import datetime
 
-DEBUG = False 
+DEBUG = True
 
 PROJECT_DIR = os.path.dirname(BASE_DIR)
 

--- a/signbank/urls.py
+++ b/signbank/urls.py
@@ -28,7 +28,7 @@ from signbank.dictionary.adminviews import (GlossListView, MorphemeListView, Dat
                                             SearchHistoryView, SenseListView, LemmaListView, ToggleListView,
                                             DatasetMediaView, BatchEditView, AnnotatedGlossListView,
                                             AnnotatedSentenceListView, RecentGlossListView)
-from signbank.dictionary.dataset_views import DatasetConstraintsView
+from signbank.dictionary.dataset_views import DatasetConstraintsView, GlossVideoListView
 from signbank.dictionary.views import add_image, delete_image, add_new_morpheme, add_handshape_image
 
 from django.contrib import admin
@@ -137,6 +137,7 @@ urlpatterns = [
     re_path(r'^datasets/show_glosses_with_no_lemma', signbank.dictionary.views.show_glosses_with_no_lemma, name="show_glosses_with_no_lemma"),
     re_path(r'^datasets/manage_media/(?P<pk>\d+)$', login_required(DatasetMediaView.as_view()), name='admin_dataset_media'),
     re_path(r'^datasets/checks/(?P<pk>\d+)$', login_required(DatasetConstraintsView.as_view()), name='admin_dataset_checks'),
+    re_path(r'^datasets/glossvideos/(?P<pk>\d+)$', login_required(GlossVideoListView.as_view()), name='admin_dataset_video_list'),
     re_path(r'^datasets/manager', login_required(DatasetManagerView.as_view()), name='admin_dataset_manager'),
     re_path(r'^datasets/detail/(?P<pk>\d+)$', DatasetDetailView.as_view(), name='admin_dataset_detail'),
     re_path(r'^datasets/frequency/(?P<pk>\d+)$', DatasetFrequencyView.as_view(), name='admin_dataset_frequency'),


### PR DESCRIPTION
- This pull request sets up a Template, List View, and Search Form for Gloss Videos of a Dataset

- This is completed. It's on signbank-dev.

- To navigate to the page, it's linked to under Manage Datasets -> (Dataset) Manage Video Storage

https://signbank-dev.cls.ru.nl/datasets/glossvideos/5

- The new page replaces the existing page.

<details>
(The old template file, class, and url have not been removed yet, they are just unnavigable now. If you type in the former url you can still compare the old page to the new, which is now linked to as described above.)
</details>

- New: Search functionality
- New: Delete buttons for cleaning up excessive backup files. (Moves them to trash folder as is done in ADMIN.) (Note, when you try this on the development server, it merely deletes the objects if there are no video files.)

- I added a limit of 1000 objects to the search and a message to refine your query to retrieve fewer results.
This is necessary because there are more than 100,000 backup videos for NGT.  I added a count column for the backups.

- For filtering on Wrong Filename this is kind of backfiring because most of the backup filenames are wrong, so overload the number of results. The user will need to add an annotation search to decrease results.

<details>
(The display chokes if there are too many results, hence the limit. The ADMIN only retrieves 100 results at a time. But that is too complicated to implement something like that here.)
</details>

The code revises the setup on the existing page with a search functionality.

The "kind" of videos can be queried as well as the "annotations".

For the display of the results, the same setup is used as the existing page, a separate scroll list for each type of video, ordered by Gloss Lemma.
<details>
(That may not be true anymore. There were lots of problems because sorting by lemma was causing duplicate objects in the query.)
<details>

Because the kind of videos are shown in separate sections, to keep the query retrieval simple, the videos are "partitioned" with the gloss as the gloss videos are examined per kind of video.

(See the code.)

<details>
I haven't come up with an alternative "data structure" combined with "query" for efficiency.
(You'll see what I mean if you look at the code. All of the objects are of type GlossVideo, but they are further categorised by subclasses. I made it as it is in order to put the videos in separate display areas, but only iterate (fetch all the video paths and make a string from them for display in the tables.)
This is to prevent all of the different kinds of videos being in the same "gloss row".
</details>
