### PR TITLE
#1526: Display viewer for NME videos with perspective

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -1185,6 +1185,8 @@ class GlossDetailView(DetailView):
 
         context['nme_video_descriptions'] = get_nme_video_descriptions(gloss)
 
+        context['nme_videos_lookup'] = gloss.get_nme_videos_lookup
+
         # it does not work to put this in a separate function
         # the url parameter encoding is erased by Django of it's not constructed here
         lemma_group = gloss.lemma.gloss_set.all()

--- a/signbank/dictionary/context_data_gloss.py
+++ b/signbank/dictionary/context_data_gloss.py
@@ -98,7 +98,7 @@ def get_annotated_sentences(gloss):
 
 
 def get_nme_video_descriptions(gloss):
-    glossnmevideos = GlossVideoNME.objects.filter(gloss=gloss)
+    glossnmevideos = GlossVideoNME.objects.filter(gloss=gloss, perspective__in=['', 'center'])
     nme_video_descriptions = dict()
     for nmevideo in glossnmevideos:
         nme_video_descriptions[nmevideo] = {}

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2470,6 +2470,17 @@ class Gloss(models.Model):
         nmevideos = GlossVideoNME.objects.filter(gloss=self)
         return nmevideos
 
+    def get_nme_videos_lookup(self):
+        # Group the NME video objects together by their offset
+        from signbank.video.models import GlossVideoNME
+        nmevideos = GlossVideoNME.objects.filter(gloss=self)
+        nme_videos_dict = dict()
+        for nmevideo in nmevideos:
+            if str(nmevideo.offset) not in nme_videos_dict.keys():
+                nme_videos_dict[str(nmevideo.offset)] = []
+            nme_videos_dict[str(nmevideo.offset)].append(nmevideo)
+        return nme_videos_dict
+
     def add_nme_video(self, user, videofile, new_offset, recorded, perspective='center'):
         # Preventing circular import
         from signbank.video.models import GlossVideoNME, GlossVideoHistory, get_video_file_path

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2466,26 +2466,40 @@ class Gloss(models.Model):
         return nmevideos.count()
 
     def get_nme_videos(self):
+        # Only retrieve the primary NME video
         from signbank.video.models import GlossVideoNME
-        nmevideos = GlossVideoNME.objects.filter(gloss=self)
+        nmevideos = GlossVideoNME.objects.filter(gloss=self, perspective__in=['', 'center'])
         return nmevideos
 
     def get_nme_videos_lookup(self):
-        # Group the NME video objects together by their offset
+        # Group the NME video objects together by their offset; this is used for retrieval in the template
         from signbank.video.models import GlossVideoNME
         nmevideos = GlossVideoNME.objects.filter(gloss=self)
         nme_videos_dict = dict()
         for nmevideo in nmevideos:
-            if str(nmevideo.offset) not in nme_videos_dict.keys():
-                nme_videos_dict[str(nmevideo.offset)] = []
-            nme_videos_dict[str(nmevideo.offset)].append(nmevideo)
+            if nmevideo.offset not in nme_videos_dict.keys():
+                nme_videos_dict[nmevideo.offset] = dict()
+            if nmevideo.perspective not in nme_videos_dict[nmevideo.offset].keys():
+                nme_videos_dict[nmevideo.offset][nmevideo.perspective] = nmevideo
         return nme_videos_dict
+
+    def nme_video_has_left_perspective(self, offset):
+        # this is used in the template to conditionally generate code
+        from signbank.video.models import GlossVideoNME
+        primary_nmevideo = GlossVideoNME.objects.filter(gloss=self, offset=offset, perspective__in=['', 'center']).first()
+        return primary_nmevideo.has_left_perspective if primary_nmevideo else False
+
+    def nme_video_has_right_perspective(self, offset):
+        # this is used in the template to conditionally generate code
+        from signbank.video.models import GlossVideoNME
+        primary_nmevideo = GlossVideoNME.objects.filter(gloss=self, offset=offset, perspective__in=['', 'center']).first()
+        return primary_nmevideo.has_right_perspective if primary_nmevideo else False
 
     def add_nme_video(self, user, videofile, new_offset, recorded, perspective='center'):
         # Preventing circular import
         from signbank.video.models import GlossVideoNME, GlossVideoHistory, get_video_file_path
 
-        existing_offsets_for_this_perspective = [nmev.offset for nmev in GlossVideoNME.objects.filter(gloss=self,perspective=perspective)]
+        existing_offsets_for_this_perspective = [nmev.offset for nmev in GlossVideoNME.objects.filter(gloss=self, perspective=perspective)]
         if new_offset in existing_offsets_for_this_perspective:
             # override given offset to avoid duplicate usage
             offset = max(existing_offsets_for_this_perspective)+1

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -1798,6 +1798,7 @@ textarea:focus {
                <table class='table table-responsive' style="text-align: left;width:100%;">
                 <tr style="overflow-y:auto;">
                     <td style="display:inline-block;">
+                        <div>
                     {% for videonme in gloss.get_nme_videos %}
                         <div class="table-responsive" style="display:inline-block;">
                          <table class="table table-condensed" style="text-align: left;">
@@ -1831,9 +1832,57 @@ textarea:focus {
                                <table>
                                    <tr>
                                        <td colspan="2">
-                                           <div id="nmeplayer">
-                                            <video id='videonmeplayer' src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
-                                                   style="height:200px;width:auto;" controls muted></video>
+                                           <div>
+    {% if videonme.has_perspective_videos %}
+    <div id="buttonbar_nme_{{videonme.offset}}-top" style="background-color:transparent;height:auto;">
+        {% if videonme.has_left_perspective %}
+        <button class="btn video_button" id="show_nme_{{videonme.offset}}_left" style="font-size:18px;background-color:transparent;">
+            <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(-30deg);rotateY(0deg);height:auto;"></span>
+        </button>
+        {% endif %}
+    <button class="btn video_button active" id="show_nme_{{videonme.offset}}_middle" style="font-size:18px;background-color:transparent;">
+        <span class="glyphicon glyphicon-user"></span>
+    </button>
+        {% if videonme.has_right_perspective %}
+        <button class="btn video_button" id="show_nme_{{videonme.offset}}_right" style="font-size:18px;background-color:transparent;">
+            <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(210deg);height:auto;"></span></button>
+        {% endif %}
+    </div>
+    {% endif %}
+
+        <div id="player_nme_{{videonme.offset}}" style="">
+            <video id='videonmeplayer_{{videonme.offset}}_middle' src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
+                   style="height:200px;width:auto;" controls muted></video>
+
+        {% if videonme.has_left_perspective %}
+            {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
+            {% with nme_perspectives|get_item:'left' as nmevideo_left %}
+            <video id='videonmeplayer_{{videonme.offset}}_left' src="{{protected_media_url}}{{nmevideo_left.get_video_path}}?v={% now 'YmdHis' %}"
+                   style="height:200px;width:auto;" controls muted></video>
+            {% endwith %}
+            {% endwith %}
+        {% endif %}
+        {% if videonme.has_right_perspective %}
+            {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
+            {% with nme_perspectives|get_item:'right' as nmevideo_right %}
+            <video id='videonmeplayer_{{videonme.offset}}_right' src="{{protected_media_url}}{{nmevideo_right.get_video_path}}?v={% now 'YmdHis' %}"
+                   style="height:200px;width:auto;" controls muted></video>
+            {% endwith %}
+            {% endwith %}
+        {% endif %}
+        </div>
+        <div id="buttonbar_nme_{{videonme.offset}}" style="background-color:transparent;">
+        <button class="btn" id="play_nme_{{videonme.offset}}_perspective" onclick="play_perspective();"
+                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-play"></span></button>
+        <button class="btn" id="pause_nme_{{videonme.offset}}_perspective" onclick="pause_perspective();"
+                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-pause"></span></button>
+        <button class="btn" id="fullscreen_nme_{{videonme.offset}}_perspective" onclick="openFullscreen();"
+                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-fullscreen"></span></button>
+        </div>
+                                           <!--                                           <div id="nmeplayer">-->
+<!--                                            <video id='videonmeplayer' src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"-->
+<!--                                                   style="height:200px;width:auto;" controls muted></video>-->
+<!--                                           </div>-->
                                            </div>
                                         </td>
                                    </tr>
@@ -1862,6 +1911,7 @@ textarea:focus {
                          </table>
                       </div>
                     {% endfor %}
+                        </div>
                     </td>
                 </tr>
                </table>

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -1296,7 +1296,7 @@ textarea:focus {
                             <td>{{perspectivevideoform.videofile}}</td>
                           </tr>
                          <tr>
-                            <td>{{perspectivevideoform.perspective}}</td>
+                            <td class="td td-light" style='width:5em'>{{perspectivevideoform.perspective}}</td>
                           </tr>
                           <tr>
                             <td id="perspvideo-buttons">
@@ -1908,64 +1908,64 @@ textarea:focus {
                                    <tr>
                                        <td colspan="2">
                                            <div>
-    {% if videonme.has_perspective_videos %}
-    <div id="buttonbar_nme_{{videonme.offset}}-top" style="background-color:transparent;height:auto;">
-        {% if videonme.has_left_perspective %}
-        <button class="btn video_button_nme" id="show_nme_{{videonme.offset}}_left"
-                data-offset="{{videonme.offset}}" onclick="show_nme_left(this);"
-                style="font-size:18px;background-color:transparent;">
-            <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(-30deg);rotateY(0deg);height:auto;"></span>
-        </button>
-        {% endif %}
-    <button class="btn video_button_nme active" id="show_nme_{{videonme.offset}}_middle"
-            data-offset="{{videonme.offset}}" onclick="show_nme_middle(this);"
-            style="font-size:18px;background-color:transparent;">
-        <span class="glyphicon glyphicon-user"></span>
-    </button>
-        {% if videonme.has_right_perspective %}
-        <button class="btn video_button_nme" id="show_nme_{{videonme.offset}}_right"
-                data-offset="{{videonme.offset}}" onclick="show_nme_right(this);"
-                style="font-size:18px;background-color:transparent;">
-            <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(210deg);height:auto;"></span></button>
-        {% endif %}
-    </div>
-    {% endif %}
+                                            {% if videonme.has_perspective_videos %}
+                                            <div id="buttonbar_nme_{{videonme.offset}}-top" style="background-color:transparent;height:auto;">
+                                                {% if videonme.has_left_perspective %}
+                                                <button class="btn video_button_nme" id="show_nme_{{videonme.offset}}_left"
+                                                        data-offset="{{videonme.offset}}" onclick="show_nme_left(this);"
+                                                        style="font-size:18px;background-color:transparent;">
+                                                    <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(-30deg);rotateY(0deg);height:auto;"></span>
+                                                </button>
+                                                {% endif %}
+                                            <button class="btn video_button_nme active" id="show_nme_{{videonme.offset}}_middle"
+                                                    data-offset="{{videonme.offset}}" onclick="show_nme_middle(this);"
+                                                    style="font-size:18px;background-color:transparent;">
+                                                <span class="glyphicon glyphicon-user"></span>
+                                            </button>
+                                                {% if videonme.has_right_perspective %}
+                                                <button class="btn video_button_nme" id="show_nme_{{videonme.offset}}_right"
+                                                        data-offset="{{videonme.offset}}" onclick="show_nme_right(this);"
+                                                        style="font-size:18px;background-color:transparent;">
+                                                    <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(210deg);height:auto;"></span></button>
+                                                {% endif %}
+                                            </div>
+                                            {% endif %}
 
-        <div id="player_nme_{{videonme.offset}}" style="">
-            <video id='videonmeplayer_{{videonme.offset}}_middle' class="videonmeplayer_middle"
-                   src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
-                   style="height:200px;width:auto;" playsinline autoplay muted></video>
+                                                <div id="player_nme_{{videonme.offset}}" style="">
+                                                    <video id='videonmeplayer_{{videonme.offset}}_middle' class="videonmeplayer_middle"
+                                                           src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
+                                                           style="height:200px;width:auto;" playsinline muted></video>
 
-        {% if videonme.has_left_perspective %}
-            {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
-            {% with nme_perspectives|get_item:'left' as nmevideo_left %}
-            <video id='videonmeplayer_{{videonme.offset}}_left'  class="videonmeplayer_left"
-                   src="{{protected_media_url}}{{nmevideo_left.get_video_path}}?v={% now 'YmdHis' %}"
-                   style="height:200px;width:auto;" playsinline autoplay muted></video>
-            {% endwith %}
-            {% endwith %}
-        {% endif %}
-        {% if videonme.has_right_perspective %}
-            {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
-            {% with nme_perspectives|get_item:'right' as nmevideo_right %}
-            <video id='videonmeplayer_{{videonme.offset}}_right'  class="videonmeplayer_right"
-                   src="{{protected_media_url}}{{nmevideo_right.get_video_path}}?v={% now 'YmdHis' %}"
-                   style="height:200px;width:auto;" playsinline autoplay muted></video>
-            {% endwith %}
-            {% endwith %}
-        {% endif %}
-        </div>
-        <div id="buttonbar_nme_{{videonme.offset}}" style="background-color:transparent;">
-        <button class="btn" id="play_nme_{{videonme.offset}}_perspective"
-                onclick="play_perspective_nme(this);" data-offset="{{videonme.offset}}"
-                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-play"></span></button>
-        <button class="btn" id="pause_nme_{{videonme.offset}}_perspective"
-                onclick="pause_perspective_nme(this);" data-offset="{{videonme.offset}}"
-                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-pause"></span></button>
-<!--        <button class="btn" id="fullscreen_nme_{{videonme.offset}}_perspective"-->
-<!--                onclick="openFullscreen_nme(this);" data-offset="{{videonme.offset}}"-->
-<!--                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-fullscreen"></span></button>-->
-        </div>
+                                                {% if videonme.has_left_perspective %}
+                                                    {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
+                                                    {% with nme_perspectives|get_item:'left' as nmevideo_left %}
+                                                    <video id='videonmeplayer_{{videonme.offset}}_left'  class="videonmeplayer_left"
+                                                           src="{{protected_media_url}}{{nmevideo_left.get_video_path}}?v={% now 'YmdHis' %}"
+                                                           style="height:200px;width:auto;" playsinline muted></video>
+                                                    {% endwith %}
+                                                    {% endwith %}
+                                                {% endif %}
+                                                {% if videonme.has_right_perspective %}
+                                                    {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
+                                                    {% with nme_perspectives|get_item:'right' as nmevideo_right %}
+                                                    <video id='videonmeplayer_{{videonme.offset}}_right'  class="videonmeplayer_right"
+                                                           src="{{protected_media_url}}{{nmevideo_right.get_video_path}}?v={% now 'YmdHis' %}"
+                                                           style="height:200px;width:auto;" playsinline muted></video>
+                                                    {% endwith %}
+                                                    {% endwith %}
+                                                {% endif %}
+                                                </div>
+                                                <div id="buttonbar_nme_{{videonme.offset}}" style="background-color:transparent;">
+                                                <button class="btn" id="play_nme_{{videonme.offset}}_perspective"
+                                                        onclick="play_perspective_nme(this);" data-offset="{{videonme.offset}}"
+                                                        style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-play"></span></button>
+                                                <button class="btn" id="pause_nme_{{videonme.offset}}_perspective"
+                                                        onclick="pause_perspective_nme(this);" data-offset="{{videonme.offset}}"
+                                                        style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-pause"></span></button>
+                                        <!--        <button class="btn" id="fullscreen_nme_{{videonme.offset}}_perspective"-->
+                                        <!--                onclick="openFullscreen_nme(this);" data-offset="{{videonme.offset}}"-->
+                                        <!--                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-fullscreen"></span></button>-->
+                                                </div>
                                            </div>
                                         </td>
                                    </tr>
@@ -1981,7 +1981,6 @@ textarea:focus {
                                     </tr>
                                    {% endfor %}
                                    {% endwith %}
-                                   <tr>Perspective {{videonme.perspective}}</tr>
                                    <tr class="editform">
                                        <td>{% trans "Index" %}</td>
                                        <td class='edit edit_int' id='nmevideo_offset_{{videonme.id}}'>{{videonme.offset}}</td>
@@ -2041,12 +2040,12 @@ textarea:focus {
                                     </td>
                                 </tr>
                                 {% endfor %}
-
+                                <tr>
                                 <th>{% trans "Perspective" %}</th>
-                                <td>
+                                <td class="td td-light" style='width:5em'>
                                     {{nmevideoform.nme_perspective}}
                                 </td>
-
+                                </tr>
                             </table>
                       <br><br>
                     </form>

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -196,6 +196,12 @@ function checkKey(e)
 .video_button.active {
     color: red;
 }
+.video_button_nme:hover {
+    color: red;
+}
+.video_button_nme.active {
+    color: red;
+}
 </style>
     <script type='text/javascript' src="{{STATIC_URL}}js/gloss_edit_color.js"></script>
     <script type="text/javascript" src="{{STATIC_URL}}js/drag_drop_files.js"></script>
@@ -263,10 +269,30 @@ function checkKey(e)
             $('#videoplayer_right').trigger('play');
         }
 
+        function play_perspective_nme(el) {
+            var offset = $(el).attr('data-offset');
+            var middle_player = '#videonmeplayer_'+offset+'_middle';
+            var left_player = '#videonmeplayer_'+offset+'_left';
+            var right_player = '#videonmeplayer_'+offset+'_right';
+            $(middle_player).trigger('play');
+            $(left_player).trigger('play');
+            $(right_player).trigger('play');
+        }
+
         function pause_perspective() {
             $('#videoplayer_middle').trigger('pause');
             $('#videoplayer_left').trigger('pause');
             $('#videoplayer_right').trigger('pause');
+        }
+
+        function pause_perspective_nme(el) {
+            var offset = $(el).attr('data-offset');
+            var middle_player = '#videonmeplayer_'+offset+'_middle';
+            var left_player = '#videonmeplayer_'+offset+'_left';
+            var right_player = '#videonmeplayer_'+offset+'_right';
+            $(middle_player).trigger('pause');
+            $(left_player).trigger('pause');
+            $(right_player).trigger('pause');
         }
 
         function restart_video(vid) {
@@ -282,6 +308,19 @@ function checkKey(e)
             var left = $('#videoplayer_left');
             restart_video(left);
             var right = $('#videoplayer_right');
+            restart_video(right);
+        }
+
+        function restart_perspective_nme() {
+            var offset = $(el).attr('data-offset');
+            var middle_player = '#videonmeplayer_'+offset+'_middle';
+            var left_player = '#videonmeplayer_'+offset+'_left';
+            var right_player = '#videonmeplayer_'+offset+'_right';
+            var middle = $(middle_player);
+            restart_video(middle);
+            var left = $(left_player);
+            restart_video(left);
+            var right = $(right_player);
             restart_video(right);
         }
 
@@ -358,6 +397,9 @@ function checkKey(e)
             $('#videoplayer_middle').show();
             $('#videoplayer_left').hide();
             $('#videoplayer_right').hide();
+            $('.videonmeplayer_middle').show();
+            $('.videonmeplayer_left').hide();
+            $('.videonmeplayer_right').hide();
         });
 
         $('#searchquery').css({'margin-bottom': 10, 'padding-bottom': 10});
@@ -388,6 +430,39 @@ function checkKey(e)
             $('#videoplayer_left').hide();
             $('#videoplayer_right').hide();
         });
+        function show_nme_left(el) {
+            var offset = $(el).attr('data-offset');
+            $('.video_button_nme').removeClass("active");
+            $(el).addClass("active");
+            var middle_player = '#videonmeplayer_'+offset+'_middle';
+            var left_player = '#videonmeplayer_'+offset+'_left';
+            var right_player = '#videonmeplayer_'+offset+'_right';
+            $(middle_player).hide();
+            $(left_player).show();
+            $(right_player).hide();
+        };
+        function show_nme_right(el) {
+            var offset = $(el).attr('data-offset');
+            $('.video_button_nme').removeClass("active");
+            $(el).addClass("active");
+            var middle_player = '#videonmeplayer_'+offset+'_middle';
+            var left_player = '#videonmeplayer_'+offset+'_left';
+            var right_player = '#videonmeplayer_'+offset+'_right';
+            $(middle_player).hide();
+            $(left_player).hide();
+            $(right_player).show();
+        };
+        function show_nme_middle(el) {
+            var offset = $(el).attr('data-offset');
+            $('.video_button_nme').removeClass("active");
+            $(el).addClass("active");
+            var middle_player = '#videonmeplayer_'+offset+'_middle';
+            var left_player = '#videonmeplayer_'+offset+'_left';
+            var right_player = '#videonmeplayer_'+offset+'_right';
+            $(middle_player).show();
+            $(left_player).hide();
+            $(right_player).hide();
+        };
     </script>
 {% endblock %}
 
@@ -1836,53 +1911,61 @@ textarea:focus {
     {% if videonme.has_perspective_videos %}
     <div id="buttonbar_nme_{{videonme.offset}}-top" style="background-color:transparent;height:auto;">
         {% if videonme.has_left_perspective %}
-        <button class="btn video_button" id="show_nme_{{videonme.offset}}_left" style="font-size:18px;background-color:transparent;">
+        <button class="btn video_button_nme" id="show_nme_{{videonme.offset}}_left"
+                data-offset="{{videonme.offset}}" onclick="show_nme_left(this);"
+                style="font-size:18px;background-color:transparent;">
             <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(-30deg);rotateY(0deg);height:auto;"></span>
         </button>
         {% endif %}
-    <button class="btn video_button active" id="show_nme_{{videonme.offset}}_middle" style="font-size:18px;background-color:transparent;">
+    <button class="btn video_button_nme active" id="show_nme_{{videonme.offset}}_middle"
+            data-offset="{{videonme.offset}}" onclick="show_nme_middle(this);"
+            style="font-size:18px;background-color:transparent;">
         <span class="glyphicon glyphicon-user"></span>
     </button>
         {% if videonme.has_right_perspective %}
-        <button class="btn video_button" id="show_nme_{{videonme.offset}}_right" style="font-size:18px;background-color:transparent;">
+        <button class="btn video_button_nme" id="show_nme_{{videonme.offset}}_right"
+                data-offset="{{videonme.offset}}" onclick="show_nme_right(this);"
+                style="font-size:18px;background-color:transparent;">
             <span class="glyphicon glyphicon-facetime-video" style="transform:rotateZ(210deg);height:auto;"></span></button>
         {% endif %}
     </div>
     {% endif %}
 
         <div id="player_nme_{{videonme.offset}}" style="">
-            <video id='videonmeplayer_{{videonme.offset}}_middle' src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
-                   style="height:200px;width:auto;" controls muted></video>
+            <video id='videonmeplayer_{{videonme.offset}}_middle' class="videonmeplayer_middle"
+                   src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"
+                   style="height:200px;width:auto;" playsinline autoplay muted></video>
 
         {% if videonme.has_left_perspective %}
             {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
             {% with nme_perspectives|get_item:'left' as nmevideo_left %}
-            <video id='videonmeplayer_{{videonme.offset}}_left' src="{{protected_media_url}}{{nmevideo_left.get_video_path}}?v={% now 'YmdHis' %}"
-                   style="height:200px;width:auto;" controls muted></video>
+            <video id='videonmeplayer_{{videonme.offset}}_left'  class="videonmeplayer_left"
+                   src="{{protected_media_url}}{{nmevideo_left.get_video_path}}?v={% now 'YmdHis' %}"
+                   style="height:200px;width:auto;" playsinline autoplay muted></video>
             {% endwith %}
             {% endwith %}
         {% endif %}
         {% if videonme.has_right_perspective %}
             {% with nme_videos_lookup|get_item:videonme.offset as nme_perspectives %}
             {% with nme_perspectives|get_item:'right' as nmevideo_right %}
-            <video id='videonmeplayer_{{videonme.offset}}_right' src="{{protected_media_url}}{{nmevideo_right.get_video_path}}?v={% now 'YmdHis' %}"
-                   style="height:200px;width:auto;" controls muted></video>
+            <video id='videonmeplayer_{{videonme.offset}}_right'  class="videonmeplayer_right"
+                   src="{{protected_media_url}}{{nmevideo_right.get_video_path}}?v={% now 'YmdHis' %}"
+                   style="height:200px;width:auto;" playsinline autoplay muted></video>
             {% endwith %}
             {% endwith %}
         {% endif %}
         </div>
         <div id="buttonbar_nme_{{videonme.offset}}" style="background-color:transparent;">
-        <button class="btn" id="play_nme_{{videonme.offset}}_perspective" onclick="play_perspective();"
+        <button class="btn" id="play_nme_{{videonme.offset}}_perspective"
+                onclick="play_perspective_nme(this);" data-offset="{{videonme.offset}}"
                 style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-play"></span></button>
-        <button class="btn" id="pause_nme_{{videonme.offset}}_perspective" onclick="pause_perspective();"
+        <button class="btn" id="pause_nme_{{videonme.offset}}_perspective"
+                onclick="pause_perspective_nme(this);" data-offset="{{videonme.offset}}"
                 style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-pause"></span></button>
-        <button class="btn" id="fullscreen_nme_{{videonme.offset}}_perspective" onclick="openFullscreen();"
-                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-fullscreen"></span></button>
+<!--        <button class="btn" id="fullscreen_nme_{{videonme.offset}}_perspective"-->
+<!--                onclick="openFullscreen_nme(this);" data-offset="{{videonme.offset}}"-->
+<!--                style="font-size:16px;background-color:transparent;"><span class="glyphicon glyphicon-fullscreen"></span></button>-->
         </div>
-                                           <!--                                           <div id="nmeplayer">-->
-<!--                                            <video id='videonmeplayer' src="{{protected_media_url}}{{videonme.get_video_path}}?v={% now 'YmdHis' %}"-->
-<!--                                                   style="height:200px;width:auto;" controls muted></video>-->
-<!--                                           </div>-->
                                            </div>
                                         </td>
                                    </tr>

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -939,12 +939,13 @@ class GlossVideoNME(GlossVideo):
         lemma = gloss.lemma
         count_dataset_languages = lemma.dataset.translation_languages.all().count() if lemma else 0
         glossvideodescriptions = GlossVideoDescription.objects.filter(nmevideo=self)
+        display_preface = str(self.offset) + "_" + self.perspective if self.perspective else str(self.offset)
         for description in glossvideodescriptions:
             if count_dataset_languages > 1:
                 translations.append("{}: {}".format(description.language, description.text))
             else:
                 translations.append("{}".format(description.text))
-        return ", ".join(translations)
+        return display_preface + ": " + ", ".join(translations)
 
     def add_descriptions(self, descriptions):
         """Add descriptions to the nme video"""

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -925,6 +925,7 @@ class GlossVideoDescription(models.Model):
     def __str__(self):
         return self.text
 
+
 class GlossVideoNME(GlossVideo):
     offset = models.IntegerField(default=1)
     perspective = models.CharField(max_length=20, choices=NME_PERSPECTIVE_CHOICES, default='center')       
@@ -939,7 +940,7 @@ class GlossVideoNME(GlossVideo):
         lemma = gloss.lemma
         count_dataset_languages = lemma.dataset.translation_languages.all().count() if lemma else 0
         glossvideodescriptions = GlossVideoDescription.objects.filter(nmevideo=self)
-        display_preface = str(self.offset) + "_" + self.perspective if self.perspective else str(self.offset)
+        display_preface = str(self.offset) + "_" + str(self.perspective) if self.perspective else str(self.offset)
         for description in glossvideodescriptions:
             if count_dataset_languages > 1:
                 translations.append("{}: {}".format(description.language, description.text))
@@ -947,8 +948,18 @@ class GlossVideoNME(GlossVideo):
                 translations.append("{}".format(description.text))
         return display_preface + ": " + ", ".join(translations)
 
+    def has_left_perspective(self):
+        nmevideos = GlossVideoNME.objects.filter(gloss=self.gloss, offset=self.offset, perspective='left')
+        return nmevideos.count() > 0
+
+    def has_right_perspective(self):
+        nmevideos = GlossVideoNME.objects.filter(gloss=self.gloss, offset=self.offset, perspective='right')
+        return nmevideos.count() > 0
+
     def add_descriptions(self, descriptions):
         """Add descriptions to the nme video"""
+        if self.perspective not in ['', 'center']:
+            return
         for language in self.gloss.lemma.dataset.translation_languages.all():
             if language.language_code_2char in descriptions.keys():
                 text = descriptions[language.language_code_2char]

--- a/signbank/video/models.py
+++ b/signbank/video/models.py
@@ -948,6 +948,12 @@ class GlossVideoNME(GlossVideo):
                 translations.append("{}".format(description.text))
         return display_preface + ": " + ", ".join(translations)
 
+    def has_perspective_videos(self):
+        if self.perspective not in ['', 'center']:
+            return False
+        perspectivevideos = GlossVideoNME.objects.filter(gloss=self.gloss, offset=self.offset, perspective__in=['left', 'right'])
+        return perspectivevideos.count() > 0
+
     def has_left_perspective(self):
         nmevideos = GlossVideoNME.objects.filter(gloss=self.gloss, offset=self.offset, perspective='left')
         return nmevideos.count() > 0


### PR DESCRIPTION
I have implemented new model methods to accomplish what is needed. The javascript in the detail view has been parameterized with the offset of the NME video (collection) parameters.

Everything is implemented except a "full screen" button. (Jetske wrote the existing full screen code for normal videos.)

This issue is about the display of NME perspective videos.  As a side effect, I had to change the "NME update" because the descriptions and offset fields are no longer visible for the perspective objects in the template.
Another side effect is the "package". It needs to code explicitly include the perspective videos for the NME videos.

1. Added perspective to NME video `__str__` method
2. Added dictionary gloss method to retrieve NME lookup dictionary per NME offset to group the perspectives with the normal one. Nested dictionary
3. Boolean "has" methods for checking whether perspective exists for particular offset. These will be used in the template to conditionally generate code for the left/right icons and video display, etc.
4. Do not add description to perspective video objects of same NME video (also need to make sure form does not do this) NOTE: do we need these descriptions on the perspective "video"? I think not. (The perspective video object is an implementation, just a different camera) The perspective video viewer just puts all three videos on top of each other and switches which is visible. If we have text descriptions on each of these, they cannot be displayed.
5. Modifications to update NME method as described
6. Added the parsing and mechanics to the Detail View. 
7. Implemented the show/hide/play/pause javascript. Makes use of element "data-offset" in the elements.

PROBLEM: RETRIEVAL

SOLUTION: Implemented numerous helper functions and a dictionary data structure to assist the template (see new code in the files changed)

<details>
MASTER CODE:
The Gloss Edit View iterates over all the NME videos and provides editing of them if the user has permission.
This is why the perspective videos are showing up by themselves in the row.
The `get_nme_videos` method retrieves all of them for the gloss, regardless of whether or not they have a perspective.
The template currently iterates over all these gloss nme video objects.

The entire editing is a problem now because it is intertwined with the iteration over the collection of all the NME objects for the gloss.

The user is also able to edit the descriptions of all of the perspective videos as well as the normal one independently.
(It's not a collection per offset in the template.)
</details>

ANOTHER PROBLEM: UPDATE

SOLUTION: Did the following to not add descriptions to perspective objects, and made the delete also delete the perspectives, and the update of the offset, also move the perspective videos.

<details>
MASTER

When updating an NME video, if the offset is updated all of the objects with that offset also need to be updated. (The code does not do anything with this on master.)

Also in the dictionary/update.py => `update_nmevideo` method, there is a delete. Probably all nme's with the same offset need to be deleted, not just the one clicked on. (It's not sure what the user has clicked on on master.)
This is a problem in the display because the perspectives will be hidden unless played. The "offset" and the "perspectives" actually (ought to) function as data structure constraints. If the user would delete the primary NME video with a specific offset, then also the perspective objects should be deleted (since it's a different camera angle of the same video.)