### PR TITLE
BUG FIX: Fixed weakdrop weakprop, made editable mimic list code

### DIFF
--- a/media/js/gloss_edit_color.js
+++ b/media/js/gloss_edit_color.js
@@ -436,23 +436,55 @@ function configure_edit() {
          checkbox: { trueValue: yes_str, falseValue: no_str },
 		 callback : update_view_and_remember_original_value
      });
-     $('.edit_WD').editable(edit_post_url, {
-         params : { a: handedness_weakdrop,
-                    field: 'weakdrop',
-                    choices: handedness_weak_choices,
-                    colors: handedness_weak_choices_colors },
-         type      : 'select',
-         data: handedness_weak_choices,
-		 callback : update_view_and_remember_original_value
+     $('.edit_WD').click(function()
+	 {
+	     var this_data = $(this).attr('value');
+	     var edit_list_choices = handedness_weak_choices;
+	     var edit_list_choice_colors = handedness_weak_choices_colors;
+	     var index_of_modified_field = '1';
+         for (var key in edit_list_choices) {
+            var value = edit_list_choices[key];
+            if (value == this_data) {
+                index_of_modified_field = key;
+                break;
+            }
+         };
+         $(this).attr('data-value', index_of_modified_field);
+		 $(this).editable(edit_post_url, {
+		     params : { a: index_of_modified_field,
+		                field: 'weakdrop',
+		                display: $(this).attr('value'),
+		                colors: edit_list_choice_colors,
+		                choices: edit_list_choices },
+		     type      : 'select',
+		     data    : handedness_weak_choices,
+			 callback : update_view_and_remember_original_value
+		 });
      });
-     $('.edit_WP').editable(edit_post_url, {
-         params : { a: handedness_weakprop,
-                    field: 'weakprop',
-                    choices: handedness_weak_choices,
-                    colors: handedness_weak_choices_colors },
-         type      : 'select',
-         data: handedness_weak_choices,
-		 callback : update_view_and_remember_original_value
+     $('.edit_WP').click(function()
+	 {
+	     var this_data = $(this).attr('value');
+	     var edit_list_choices = handedness_weak_choices;
+	     var edit_list_choice_colors = handedness_weak_choices_colors;
+	     var index_of_modified_field = '1';
+         for (var key in edit_list_choices) {
+            var value = edit_list_choices[key];
+            if (value == this_data) {
+                index_of_modified_field = key;
+                break;
+            }
+         };
+         $(this).attr('data-value', index_of_modified_field);
+		 $(this).editable(edit_post_url, {
+		     params : { a: index_of_modified_field,
+		                field: 'weakprop',
+		                display: $(this).attr('value'),
+		                colors: edit_list_choice_colors,
+		                choices: edit_list_choices },
+		     type      : 'select',
+		     data    : handedness_weak_choices,
+			 callback : update_view_and_remember_original_value
+		 });
      });
      $('.edit_letter').editable(edit_post_url, {
          params : { a: 0 },

--- a/media/js/gloss_edit_color.js
+++ b/media/js/gloss_edit_color.js
@@ -439,11 +439,9 @@ function configure_edit() {
      $('.edit_WD').click(function()
 	 {
 	     var this_data = $(this).attr('value');
-	     var edit_list_choices = handedness_weak_choices;
-	     var edit_list_choice_colors = handedness_weak_choices_colors;
 	     var index_of_modified_field = '1';
-         for (var key in edit_list_choices) {
-            var value = edit_list_choices[key];
+         for (var key in handedness_weak_choices) {
+            var value = handedness_weak_choices[key];
             if (value == this_data) {
                 index_of_modified_field = key;
                 break;
@@ -454,8 +452,8 @@ function configure_edit() {
 		     params : { a: index_of_modified_field,
 		                field: 'weakdrop',
 		                display: $(this).attr('value'),
-		                colors: edit_list_choice_colors,
-		                choices: edit_list_choices },
+		                colors: handedness_weak_choices_colors,
+		                choices: handedness_weak_choices },
 		     type      : 'select',
 		     data    : handedness_weak_choices,
 			 callback : update_view_and_remember_original_value
@@ -464,11 +462,9 @@ function configure_edit() {
      $('.edit_WP').click(function()
 	 {
 	     var this_data = $(this).attr('value');
-	     var edit_list_choices = handedness_weak_choices;
-	     var edit_list_choice_colors = handedness_weak_choices_colors;
 	     var index_of_modified_field = '1';
-         for (var key in edit_list_choices) {
-            var value = edit_list_choices[key];
+         for (var key in handedness_weak_choices) {
+            var value = handedness_weak_choices[key];
             if (value == this_data) {
                 index_of_modified_field = key;
                 break;
@@ -479,8 +475,8 @@ function configure_edit() {
 		     params : { a: index_of_modified_field,
 		                field: 'weakprop',
 		                display: $(this).attr('value'),
-		                colors: edit_list_choice_colors,
-		                choices: edit_list_choices },
+		                colors: handedness_weak_choices_colors,
+		                choices: handedness_weak_choices },
 		     type      : 'select',
 		     data    : handedness_weak_choices,
 			 callback : update_view_and_remember_original_value

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -1268,8 +1268,8 @@ class GlossDetailView(DetailView):
 
         # set up weak drop weak prop fields
         context['handedness_fields'] = []
-        weak_drop = getattr(gloss, 'weakdrop')
-        weak_prop = getattr(gloss, 'weakprop')
+        weak_drop = gloss.get_weakdrop_display()
+        weak_prop = gloss.get_weakprop_display()
         context['handedness_fields'].append([weak_drop, 'weakdrop', labels['weakdrop'], 'list'])
         context['handedness_fields'].append([weak_prop, 'weakprop', labels['weakprop'], 'list'])
 

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -1308,6 +1308,24 @@ class Gloss(models.Model):
     def get_subhndsh_display(self):
         return self.subhndsh.name if self.subhndsh else '-'
 
+    def get_weakdrop_display(self):
+        if self.weakdrop is None:
+            coerced_value = 'None'
+        elif self.weakdrop is True:
+            coerced_value = 'True'
+        else:
+            coerced_value = 'False'
+        return coerced_value
+
+    def get_weakprop_display(self):
+        if self.weakprop is None:
+            coerced_value = 'None'
+        elif self.weakprop is True:
+            coerced_value = 'True'
+        else:
+            coerced_value = 'False'
+        return coerced_value
+
     def get_semField_display(self):
         return ", ".join([str(sf.name) for sf in self.semField.all()])
 

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -2664,24 +2664,10 @@ class Gloss(models.Model):
 
         return self.options_to_json(RELATION_ROLE_CHOICES)
 
-    def handedness_weak_drop_prop_json(self):
-        """Return JSON for the etymology choice list"""
-
-        NEUTRALBOOLEANCHOICES = [('None', _('Neutral')), ('True', _('Yes')), ('False', _('No'))]
-
-        return self.options_to_json(NEUTRALBOOLEANCHOICES)
-
-    def handedness_weak_drop_reverse_prop_json(self):
+    def handedness_weak_choices(self):
         """Return JSON for the etymology choice list"""
 
         NEUTRALBOOLEANCHOICES = [('1', _('Neutral')), ('2', _('Yes')), ('3', _('No'))]
-
-        return self.options_to_json(NEUTRALBOOLEANCHOICES)
-
-    def handedness_weak_drop_json(self):
-        """Return JSON for the etymology choice list"""
-
-        NEUTRALBOOLEANCHOICES = [(_('Neutral'), '1'), (_('Yes'), '2'), (_('No'), '3')]
 
         return self.options_to_json(NEUTRALBOOLEANCHOICES)
 

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -50,7 +50,7 @@
     var relation_role_choices = {{gloss.relation_role_choices_json|safe}};
     var relation_delete_choices = { "delete" : "Delete" };
     var relation_delete_choices_colors = { "delete" : "ffffff" };
-    var handedness_weak_choices = {{gloss.handedness_weak_drop_prop_json|safe}};
+    var handedness_weak_choices = {{gloss.handedness_weak_drop_reverse_prop_json|safe}};
     var handedness_weak_choices_colors = {};
     for (var key in handedness_weak_choices) {
         if (dark_mode_django == 'True') {
@@ -59,9 +59,6 @@
             handedness_weak_choices_colors[key] = 'ffffff';
         }
     };
-    var handedness_weak_drop_reverse = {{gloss.handedness_weak_drop_prop_json|safe}};
-    var handedness_weakdrop = handedness_weak_drop_reverse['{{gloss.weakdrop}}'];
-    var handedness_weakprop = handedness_weak_drop_reverse['{{gloss.weakprop}}'];
     var dialects = {{gloss.dialect_choices|safe}};
     var semanticfield_choices = {{gloss.semanticfield_choices|safe}};
     var derivationhistory_choices = {{gloss.derivationhistory_choices|safe}};
@@ -2338,10 +2335,10 @@ textarea:focus {
                         {% for value,name,label,kind in handedness_fields %}
                             {% if name == 'weakdrop' %}
                             <td class="edit edit_WD" id='{{name}}'
-                                value="{{value}}">{% if value %}+WD{% elif value == None %}&nbsp;{% else %}-WD{% endif %}</td>
+                                value="{{value}}">{% if value == 'True' %}+WD{% elif value == 'None' %}&nbsp;{% else %}-WD{% endif %}</td>
                             {% else %}
                             <td class="edit edit_WP" id='{{name}}'
-                                value="{{value}}">{% if value %}+WP{% elif value == None %}&nbsp;{% else %}-WP{% endif %}</td>
+                                value="{{value}}">{% if value == 'True' %}+WP{% elif value == 'None' %}&nbsp;{% else %}-WP{% endif %}</td>
                             {% endif %}
 		                {% endfor %}
                     </tr>
@@ -2353,10 +2350,10 @@ textarea:focus {
                         {% for value,name,label,kind in handedness_fields %}
                             {% if name == 'weakdrop' %}
                             <td class="edit edit_WD" id='{{name}}'
-                                value="{{value}}">{% if value %}+WD{% elif value == None %}&nbsp;{% else %}-WD{% endif %}</td>
+                                value="{{value}}">{% if value == 'True' %}+WD{% elif value == 'None' %}&nbsp;{% else %}-WD{% endif %}</td>
                             {% else %}
                             <td class="edit edit_WP" id='{{name}}'
-                                value="{{value}}">{% if value %}+WP{% elif value == None %}&nbsp;{% else %}-WP{% endif %}</td>
+                                value="{{value}}">{% if value == 'True' %}+WP{% elif value == 'None' %}&nbsp;{% else %}-WP{% endif %}</td>
                             {% endif %}
                         {% endfor %}
                     </tr>

--- a/signbank/dictionary/templates/dictionary/gloss_detail.html
+++ b/signbank/dictionary/templates/dictionary/gloss_detail.html
@@ -50,7 +50,7 @@
     var relation_role_choices = {{gloss.relation_role_choices_json|safe}};
     var relation_delete_choices = { "delete" : "Delete" };
     var relation_delete_choices_colors = { "delete" : "ffffff" };
-    var handedness_weak_choices = {{gloss.handedness_weak_drop_reverse_prop_json|safe}};
+    var handedness_weak_choices = {{gloss.handedness_weak_choices|safe}};
     var handedness_weak_choices_colors = {};
     for (var key in handedness_weak_choices) {
         if (dark_mode_django == 'True') {

--- a/signbank/dictionary/update.py
+++ b/signbank/dictionary/update.py
@@ -1049,11 +1049,11 @@ def update_gloss(request, glossid):
             # value is the html 'value' received during editing
             # value gets converted to a Boolean by the following statement
             if field in ['weakdrop', 'weakprop']:
-                NEUTRALBOOLEANCHOICES = { 'None': '1', 'True': '2', 'False': '3' }
+                NEUTRALBOOLEANCHOICES = { None: '1', True: '2', False: '3' }
                 category_value = 'phonology'
                 if value not in ['1', '2', '3']:
                     # this code is for the case the user has not selected a value in the list
-                    if value in ['None', 'True', 'False']:
+                    if value in [None, True, False]:
                         value = NEUTRALBOOLEANCHOICES[value]
                     else:
                         # something is wrong, set to None


### PR DESCRIPTION
coerce Boolean internal values to strings using method to display, explicit use of internal Booleans in choice list for update

I'm not sure when the bug arose. It looks like it was using different choice lists. In the template, numbers were being used, and the (old) values were the actual NullBoolean internal values.
I added a coercion to make the internal values become strings (but using 'None' instead of it ending up the same as False for None values)
I modified the template to test on these strings rather than the internal "value" (NullBoolean).
Likewise, the update processing converts the internal (stored) values to numbers (corresponding to the choice list in the form)
The implementation of the editable code uses choice lists with numerical domains. Probably this went wrong since it does not work if the choice lists have actual Boolean values in the domain. The coercion was messed up.