### PR TITLE
Phonologicalvariations query

### DIFF
--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -143,6 +143,7 @@ from signbank.dataset_operations import (get_primary_videos_for_gloss, get_persp
                                          get_nme_videos_for_gloss, get_wrong_videos_for_gloss,
                                          get_backup_videos_for_gloss)
 from signbank.dictionary.display_functions import show_fields_rows
+from signbank.dictionary.phonology_functions import phonological_variations_matrix, display_phonology_matrix
 
 
 def order_annotatedsentence_queryset_by_sort_order(get, qs, queryset_language_codes):
@@ -1401,7 +1402,7 @@ class GlossDetailView(DetailView):
 
             return context
 
-        phonology_matrix = context['gloss'].phonology_matrix_homonymns(use_machine_value=True)
+        phonology_matrix = context['gloss'].phonology_matrix(use_machine_value=True)
         phonology_focus = [field for field in phonology_matrix.keys()
                            if phonology_matrix[field] is not None
                            and phonology_matrix[field] not in ['Neutral',  '0', '1', 'False']]
@@ -1481,6 +1482,10 @@ class GlossDetailView(DetailView):
         for variation in context['gloss_variations']:
             variation_forms[variation.pk] = PhonologyForm(object=variation, use_lookaheads=context['use_lookaheads'])
         context['variation_forms'] = variation_forms
+
+        variations_dict = phonological_variations_matrix(gloss)
+        display_dict = display_phonology_matrix(variations_dict)
+        print('Phonological Variations by Differing Fields: ', display_dict)
 
         context['show_field_row'] = show_fields_rows(gloss)
         context['language_2chars'] = [language.language_code_2char for language in dataset_languages]

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -6089,6 +6089,8 @@ def glosslist_ajax_complete(request, gloss_id):
             else:
                 column_values.append((fieldname, '-'))
 
+    gloss_variations = PhonologicalVariation.objects.filter(gloss=this_gloss).order_by('variation')
+
     return render(request, 'dictionary/gloss_row.html',
                   {'focus_gloss': this_gloss,
                    'dataset_languages': dataset_languages,
@@ -6098,6 +6100,7 @@ def glosslist_ajax_complete(request, gloss_id):
                    'width_lemma_columns': len(dataset_languages),
                    'sensetranslations_per_language': sensetranslations_per_language,
                    'column_values': column_values,
+                   'gloss_variations': gloss_variations,
                    'USE_REGULAR_EXPRESSIONS': USE_REGULAR_EXPRESSIONS,
                    'SHOW_DATASET_INTERFACE_OPTIONS': SHOW_DATASET_INTERFACE_OPTIONS})
 

--- a/signbank/dictionary/adminviews.py
+++ b/signbank/dictionary/adminviews.py
@@ -1483,10 +1483,6 @@ class GlossDetailView(DetailView):
             variation_forms[gloss_variation.pk] = PhonologyForm(object=gloss_variation, use_lookaheads=context['use_lookaheads'])
         context['variation_forms'] = variation_forms
 
-        variations_dict = phonological_variations_matrix(gloss)
-        display_dict = display_phonology_matrix(variations_dict)
-        print('Phonological Variations by Differing Fields: ', display_dict)
-
         context['show_field_row'] = show_fields_rows(gloss)
         context['language_2chars'] = [language.language_code_2char for language in dataset_languages]
 

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -2,6 +2,7 @@ from colorfield.fields import ColorWidget
 from datetime import timedelta
 import datetime as DT
 import re
+from enum import Enum
 
 from django import forms
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -27,7 +28,7 @@ from signbank.dictionary.models import (Phonology, Gloss, Morpheme, Definition, 
                                         QueryParameterFieldChoice, SearchHistory, QueryParameter,
                                         QueryParameterMultilingual, QueryParameterHandshape, SemanticFieldTranslation,
                                         ExampleSentence, Affiliation, AffiliatedUser, AffiliatedGloss, GlossSense,
-                                        SenseTranslation, AnnotatedGloss, GlossProvenance, Dialect, PhonologicalVariation)
+                                        SenseTranslation, AnnotatedGloss, GlossProvenance, Dialect)
 from signbank.dictionary.translate_choice_list import choicelist_queryset_to_translated_dict
 from signbank.tools import get_selected_datasets_for_user
 
@@ -2071,6 +2072,11 @@ class PhonologyForm(forms.Form):
         self.fields['mouthG'].initial = self.object.mouthG if self.object.mouthG not in ['', '-', None] else ''
         self.fields['mouthing'].initial = self.object.mouthing if self.object.mouthing not in ['', '-', None] else ''
         self.fields['phonetVar'].initial = self.object.phonetVar if self.object.phonetVar not in ['', '-', None] else ''
+
+
+class PhonologicalVariationFilter(Enum):
+    HAS_VARIATION = '2'
+    NO_VARIATION = '3'
 
 
 class SemanticsForm(forms.Form):

--- a/signbank/dictionary/forms.py
+++ b/signbank/dictionary/forms.py
@@ -232,6 +232,8 @@ class GlossSearchForm(forms.ModelForm):
     search = forms.CharField(label=_('Search Gloss'))
     sortOrder = forms.CharField(label=_('Sort Order'), initial="")
     translation = forms.CharField(label=_('Search Senses'))
+    hasphonologicalvariations = forms.ChoiceField(label=_('Has Phonological Variations'), choices=[(0, '-')],
+                                                  widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
     hasvideo = forms.ChoiceField(label=_('Has Video'), choices=[(0, '-')],
                                  widget=forms.Select(attrs=ATTRS_FOR_BOOLEAN_FORMS))
     hasnmevideo = forms.ChoiceField(label=_('Has NME Video'), choices=[(0, '-')],
@@ -358,7 +360,7 @@ class GlossSearchForm(forms.ModelForm):
         self.fields['tags'] = forms.ModelChoiceField(label=_('Tags'),
                                                      queryset=Tag.objects.all(), empty_label=None,
                                                      widget=forms.Select(attrs=ATTRS_FOR_FORMS))
-        for boolean_field in ['hasvideo', 'hasnmevideo', 'repeat', 'altern', 'isNew', 'inWeb', 'defspublished',
+        for boolean_field in ['hasphonologicalvariations', 'hasvideo', 'hasnmevideo', 'repeat', 'altern', 'isNew', 'inWeb', 'defspublished',
                               'excludeFromEcv', 'hasRelationToForeignSign', 'hasmultiplesenses',
                               'hasothermedia', 'isablend', 'ispartofablend', 'hasannotatedsentences']:
             self.fields[boolean_field].choices = [('0', '-'), ('2', _('Yes')), ('3', _('No'))]

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -1174,6 +1174,51 @@ class Phonology(MetaModelMixin, models.Model):
             return '0'
         return '1' if self.altern else '0'
 
+    def phonology_matrix(self, use_machine_value=False):
+        # this method uses string representations for Boolean values
+        # in order to distinguish between null values, False values, and Neutral values
+
+        phonology_dict = dict()
+        for field in FIELDS['phonology']:
+            gloss_field = Gloss._meta.get_field(field)
+            if isinstance(gloss_field, models.CharField) or isinstance(gloss_field, models.TextField):
+                continue
+            field_value = getattr(self, gloss_field.name)
+            if isinstance(field_value, Handshape):
+                if field_value is None:
+                    # this differentiates between null field choice fields (here) versus null Boolean fields
+                    # which get mapped to either 'False' or 'Neutral'
+                    phonology_dict[field] = None
+                else:
+                    phonology_dict[field] = str(field_value.machine_value)
+            elif hasattr(gloss_field, 'field_choice_category'):
+                if field_value is None:
+                    # this differentiates between null field choice fields (here) versus null Boolean fields
+                    # which get mapped to either 'False' or 'Neutral'
+                    phonology_dict[field] = None
+                else:
+                    phonology_dict[field] = str(field_value.machine_value if use_machine_value else field_value.id)
+            else:
+                # gloss_field is a Boolean
+                # TO DO: check these conversions to Strings instead of Booleans
+
+                if field_value is not None:
+                    if field_value:
+                        # machine value is 1
+                        phonology_dict[field] = 'True'
+                    else:
+                        # machine value is 0
+                        phonology_dict[field] = 'False'
+                else:
+                    # machine value is None, for weakdrop and weakprop, this is Neutral
+                    # value is Neutral
+                    if field in settings.HANDEDNESS_ARTICULATION_FIELDS:
+                        phonology_dict[field] = 'Neutral'
+                    else:
+                        phonology_dict[field] = 'False'
+
+        return phonology_dict
+
 
 class Gloss(Phonology):
     class Meta:
@@ -2056,51 +2101,6 @@ class Gloss(Phonology):
         other_relations = self.other_relations()
         return other_relations, variant_relations
 
-    def phonology_matrix_homonymns(self, use_machine_value=False):
-        # this method uses string representations for Boolean values
-        # in order to distinguish between null values, False values, and Neutral values
-
-        phonology_dict = dict()
-        for field in FIELDS['phonology']:
-            gloss_field = Gloss._meta.get_field(field)
-            if isinstance(gloss_field, models.CharField) or isinstance(gloss_field, models.TextField):
-                continue
-            field_value = getattr(self, gloss_field.name)
-            if isinstance(field_value, Handshape):
-                if field_value is None:
-                    # this differentiates between null field choice fields (here) versus null Boolean fields
-                    # which get mapped to either 'False' or 'Neutral'
-                    phonology_dict[field] = None
-                else:
-                    phonology_dict[field] = str(field_value.machine_value)
-            elif hasattr(gloss_field, 'field_choice_category'):
-                if field_value is None:
-                    # this differentiates between null field choice fields (here) versus null Boolean fields
-                    # which get mapped to either 'False' or 'Neutral'
-                    phonology_dict[field] = None
-                else:
-                    phonology_dict[field] = str(field_value.machine_value if use_machine_value else field_value.id)
-            else:
-                # gloss_field is a Boolean
-                # TO DO: check these conversions to Strings instead of Booleans
-
-                if field_value is not None:
-                    if field_value:
-                        # machine value is 1
-                        phonology_dict[field] = 'True'
-                    else:
-                        # machine value is 0
-                        phonology_dict[field] = 'False'
-                else:
-                    # machine value is None, for weakdrop and weakprop, this is Neutral
-                    # value is Neutral
-                    if field in settings.HANDEDNESS_ARTICULATION_FIELDS:
-                        phonology_dict[field] = 'Neutral'
-                    else:
-                        phonology_dict[field] = 'False'
-
-        return phonology_dict
-
     def minimal_pairs_tuple(self):
         minimal_pairs_fields = settings.MINIMAL_PAIRS_FIELDS
 
@@ -2267,7 +2267,7 @@ class Gloss(Phonology):
         if not self.lemma or not self.lemma.dataset:
             return homonym_objects_list
 
-        phonology_for_gloss = self.phonology_matrix_homonymns()
+        phonology_for_gloss = self.phonology_matrix()
         handedness_of_this_gloss = phonology_for_gloss['handedness']
 
         homonym_objects_list = []
@@ -2339,7 +2339,7 @@ class Gloss(Phonology):
 
         targets_of_homonyms_of_this_gloss = [r.target for r in gloss_homonym_relations]
 
-        phonology_for_gloss = self.phonology_matrix_homonymns()
+        phonology_for_gloss = self.phonology_matrix()
         handedness_of_this_gloss = phonology_for_gloss['handedness']
         empty_or_X_handedness = [str(fc.id) for fc in FieldChoice.objects.filter(field='Handedness', name__in=['-','N/A', 'X'])]
         if handedness_of_this_gloss in empty_or_X_handedness:

--- a/signbank/dictionary/models.py
+++ b/signbank/dictionary/models.py
@@ -5,6 +5,7 @@ import copy
 import os
 import json
 import tagging
+from django.db.models.fields import BooleanField
 
 from django.utils.timezone import get_current_timezone
 from django.db.models import Q, When, Case, IntegerField
@@ -1180,24 +1181,16 @@ class Phonology(MetaModelMixin, models.Model):
 
         phonology_dict = dict()
         for field in FIELDS['phonology']:
-            gloss_field = Gloss._meta.get_field(field)
+            gloss_field = self._meta.get_field(field)
             if isinstance(gloss_field, models.CharField) or isinstance(gloss_field, models.TextField):
                 continue
             field_value = getattr(self, gloss_field.name)
-            if isinstance(field_value, Handshape):
-                if field_value is None:
-                    # this differentiates between null field choice fields (here) versus null Boolean fields
-                    # which get mapped to either 'False' or 'Neutral'
-                    phonology_dict[field] = None
-                else:
-                    phonology_dict[field] = str(field_value.machine_value)
+            if field_value is None and not isinstance(field_value, BooleanField):
+                phonology_dict[field] = None
+            elif isinstance(field_value, Handshape):
+                phonology_dict[field] = str(field_value.machine_value)
             elif hasattr(gloss_field, 'field_choice_category'):
-                if field_value is None:
-                    # this differentiates between null field choice fields (here) versus null Boolean fields
-                    # which get mapped to either 'False' or 'Neutral'
-                    phonology_dict[field] = None
-                else:
-                    phonology_dict[field] = str(field_value.machine_value if use_machine_value else field_value.id)
+                phonology_dict[field] = str(field_value.machine_value if use_machine_value else field_value.id)
             else:
                 # gloss_field is a Boolean
                 # TO DO: check these conversions to Strings instead of Booleans

--- a/signbank/dictionary/phonology_functions.py
+++ b/signbank/dictionary/phonology_functions.py
@@ -1,0 +1,61 @@
+
+from django.utils.translation import gettext_noop, gettext_lazy as _, gettext, activate
+
+from signbank.settings.server_specific import FIELDS
+
+from signbank.dictionary.models import FieldChoiceForeignKey, PhonologicalVariation, Phonology, Gloss, FieldChoice, Handshape
+
+def display_phonology_matrix(matrix):
+    display_matrix = {}
+    for field in matrix.keys():
+        gloss_field = Gloss._meta.get_field(field)
+        field_label = gettext_noop(gloss_field.verbose_name)
+        display_matrix[field_label] = {}
+        if hasattr(gloss_field, 'field_choice_category'):
+            for variation_num in matrix[field]:
+                field_value = matrix[field][variation_num]
+                if field_value is not None:
+                    field_value_display = FieldChoice.objects.get(id=int(field_value)).name
+                else:
+                    field_value_display = '-'
+                display_matrix[field_label][variation_num] = field_value_display
+        elif field in ['domhndsh', 'subhndsh', 'final_domhndsh', 'final_subhndsh']:
+            for variation_num in matrix[field]:
+                field_value = matrix[field][variation_num]
+                if field_value is not None:
+                    field_value_display = Handshape.objects.get(machine_value=int(field_value)).name
+                else:
+                    field_value_display = '-'
+                display_matrix[field_label][variation_num] = field_value_display
+        else:
+            for variation_num in matrix[field]:
+                field_value = matrix[field][variation_num]
+                display_matrix[field_label][variation_num] = field_value
+    return display_matrix
+
+
+def phonological_variations_matrix(gloss):
+    gloss_phonology = gloss.phonology_matrix(use_machine_value=False)
+    phonology_variations = PhonologicalVariation.objects.filter(gloss=gloss).order_by('variation')
+    variations = {}
+    for variation in phonology_variations:
+        variations[variation.variation] = variation.phonology_matrix(use_machine_value=False)
+    for field in FIELDS['phonology']:
+        if field in gloss_phonology.keys():
+            continue
+        gloss_phonology[field] = getattr(gloss, field)
+        for variation in phonology_variations:
+            variations[variation.variation][field] = getattr(variation, field)
+    phonology_differences = {}
+    for field in FIELDS['phonology']:
+        primary_value = gloss_phonology[field]
+        for variation in variations.keys():
+            if variations[variation][field] != primary_value:
+                if field not in phonology_differences.keys():
+                    phonology_differences[field] = {}
+    for field in phonology_differences.keys():
+        for variation_num in variations.keys():
+            phonology_differences[field][1] = gloss_phonology[field]
+            phonology_differences[field][variation_num] = variations[variation_num][field]
+
+    return phonology_differences

--- a/signbank/dictionary/phonology_functions.py
+++ b/signbank/dictionary/phonology_functions.py
@@ -50,9 +50,10 @@ def phonological_variations_matrix(gloss):
     for field in FIELDS['phonology']:
         primary_value = gloss_phonology[field]
         for variation in variations.keys():
-            if variations[variation][field] != primary_value:
-                if field not in phonology_differences.keys():
-                    phonology_differences[field] = {}
+            if variations[variation][field] == primary_value:
+                continue
+            if field not in phonology_differences.keys():
+                phonology_differences[field] = {}
     for field in phonology_differences.keys():
         for variation_num in variations.keys():
             phonology_differences[field][1] = gloss_phonology[field]

--- a/signbank/dictionary/templates/dictionary/gloss_row.html
+++ b/signbank/dictionary/templates/dictionary/gloss_row.html
@@ -109,7 +109,7 @@
         <td class="field_dataset" style="width:12em;"></td>
     {% endif %}
 
-    <td class="field_hasvideo" style="margin-left:20px;"></td>
+    <td class="field_hasvideo" style="padding-left:20px;"></td>
     <td class="field_hasvideo">
       {% if gloss_variation.has_video %}
       {% url 'dictionary:protected_media' '' as protected_media_url %}
@@ -132,7 +132,7 @@
            </div>
       {% endif %}
     </td>
-    <td>{% trans "Variation" %} #{{gloss_variation.variation}}</td>
+    <td colspan="999"><small>{% trans "Variation" %} #{{gloss_variation.variation}}</small></td>
 </tr>
 {% endfor %}
 {% endif %}

--- a/signbank/dictionary/templates/dictionary/gloss_row.html
+++ b/signbank/dictionary/templates/dictionary/gloss_row.html
@@ -100,3 +100,39 @@
     {% endif %}
     {% endif %}
 </tr>
+
+{% if gloss_variations %}
+{% for gloss_variation in gloss_variations %}
+<tr id = "glossrow_{{gloss_variation.id}}" class="gloss_row">
+
+    {% if SHOW_DATASET_INTERFACE_OPTIONS and selected_datasets|length > 1 %}
+        <td class="field_dataset" style="width:12em;"></td>
+    {% endif %}
+
+    <td class="field_hasvideo" style="margin-left:20px;"></td>
+    <td class="field_hasvideo">
+      {% if gloss_variation.has_video %}
+      {% url 'dictionary:protected_media' '' as protected_media_url %}
+
+      <div class="thumbnail_container">
+      <a href="{{PREFIX_URL}}/dictionary/gloss/{{focus_gloss.pk}}{% if user.is_anonymous %}.html{% else %}/{% endif %}">
+
+        <div id='glossvideo_variation_{{gloss_variation.id}}'>
+            {% if gloss_variation.has_video %}
+            <video id="videoplayer_variation_{{gloss_variation.id}}" class="thumbnail-video" src="{{protected_media_url}}{{gloss_variation.get_video_url}}"
+                   type="video/mp4" muted="muted" onmouseover="this.play()"></video>
+            {% endif %}
+        </div>
+
+      </a>
+      </div>
+     {% else %}
+           <div class="thumbnail_container">
+               <img id="videoplayer_{{gloss_variation.id}}" class="thumbnail-video" src='{{STATIC_URL}}images/no-video.png' >
+           </div>
+      {% endif %}
+    </td>
+    <td>{% trans "Variation" %} #{{gloss_variation.variation}}</td>
+</tr>
+{% endfor %}
+{% endif %}

--- a/signbank/query_parameters.py
+++ b/signbank/query_parameters.py
@@ -277,14 +277,12 @@ def convert_query_parameters_to_filter(query_parameters):
             query_list.append(Q(**{query_filter_sense_text: get_value}))
 
         elif get_key == 'hasphonologicalvariations' and get_value != '':
-            # Remember the pk of all glosses that have phonological variations
-            pks_for_glosses_with_phonological_variations = [ pv.gloss.pk for pv in PhonologicalVariation.objects.all() ]
+            gloss_ids_with_phonological_variations = PhonologicalVariation.objects.values_list('gloss_id',
+                                                                                               flat=True).distinct()
             if get_value == '2':
-                # value '1' filters glosses with othermedia
-                query_list.append(Q(pk__in=pks_for_glosses_with_phonological_variations))
+                query_list.append(Q(pk__in=gloss_ids_with_phonological_variations))
             elif get_value == '3':
-                # the code for '3' excludes the above glosses from the results
-                query_list.append(~Q(pk__in=pks_for_glosses_with_phonological_variations))
+                query_list.append(~Q(pk__in=gloss_ids_with_phonological_variations))
             else:
                 continue
 
@@ -950,12 +948,12 @@ def queryset_from_get(formclass, searchform, GET, qs):
                 qs = qs.filter(creationDate__range=(created_after_date, DT.datetime.now()))
         elif searchform.fields[get_key].widget.input_type in ['select']:
             if get_key in ['hasphonologicalvariations']:
-                pks_for_glosses_with_phonological_variations = [pv.gloss.pk for pv in
-                                                                PhonologicalVariation.objects.all()]
+                gloss_ids_with_phonological_variations = PhonologicalVariation.objects.values_list('gloss_id',
+                                                                                                   flat=True).distinct()
                 if get_value == '2':
-                    qs = qs.filter(pk__in=pks_for_glosses_with_phonological_variations)
+                    qs = qs.filter(pk__in=gloss_ids_with_phonological_variations)
                 elif get_value == '3':
-                    qs = qs.exclude(pk__in=pks_for_glosses_with_phonological_variations)
+                    qs = qs.exclude(pk__in=gloss_ids_with_phonological_variations)
                 continue
             elif get_key in ['inWeb', 'repeat', 'altern', 'isNew']:
                 val = get_value == '2'
@@ -1226,12 +1224,12 @@ def queryset_glosssense_from_get(model, formclass, searchform, GET, qs):
                 qs = qs.filter(**{query_filter: (created_after_date, DT.datetime.now())})
         elif searchform.fields[get_key].widget.input_type in ['select']:
             if get_key in ['hasphonologicalvariations']:
-                pks_for_glosses_with_phonological_variations = [pv.gloss.pk for pv in
-                                                                PhonologicalVariation.objects.all()]
+                gloss_ids_with_phonological_variations = PhonologicalVariation.objects.values_list('gloss_id',
+                                                                                                   flat=True).distinct()
                 if get_value == '2':
-                    qs = qs.filter(pk__in=pks_for_glosses_with_phonological_variations)
+                    qs = qs.filter(pk__in=gloss_ids_with_phonological_variations)
                 elif get_value == '3':
-                    qs = qs.exclude(pk__in=pks_for_glosses_with_phonological_variations)
+                    qs = qs.exclude(pk__in=gloss_ids_with_phonological_variations)
                 continue
             elif get_key in ['hasmultiplesenses']:
                 if get_value == '2':

--- a/signbank/query_parameters.py
+++ b/signbank/query_parameters.py
@@ -15,7 +15,7 @@ from signbank.settings.base import EARLIEST_GLOSS_CREATION_DATE, DATE_FORMAT
 from signbank.settings.server_specific import (USE_REGULAR_EXPRESSIONS, WRITABLE_FOLDER,
                                                GLOSS_LIST_DISPLAY_FIELDS, SEARCH_BY, HANDEDNESS_ARTICULATION_FIELDS, HANDSHAPE_ETYMOLOGY_FIELDS)
 from signbank.video.models import GlossVideo, GlossVideoNME
-from signbank.dictionary.models import (Language, SignLanguage, Dialect, Gloss, Morpheme, GlossSense, ExampleSentence,
+from signbank.dictionary.models import (Language, SignLanguage, Dialect, Gloss, PhonologicalVariation, Morpheme, GlossSense, ExampleSentence,
                                         Definition, FieldChoice, Handshape, SemanticField, DerivationHistory,
                                         AnnotatedGloss, OtherMedia, RelationToForeignSign, Relation,
                                         AnnotatedSentenceTranslation, ExampleSentenceTranslation,
@@ -275,6 +275,18 @@ def convert_query_parameters_to_filter(query_parameters):
         elif get_key == 'translation' and get_value:
             query_filter_sense_text = 'translation__translation__text__' + text_filter
             query_list.append(Q(**{query_filter_sense_text: get_value}))
+
+        elif get_key == 'hasphonologicalvariations' and get_value != '':
+            # Remember the pk of all glosses that have phonological variations
+            pks_for_glosses_with_phonological_variations = [ pv.gloss.pk for pv in PhonologicalVariation.objects.all() ]
+            if get_value == '2':
+                # value '1' filters glosses with othermedia
+                query_list.append(Q(pk__in=pks_for_glosses_with_phonological_variations))
+            elif get_value == '3':
+                # the code for '3' excludes the above glosses from the results
+                query_list.append(~Q(pk__in=pks_for_glosses_with_phonological_variations))
+            else:
+                continue
 
         elif get_key == 'inWeb' and get_value != '':
             val = get_value == '2'
@@ -686,7 +698,7 @@ def pretty_print_query_values(dataset_languages, query_parameters):
                 query_dict[key] = _('Yes')
             elif query_parameters[key] in ['3']:
                 query_dict[key] = _('No')
-        elif key in ['inWeb', 'isNew', 'excludeFromEcv', 'hasvideo', 'hasnmevideo', 'hasothermedia']:
+        elif key in ['hasphonologicalvariations', 'inWeb', 'isNew', 'excludeFromEcv', 'hasvideo', 'hasnmevideo', 'hasothermedia']:
             query_dict[key] = NULLBOOLEANCHOICES.get(query_parameters[key], NULLBOOLEANCHOICES['0'])
         elif key in ['defspublished', 'hasmultiplesenses', 'negative', 'hasannotatedsentences']:
             query_dict[key] = YESNOCHOICES.get(query_parameters[key], YESNOCHOICES['0'])
@@ -937,7 +949,15 @@ def queryset_from_get(formclass, searchform, GET, qs):
             elif get_key == 'createdAfter':
                 qs = qs.filter(creationDate__range=(created_after_date, DT.datetime.now()))
         elif searchform.fields[get_key].widget.input_type in ['select']:
-            if get_key in ['inWeb', 'repeat', 'altern', 'isNew']:
+            if get_key in ['hasphonologicalvariations']:
+                pks_for_glosses_with_phonological_variations = [pv.gloss.pk for pv in
+                                                                PhonologicalVariation.objects.all()]
+                if get_value == '2':
+                    qs = qs.filter(pk__in=pks_for_glosses_with_phonological_variations)
+                elif get_value == '3':
+                    qs = qs.exclude(pk__in=pks_for_glosses_with_phonological_variations)
+                continue
+            elif get_key in ['inWeb', 'repeat', 'altern', 'isNew']:
                 val = get_value == '2'
                 key = get_key + '__exact'
             elif get_key in ['hasvideo', 'hasnmevideo']:
@@ -1205,7 +1225,15 @@ def queryset_glosssense_from_get(model, formclass, searchform, GET, qs):
             elif get_key == 'createdAfter':
                 qs = qs.filter(**{query_filter: (created_after_date, DT.datetime.now())})
         elif searchform.fields[get_key].widget.input_type in ['select']:
-            if get_key in ['hasmultiplesenses']:
+            if get_key in ['hasphonologicalvariations']:
+                pks_for_glosses_with_phonological_variations = [pv.gloss.pk for pv in
+                                                                PhonologicalVariation.objects.all()]
+                if get_value == '2':
+                    qs = qs.filter(pk__in=pks_for_glosses_with_phonological_variations)
+                elif get_value == '3':
+                    qs = qs.exclude(pk__in=pks_for_glosses_with_phonological_variations)
+                continue
+            elif get_key in ['hasmultiplesenses']:
                 if get_value == '2':
                     multiple_senses = [gsv['gloss'] for gsv in GlossSense.objects.values(
                         'gloss').annotate(Count('id')).filter(id__count__gt=1)]

--- a/signbank/query_parameters.py
+++ b/signbank/query_parameters.py
@@ -20,7 +20,7 @@ from signbank.dictionary.models import (Language, SignLanguage, Dialect, Gloss, 
                                         AnnotatedGloss, OtherMedia, RelationToForeignSign, Relation,
                                         AnnotatedSentenceTranslation, ExampleSentenceTranslation,
                                         BlendMorphology, MorphologyDefinition, SimultaneousMorphologyDefinition)
-from signbank.dictionary.forms import GlossSearchForm, SentenceForm
+from signbank.dictionary.forms import GlossSearchForm, SentenceForm, PhonologicalVariationFilter
 from signbank.dictionary.field_choices import fields_to_fieldcategory_dict
 from signbank.dictionary.translate_choice_list import choicelist_queryset_to_translated_dict, \
     machine_value_to_translated_human_value
@@ -279,9 +279,9 @@ def convert_query_parameters_to_filter(query_parameters):
         elif get_key == 'hasphonologicalvariations' and get_value != '':
             gloss_ids_with_phonological_variations = PhonologicalVariation.objects.values_list('gloss_id',
                                                                                                flat=True).distinct()
-            if get_value == '2':
+            if get_value == PhonologicalVariationFilter.HAS_VARIATION.value:
                 query_list.append(Q(pk__in=gloss_ids_with_phonological_variations))
-            elif get_value == '3':
+            elif get_value == PhonologicalVariationFilter.NO_VARIATION.value:
                 query_list.append(~Q(pk__in=gloss_ids_with_phonological_variations))
             else:
                 continue
@@ -950,9 +950,9 @@ def queryset_from_get(formclass, searchform, GET, qs):
             if get_key in ['hasphonologicalvariations']:
                 gloss_ids_with_phonological_variations = PhonologicalVariation.objects.values_list('gloss_id',
                                                                                                    flat=True).distinct()
-                if get_value == '2':
+                if get_value == PhonologicalVariationFilter.HAS_VARIATION.value:
                     qs = qs.filter(pk__in=gloss_ids_with_phonological_variations)
-                elif get_value == '3':
+                elif get_value == PhonologicalVariationFilter.NO_VARIATION.value:
                     qs = qs.exclude(pk__in=gloss_ids_with_phonological_variations)
                 continue
             elif get_key in ['inWeb', 'repeat', 'altern', 'isNew']:
@@ -1226,9 +1226,9 @@ def queryset_glosssense_from_get(model, formclass, searchform, GET, qs):
             if get_key in ['hasphonologicalvariations']:
                 gloss_ids_with_phonological_variations = PhonologicalVariation.objects.values_list('gloss_id',
                                                                                                    flat=True).distinct()
-                if get_value == '2':
+                if get_value == PhonologicalVariationFilter.HAS_VARIATION.value:
                     qs = qs.filter(pk__in=gloss_ids_with_phonological_variations)
-                elif get_value == '3':
+                elif get_value == PhonologicalVariationFilter.NO_VARIATION.value:
                     qs = qs.exclude(pk__in=gloss_ids_with_phonological_variations)
                 continue
             elif get_key in ['hasmultiplesenses']:

--- a/signbank/settings/server_specific/default.py
+++ b/signbank/settings/server_specific/default.py
@@ -153,7 +153,7 @@ FIELDS['handshape'] = ['hsNumSel','hsFingSel','hsFingSel2','hsFingConf','hsFingC
 
 FIELDS['publication'] = ['inWeb', 'isNew']
 
-FIELDS['properties'] = ['hasvideo', 'hasnmevideo', 'hasothermedia', 'hasmultiplesenses', 'hasannotatedsentences',
+FIELDS['properties'] = ['hasphonologicalvariations', 'hasvideo', 'hasnmevideo', 'hasothermedia', 'hasmultiplesenses', 'hasannotatedsentences',
                         'definitionRole', 'definitionContains', 'defspublished',
                         'createdBy', 'createdAfter', 'createdBefore',
                         'tags', 'excludeFromEcv']


### PR DESCRIPTION
Add querying of phonological variations #1757

- For a robust, extendable search functionality regarding phonology, it is wise to move the phonology specific functions of the Gloss model to the Phonology abstract class, to allow them to also be applied to the variations

`phonology_matrix_homonymns` (moved to `Phonology` class and renamed to `phonology_matrix`)
`minimal_pairs_tuple`
`minimalpairs_objects`
`minimal_pairs_dict`
`homonym_objects`
